### PR TITLE
Updating areas with all of their climbs.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -111,20 +111,6 @@ exports.createPages = async ({ graphql, actions }) => {
       },
     });
   }
-  // result.data.allMdx.edges.forEach(({ node }) => {
-  //   const climbs = await retrieveClimbs(node.fields.pathId);
-  //   console.log(climbs);
-  //   createPage({
-  //     path: node.fields.slug,
-  //     component: path.resolve(`./src/templates/leaf-area-page-md.js`),
-  //     context: {
-  //       legacy_id: node.frontmatter.metadata.legacy_id,
-  //       // climbs: node.climbs,
-  //       // name: node.area_name,
-  //       slug: node.fields.slug,
-  //     },
-  //   });
-  // });
 
   // Query all route .md documents
   result = await graphql(`

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,7 +6,12 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
     const { createNodeField } = actions;
     const parent = getNode(node["parent"]);
     const nodeType = parent["sourceInstanceName"];
+
     if (nodeType === "climbing-routes") {
+      
+      // Computed on the fly based off relative path of the current file
+      // climbing routes's parent id is the current directory.
+      const parentId = path.dirname(parent.relativePath);
       createNodeField({
         node,
         name: `slug`,
@@ -22,6 +27,11 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
         name: `collection`,
         value: nodeType,
       });
+      createNodeField({
+        node,
+        name: `parentId`,
+        value: parentId
+      })
       //TODO: create a new field to help linking with parent area. But how??
       // createNodeField({
       //   node,
@@ -29,6 +39,13 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       //   value: ???,
       // });
     } else if (nodeType === "area-indices") {
+
+      // Computed on the fly based off relative path of the current file
+      // If you looking at an index.md for an area the parent would be the 
+      // index.md of 1 directory level up.
+      // i.g. Take current path, go up one directory.
+      const parentId = path.normalize(path.join(path.dirname(parent.relativePath),'..'));
+      const pathId = path.dirname(parent.relativePath);
       createNodeField({
         node,
         name: `slug`,
@@ -44,6 +61,16 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
         name: `collection`,
         value: nodeType,
       });
+      createNodeField({
+        node,
+        name: `parentId`,
+        value: parentId
+      });
+      createNodeField({
+        node,
+        name: `pathId`,
+        value: pathId
+      });
     }
   }
 };
@@ -57,6 +84,7 @@ exports.createPages = async ({ graphql, actions }) => {
           node {
             fields {
               slug
+              pathId
             }
             frontmatter {
               metadata {
@@ -70,7 +98,7 @@ exports.createPages = async ({ graphql, actions }) => {
   `);
   // Create each index page for each leaf area
   const { createPage } = actions;
-  result.data.allMdx.edges.forEach(({ node }) => {
+  for (const {node} of result.data.allMdx.edges) {
     createPage({
       path: node.fields.slug,
       component: path.resolve(`./src/templates/leaf-area-page-md.js`),
@@ -79,9 +107,24 @@ exports.createPages = async ({ graphql, actions }) => {
         // climbs: node.climbs,
         // name: node.area_name,
         slug: node.fields.slug,
+        pathId: node.fields.pathId
       },
     });
-  });
+  }
+  // result.data.allMdx.edges.forEach(({ node }) => {
+  //   const climbs = await retrieveClimbs(node.fields.pathId);
+  //   console.log(climbs);
+  //   createPage({
+  //     path: node.fields.slug,
+  //     component: path.resolve(`./src/templates/leaf-area-page-md.js`),
+  //     context: {
+  //       legacy_id: node.frontmatter.metadata.legacy_id,
+  //       // climbs: node.climbs,
+  //       // name: node.area_name,
+  //       slug: node.fields.slug,
+  //     },
+  //   });
+  // });
 
   // Query all route .md documents
   result = await graphql(`

--- a/src/components/ui/Chip.js
+++ b/src/components/ui/Chip.js
@@ -3,6 +3,8 @@ import React from "react";
 const ChipType = {
   sport: "border-indigo-400",
   trad: "border-red-700",
+  boulder: "border-green-700",
+  tr: "border-yellow-400"
 };
   
 function Chip({ type }) {

--- a/src/components/ui/RouteCard.js
+++ b/src/components/ui/RouteCard.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Card from './Card';
+import Card from './card';
 import Chip from "./Chip";
 
 function RouteCard({route_name, type, safety, YDS}) {

--- a/src/components/ui/RouteCard.js
+++ b/src/components/ui/RouteCard.js
@@ -18,6 +18,8 @@ function RouteCard({route_name, type, safety, YDS}) {
             </span>
             {type.trad && <Chip type="trad" />}
             {type.sport && <Chip type="sport" />}
+            {type.tr && <Chip type="tr" />}
+            {type.boulder && <Chip type="boulder" />}
           </div>
         </div>
     </Card>

--- a/src/templates/leaf-area-page-md.js
+++ b/src/templates/leaf-area-page-md.js
@@ -69,26 +69,26 @@ export const query = graphql`
     climbs: allMdx(
       filter:{fields:{collection:{eq:"climbing-routes"}, parentId:{eq:$pathId}}}
     ) {
- 			totalCount
+      totalCount
       edges {
-				node {
-            fields {
-   						parentId
+        node {
+          fields {
+            parentId
+          }
+          frontmatter {
+            route_name
+            yds
+            type {
+              tr
+              trad
+              sport
+              boulder
             }
-            frontmatter {
-              route_name
-              yds
-              type {
-                tr
-                trad
-                sport
-                boulder
-              }
-              metadata {
-                legacy_id
-              }
+            metadata {
+              legacy_id
             }
           }
+        }
       }
     }
   }

--- a/src/templates/leaf-area-page-md.js
+++ b/src/templates/leaf-area-page-md.js
@@ -46,15 +46,19 @@ export const query = graphql`
       }
       body
     }
-    climbs: mdx(
-      fields: { collection: { eq: "climbing-routes" }, parentId: { eq: $pathId } }
+    climbs: allMdx(
+      filter:{fields:{collection:{eq:"climbing-routes"}, parentId:{eq:$pathId}}}
     ) {
-      id
-      frontmatter {
-        route_name
-        metadata {
-          legacy_id
-        }
+ 			totalCount
+      edges {
+				node {
+            fields {
+   						parentId
+            }
+            frontmatter {
+              route_name
+            }
+          }
       }
     }
   }

--- a/src/templates/leaf-area-page-md.js
+++ b/src/templates/leaf-area-page-md.js
@@ -5,14 +5,17 @@ import SEO from "../components/seo";
 import { MDXProvider } from "@mdx-js/react";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import { Link } from "gatsby";
+import RouteCard from "../components/ui/RouteCard";
 
 const shortcodes = { Link };
 
 /**
  * Templage for generating individual page for the climb
  */
-export default function LeafAreaPage({ data: { mdx } }) {
+export default function LeafAreaPage({ data }) {
+  const {mdx, climbs} = data;
   const { area_name } = mdx.frontmatter;
+  console.log(data);
   return (
     <Layout>
       {/* eslint-disable react/jsx-pascal-case */}
@@ -21,13 +24,14 @@ export default function LeafAreaPage({ data: { mdx } }) {
       <MDXProvider components={shortcodes}>
         <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>
+      
     </Layout>
   );
 }
 
 export const query = graphql`
-  query ($legacy_id: String!) {
-    mdx(
+  query ($legacy_id: String!, $pathId: String) {
+    mdx: mdx(
       fields: { collection: { eq: "area-indices" } }
       frontmatter: { metadata: { legacy_id: { eq: $legacy_id } } }
     ) {
@@ -41,6 +45,17 @@ export const query = graphql`
         }
       }
       body
+    }
+    climbs: mdx(
+      fields: { collection: { eq: "climbing-routes" }, parentId: { eq: $pathId } }
+    ) {
+      id
+      frontmatter {
+        route_name
+        metadata {
+          legacy_id
+        }
+      }
     }
   }
 `;

--- a/src/templates/leaf-area-page-md.js
+++ b/src/templates/leaf-area-page-md.js
@@ -6,16 +6,15 @@ import { MDXProvider } from "@mdx-js/react";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import { Link } from "gatsby";
 import RouteCard from "../components/ui/RouteCard";
+import slugify from "slugify";
 
 const shortcodes = { Link };
 
 /**
  * Templage for generating individual page for the climb
  */
-export default function LeafAreaPage({ data }) {
-  const {mdx, climbs} = data;
+export default function LeafAreaPage({ data: {mdx, climbs} }) {
   const { area_name } = mdx.frontmatter;
-  console.log(data);
   return (
     <Layout>
       {/* eslint-disable react/jsx-pascal-case */}
@@ -24,7 +23,28 @@ export default function LeafAreaPage({ data }) {
       <MDXProvider components={shortcodes}>
         <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>
-      
+      <div className="grid grid-cols-3 gap-x-3">
+        {
+          climbs.edges.map(({ node }) => {
+            const {frontmatter} = node;
+            const {yds, route_name, metadata, type} = frontmatter;
+            return(
+              <div
+                className="pt-6 max-h-96"
+                id={slugify(route_name)}
+                key={metadata.legacy_id}
+              >
+                <RouteCard
+                  route_name={route_name}
+                  YDS={yds}
+                  // safety="{}" TODO: Find out what routes have this value?
+                  type={type}
+                ></RouteCard>
+              </div>
+            )
+          })
+        }
+      </div>
     </Layout>
   );
 }
@@ -57,6 +77,16 @@ export const query = graphql`
             }
             frontmatter {
               route_name
+              yds
+              type {
+                tr
+                trad
+                sport
+                boulder
+              }
+              metadata {
+                legacy_id
+              }
             }
           }
       }


### PR DESCRIPTION
# Trello 

`OpenTacos development - nadr0` -> `leaf-area-page-md.js: list of climbs contained in this area`

# Task

Structuring and passing child climbs into the area/sector page. We want access to all of the `climbing-route` nodes that belong to the current area page you are on.

# Implementation

In `gatsby-node.js` I implement a trick to encode all of the `climbing-route` and `area-indices` with a `parentId` and `pathId`. 
> I didn't implement the `parentId` for the area files themselves because not every area has a parent `index.md` file in the folder.

The on the fly id system is implemented based on the folder path structure which we know will be unique. This allows us to render our tree structure without having to hardcode ids into the actual `.md` files. 

After passing the data to the sector page, I added an extra query to the page query for it will fetch all of the `climbing-routes` for the given area page. I projected some of the climb data out of the query.

Once I had all of the climbing data I looped through all of the nodes and rendered them in a grid view based on the original `netlify` example with my new `RouteCard.js` reusable component. This was just to show you that we can render the climbs on an area. 

Lastly, I added 2 more chip colors for `tr` and `boulder` for those can be visualized while implementing. 

# Example

http://localhost:8000/areas/105816095/iron-butte is a good example since it has a lot of climbs

![image](https://user-images.githubusercontent.com/1581329/119911559-20327080-bf1f-11eb-8ddc-08fb29693bd5.png)

# Next Steps

You mentioned in my other PR you would be open to change the layout of the page.

I don't mind the grid view and the verbose description view. I could continue to refactor that code to update the new sector page with this. Additionally you mentioned about rendering some of this with the `mdx` component? 

I think on the sector page it may make sense to render it with the React Component in the sector page. I don't know how it would look within the `mdx` renderer. I would have to learn how that works. 