### PR TITLE
Added links to GitHub files

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -45,9 +45,8 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
     const { createNodeField } = actions;
     const parent = getNode(node["parent"]);
     const nodeType = parent["sourceInstanceName"];
-
+    const markdownFileName = path.posix.parse(parent.relativePath).name;
     if (nodeType === "climbing-routes") {
-      
       // Computed on the fly based off relative path of the current file
       // climbing routes's parent id is the current directory.
       const parentId = convertPathToPOSIX(path.join(path.dirname(parent.relativePath)));
@@ -62,6 +61,11 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
           }
         )}`,
       });
+      createNodeField({
+        node,
+        name:`filename`,
+        value: markdownFileName
+      })
       createNodeField({
         node,
         name: `collection`,
@@ -96,6 +100,11 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
           }
         )}`,
       });
+      createNodeField({
+        node,
+        name:`filename`,
+        value: markdownFileName
+      })
       createNodeField({
         node,
         name: `collection`,
@@ -154,7 +163,7 @@ exports.createPages = async ({ graphql, actions }) => {
         // name: node.area_name,
         slug: node.fields.slug,
         pathId: node.fields.pathId,
-        possibleParentPaths: node.fields.possibleParentPaths
+        possibleParentPaths: node.fields.possibleParentPaths,
       },
     });
   }
@@ -190,7 +199,7 @@ exports.createPages = async ({ graphql, actions }) => {
         legacy_id: node.frontmatter.metadata.legacy_id,
         slug: node.fields.slug,
         parentId: node.fields.parentId,
-        possibleParentPaths: node.fields.possibleParentPaths
+        possibleParentPaths: node.fields.possibleParentPaths,
       },
     });
   });

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -163,7 +163,7 @@ exports.createPages = async ({ graphql, actions }) => {
         // name: node.area_name,
         slug: node.fields.slug,
         pathId: node.fields.pathId,
-        possibleParentPaths: node.fields.possibleParentPaths,
+        possibleParentPaths: node.fields.possibleParentPaths
       },
     });
   }
@@ -199,7 +199,7 @@ exports.createPages = async ({ graphql, actions }) => {
         legacy_id: node.frontmatter.metadata.legacy_id,
         slug: node.fields.slug,
         parentId: node.fields.parentId,
-        possibleParentPaths: node.fields.possibleParentPaths,
+        possibleParentPaths: node.fields.possibleParentPaths
       },
     });
   });

--- a/src/components/ui/LinkToGithub.js
+++ b/src/components/ui/LinkToGithub.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+function LinkToGithub ({link, docType}) {
+  return (
+    <div className="mt-5 border-t-2 pt-5">
+      Caught a mistake or want to contribute to the {docType ? docType :'documentation'}? 
+      <a target="_blank" rel="noopener noreferrer" href={link}>
+        <span
+          className="ml-0.5 hover:underline cursor-pointer hover:text-gray-900 text-purple-600"
+        >
+          Edit on GitHub!
+        </span>
+      </a>
+    </div>
+  );
+}
+
+export default LinkToGithub;

--- a/src/components/ui/LinkToGithub.js
+++ b/src/components/ui/LinkToGithub.js
@@ -6,7 +6,7 @@ function LinkToGithub ({link, docType}) {
       Caught a mistake or want to contribute to the {docType ? docType :'documentation'}? 
       <a target="_blank" rel="noopener noreferrer" href={link}>
         <span
-          className="ml-0.5 hover:underline cursor-pointer hover:text-gray-900 text-purple-600"
+          className="ml-0.5 hover:underline cursor-pointer hover:text-purple-900 text-purple-600"
         >
           Edit on GitHub!
         </span>

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -71,8 +71,8 @@ export const createNavigatePaths = (pathId, parentAreas) => {
 
 /**
  * Given a path or parent id and the type of the page generate the GitHub URL
- * @param {String} pathOrParentId 
- * @param {String} pageType pass "area" or "climb"
+ * @param {String} pathOrParentId from createNodeField in gatsby-node.js
+ * @param {String} fileName the file name of the markdown file without extension
  */
 export const pathOrParentIdToGitHubLink = (pathOrParentId, fileName) => {
   const baseUrl = 'https://github.com/OpenBeta/open-tacos/blob/develop/content/';

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -68,3 +68,13 @@ export const createNavigatePaths = (pathId, parentAreas) => {
 
   return navigationPaths;
 };
+
+/**
+ * Given a path or parent id and the type of the page generate the GitHub URL
+ * @param {String} pathOrParentId 
+ * @param {String} pageType pass "area" or "climb"
+ */
+export const pathOrParentIdToGitHubLink = (pathOrParentId, fileName) => {
+  const baseUrl = 'https://github.com/OpenBeta/open-tacos/blob/develop/content/';
+  return baseUrl + pathOrParentId + `/${fileName}.md`;
+};

--- a/src/templates/climb-page-md.js
+++ b/src/templates/climb-page-md.js
@@ -6,7 +6,8 @@ import { MDXProvider } from "@mdx-js/react";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import { Link } from "gatsby";
 import BreadCrumbs from "../components/ui/BreadCrumbs";
-import {createNavigatePaths} from "../js/utils";
+import {createNavigatePaths, pathOrParentIdToGitHubLink} from "../js/utils";
+import LinkToGithub from "../components/ui/LinkToGithub";
 
 const shortcodes = { Link }; // Provide common components here
 
@@ -15,8 +16,9 @@ const shortcodes = { Link }; // Provide common components here
  */
 export default function ClimbPage({ data: { mdx, parentAreas } }) {
   const { route_name } = mdx.frontmatter;
-  const parentId = mdx.fields.parentId;
+  const {parentId, filename} = mdx.fields;
   const navigationPaths = createNavigatePaths(parentId, parentAreas.edges);
+  const githubLink = pathOrParentIdToGitHubLink(parentId, filename);
   return (
     <Layout>
       {/* eslint-disable react/jsx-pascal-case */}
@@ -26,6 +28,7 @@ export default function ClimbPage({ data: { mdx, parentAreas } }) {
       <MDXProvider components={shortcodes}>
         <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>
+      <LinkToGithub link={githubLink} docType="climb"></LinkToGithub>
     </Layout>
   );
 }
@@ -39,6 +42,7 @@ export const query = graphql`
       id
       fields {
         parentId
+        filename
       }
       frontmatter {
         route_name

--- a/src/templates/leaf-area-page-md.js
+++ b/src/templates/leaf-area-page-md.js
@@ -8,8 +8,9 @@ import { Link } from "gatsby";
 import RouteCard from "../components/ui/RouteCard";
 import slugify from "slugify";
 import BreadCrumbs from "../components/ui/BreadCrumbs";
-import {createNavigatePaths} from "../js/utils";
-import AreaCard from"../components/ui/AreaCard";
+import {createNavigatePaths, pathOrParentIdToGitHubLink} from "../js/utils";
+import AreaCard from "../components/ui/AreaCard";
+import LinkToGithub from "../components/ui/LinkToGithub";
 
 const shortcodes = { Link };
 /**
@@ -17,9 +18,9 @@ const shortcodes = { Link };
  */
 export default function LeafAreaPage({ data: {mdx, climbs, parentAreas, childAreas} }) {
   const { area_name } = mdx.frontmatter;
-  const parentId = mdx.fields.parentId;
+  const {parentId, pathId, filename} = mdx.fields;
   const navigationPaths = createNavigatePaths(parentId, parentAreas.edges);
-  console.log(childAreas);
+  const githubLink = pathOrParentIdToGitHubLink(pathId, filename);
   return (
     <Layout>
       {/* eslint-disable react/jsx-pascal-case */}
@@ -73,6 +74,7 @@ export default function LeafAreaPage({ data: {mdx, climbs, parentAreas, childAre
           })
         }
       </div>
+      <LinkToGithub link={githubLink} docType="area"></LinkToGithub>
     </Layout>
   );
 }
@@ -87,6 +89,7 @@ export const query = graphql`
       fields {
         parentId
         pathId
+        filename
       }
       frontmatter {
         area_name


### PR DESCRIPTION
# Trello

OpenTacos: Add link to climb/area md file

# Task

Until we have a proper editor as climber I want to see the underlying data file in GitHub.

# Implementation

- Created a new LinkToGithub component
- Added the LinkToGithub footer at the bottom of the area and climb pages

Added the filenames without extensions to the node field structure. I was having an awful time trying to pass the filename with extension. Gatsby kept wrapping it in a file object instead of treating it as a string.

The helper function in `util.js` is a little hard coded. I am assuming the github link shouldn't change that often. Additionally I generate the URL path based on the folder path which will match the github URL.

The filename has `.md` hard coded because like I said above the `createNodeField` functions were wrapping my `index.md` string value into a `File` object and I have no idea why... So I just pass the filename without extension then add the extension back.

These files should always have `.md` extensions.

# Example

Area

![image](https://user-images.githubusercontent.com/1581329/120249768-90a00100-c241-11eb-8ee6-7c1b191aa085.png)


Climb

![image](https://user-images.githubusercontent.com/1581329/120249778-9990d280-c241-11eb-9ec5-490acaee9373.png)


# Next Steps

There maybe a cleaner way to do this? I am not a huge fan of how I got the data to construct the URL but it seems to work. The encoding should be all automatic no matter what the file name is within Github assuming it is a markdown file. 