### PR TITLE
Nadr0.basic climbs formatting

### DIFF
--- a/src/components/ui/shortcodes/h1.js
+++ b/src/components/ui/shortcodes/h1.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+/**
+ * <h1> short code to be used in templates
+ */
+const shortCode_H1 = (props) => <h1 {...props} className="text-2xl font-medium my-3"/>;
+export default shortCode_H1;

--- a/src/js/styles/index.js
+++ b/src/js/styles/index.js
@@ -1,0 +1,2 @@
+// CSS for <h1/>. Use in templates (*-md.js) files
+export const template_h1_css = "text-4xl font-bold font-sans my-4";

--- a/src/templates/climb-page-md.js
+++ b/src/templates/climb-page-md.js
@@ -9,7 +9,10 @@ import BreadCrumbs from "../components/ui/BreadCrumbs";
 import {createNavigatePaths, pathOrParentIdToGitHubLink} from "../js/utils";
 import LinkToGithub from "../components/ui/LinkToGithub";
 
-const shortcodes = { Link }; // Provide common components here
+const shortcodes = { 
+  Link,
+  h1: (props) => <h1 {...props} className="text-2xl font-medium my-3"/>
+}; // Provide common components here
 
 /**
  * Templage for generating individual page for the climb
@@ -24,7 +27,7 @@ export default function ClimbPage({ data: { mdx, parentAreas } }) {
       {/* eslint-disable react/jsx-pascal-case */}
       <SEO keywords={[route_name]} title={route_name} />
       <BreadCrumbs path={parentId} navigationPaths={navigationPaths}></BreadCrumbs>
-      <h1 className="font-medium font-sans my-4">{route_name}</h1>
+      <h1 className="text-4xl font-bold font-sans my-4">{route_name}</h1>
       <MDXProvider components={shortcodes}>
         <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>

--- a/src/templates/climb-page-md.js
+++ b/src/templates/climb-page-md.js
@@ -8,10 +8,12 @@ import { Link } from "gatsby";
 import BreadCrumbs from "../components/ui/BreadCrumbs";
 import {createNavigatePaths, pathOrParentIdToGitHubLink} from "../js/utils";
 import LinkToGithub from "../components/ui/LinkToGithub";
+import shortCode_H1 from "../components/ui/shortcodes/h1";
+import {template_h1_css} from "../js/styles";
 
 const shortcodes = { 
   Link,
-  h1: (props) => <h1 {...props} className="text-2xl font-medium my-3"/>
+  h1: shortCode_H1
 }; // Provide common components here
 
 /**
@@ -27,7 +29,7 @@ export default function ClimbPage({ data: { mdx, parentAreas } }) {
       {/* eslint-disable react/jsx-pascal-case */}
       <SEO keywords={[route_name]} title={route_name} />
       <BreadCrumbs path={parentId} navigationPaths={navigationPaths}></BreadCrumbs>
-      <h1 className="text-4xl font-bold font-sans my-4">{route_name}</h1>
+      <h1 className={template_h1_css}>{route_name}</h1>
       <MDXProvider components={shortcodes}>
         <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>

--- a/src/templates/leaf-area-page-md.js
+++ b/src/templates/leaf-area-page-md.js
@@ -11,8 +11,14 @@ import BreadCrumbs from "../components/ui/BreadCrumbs";
 import {createNavigatePaths, pathOrParentIdToGitHubLink} from "../js/utils";
 import AreaCard from "../components/ui/AreaCard";
 import LinkToGithub from "../components/ui/LinkToGithub";
+import shortCode_H1 from "../components/ui/shortcodes/h1";
+import {template_h1_css} from "../js/styles";
 
-const shortcodes = { Link };
+const shortcodes = { 
+  Link,
+  h1: shortCode_H1 
+};
+
 /**
  * Templage for generating individual page for the climb
  */
@@ -26,7 +32,7 @@ export default function LeafAreaPage({ data: {mdx, climbs, parentAreas, childAre
       {/* eslint-disable react/jsx-pascal-case */}
       <SEO keywords={[area_name]} title={area_name} />
       <BreadCrumbs path={parentId} navigationPaths={navigationPaths}></BreadCrumbs>
-      <h1 className="text-lg font-bold font-sans my-4">{area_name}</h1>
+      <h1 className={template_h1_css}>{area_name}</h1>
       <MDXProvider components={shortcodes}>
         <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>


### PR DESCRIPTION
# Trello

OpenTacos: Basic formatting for climbing route pages for the text is easier to read. [[c/jLl9xVl8] ](https://trello.com/c/jLl9xVl8/30-opentacos-basic-formatting-for-climbing-route-pages-for-the-text-is-easier-to-read)

# Task

Clean up and format the climbing route pages as well as the area pages. This will allow users to easily parse and read the different headers and descriptions.

# Implementation 

I used the shortcodes within the mdxrenderer to create a reusable h1 component.

I created a file under `src/js/styles/index.js` to reuse strings of tailwind css for now because when I was trying to use `@apply` within the `global.css` file it wasn't working? I don't know if we have `postcss` running or it is something automatically setup within gatsby? For some reason it wouldn't let me configure a class with `@apply` to create a global CSS class with my classes.

Updated both the area and climb formatting for they are consistent. 

Didn't add anything too complex because it is bound to change. I added some simple font sizes and margins to visually break up the page for easier reading. 

# Example
Original route page
![image](https://user-images.githubusercontent.com/1581329/120573097-ac8ed880-c3e2-11eb-8c74-655d58fd1b04.png)


New Route page
![image](https://user-images.githubusercontent.com/1581329/120572867-4f932280-c3e2-11eb-99bb-21750e4c24c1.png)

New Area page
![image](https://user-images.githubusercontent.com/1581329/120572896-5e79d500-c3e2-11eb-882f-a78f91fe7cba.png)
