### PR TITLE
rendering area stats

### DIFF
--- a/src/components/AreaStatistics.js
+++ b/src/components/AreaStatistics.js
@@ -1,0 +1,35 @@
+import React from "react";
+import SingleStat from "./ui/SingleStat";
+import BarPercent from "./ui/BarPercent";
+import {computeClimbingPercentsAndColors} from "../js/utils";
+
+function AreaStatistics ({climbs}) {
+  const totalClimbsInArea = climbs.edges.length;
+
+  // If there are no climbs in an area do not render the stats
+  if (totalClimbsInArea === 0) return null;
+
+  const {percents, colors} = computeClimbingPercentsAndColors(climbs.edges);
+  return (
+    <table className="table-auto mx-auto">
+      <tbody>
+        <tr >
+          <td className="px-3.5">
+          <SingleStat number={totalClimbsInArea} className="w-min"></SingleStat>
+          </td>
+          <td className="px-3.5">
+            <BarPercent percents={percents} colors={colors}></BarPercent>
+          </td>
+        </tr>
+      </tbody>
+      <tfoot className="text-xs text-center text-gray-500">
+        <tr>
+          <th>Climbs</th>
+          <th>Type</th>
+        </tr>
+      </tfoot>
+    </table>
+  );
+}
+
+export default AreaStatistics;

--- a/src/components/ui/BarPercent.js
+++ b/src/components/ui/BarPercent.js
@@ -1,0 +1,39 @@
+import React from "react";
+
+function BarPercent ({percents=[], colors=[]}) {
+  return (
+    <div>
+      <div className="h-2 w-100 flex">
+        {
+          percents.map((percent, index)=> {
+            const color = colors[index];
+            const moreThanOnePercent = percents.length > 1;
+
+            // Border logic
+            // ( ) single
+            // ( ] [ ) double
+            // ( ] [ ] [ ) triple
+            // ( ] [ ] [ ] [ ) quadruple
+            let borderRounding = 'mr-1';
+            if (moreThanOnePercent && index === 0 ) 
+              borderRounding = 'rounded-l mr-1'
+            if (moreThanOnePercent && index === percents.length - 1) 
+              borderRounding = 'rounded-r'
+            if (!moreThanOnePercent)
+              borderRounding = 'rounded-lg'
+
+            return (
+              <span
+                key={index}
+                className={`${borderRounding} h-2 bg-${color} inline-block`}
+                style={{ width: `${percent}px` }}
+              ></span>
+            );
+          })
+        }
+      </div>
+    </div>
+  )
+}
+
+export default BarPercent;

--- a/src/components/ui/SingleStat.js
+++ b/src/components/ui/SingleStat.js
@@ -1,0 +1,14 @@
+import React from "React";
+
+function SingleStat ({number, className}) {
+  return (
+    <div
+      className={`h-12 flex place-items-center font-mono text-xl rounded-lg 
+      border-2 px-3 bg-gray-100 ${className}`}
+    >
+      {number}
+    </div>
+  );
+}
+
+export default SingleStat;

--- a/src/components/ui/SingleStat.js
+++ b/src/components/ui/SingleStat.js
@@ -1,4 +1,4 @@
-import React from "React";
+import React from "react";
 
 function SingleStat ({number, className}) {
   return (

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -1,0 +1,6 @@
+export const ClimbTypeToColor = {
+  sport: "indigo-400",
+  trad: "red-700",
+  boulder: "green-700",
+  tr: "yellow-400"
+};

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,4 +1,5 @@
 import slugify from "slugify";
+import {ClimbTypeToColor} from "./constants";
 
 /**
  * TODO: I know this is a duplicated function in gatsby-node.js
@@ -77,4 +78,41 @@ export const createNavigatePaths = (pathId, parentAreas) => {
 export const pathOrParentIdToGitHubLink = (pathOrParentId, fileName) => {
   const baseUrl = 'https://github.com/OpenBeta/open-tacos/blob/develop/content/';
   return baseUrl + pathOrParentId + `/${fileName}.md`;
+};
+
+/**
+ * Given an array of objects that are climbs, generate the percents
+ * and colors of all the types of climbs. This is used in the BarPercent 
+ * component.
+ * @param {Object[]} climbs, these are the nodes {frontmatter, fields} format
+ * @returns {percents: [], colors:[]}
+ */
+export const computeClimbingPercentsAndColors = (climbs) => {
+  const typeToCount = {};
+  climbs.forEach(({node:climb})=>{
+    const {type} = climb.frontmatter;
+    const types = Object.keys(type);
+    types.forEach((key)=>{
+      const isType = type[key];
+      if (!isType) return;
+      if (typeToCount[key]) {
+        typeToCount[key] = typeToCount[key] + 1;      
+      } else {
+        typeToCount[key] = 1;
+      }
+    });
+  });
+  const counts = Object.values(typeToCount) || [];
+  const reducer = (accumulator, currentValue) => accumulator + currentValue;
+  const totalClimbs = counts.reduce(reducer,0);
+  const percents = counts.map((count)=>{
+    return count/totalClimbs * 100;
+  })  
+  const colors = Object.keys(typeToCount).map((key)=>{
+    return ClimbTypeToColor[key];
+  });
+  return {
+    percents,
+    colors
+  };
 };

--- a/src/templates/leaf-area-page-md.js
+++ b/src/templates/leaf-area-page-md.js
@@ -13,6 +13,7 @@ import AreaCard from "../components/ui/AreaCard";
 import LinkToGithub from "../components/ui/LinkToGithub";
 import shortCode_H1 from "../components/ui/shortcodes/h1";
 import {template_h1_css} from "../js/styles";
+import AreaStatistics from "../components/AreaStatistics";
 
 const shortcodes = { 
   Link,
@@ -33,6 +34,7 @@ export default function LeafAreaPage({ data: {mdx, climbs, parentAreas, childAre
       <SEO keywords={[area_name]} title={area_name} />
       <BreadCrumbs path={parentId} navigationPaths={navigationPaths}></BreadCrumbs>
       <h1 className={template_h1_css}>{area_name}</h1>
+      <AreaStatistics climbs={climbs}></AreaStatistics>
       <MDXProvider components={shortcodes}>
         <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>


### PR DESCRIPTION
# Task

As a user I want to see the stats of an area. 

I wanted to reuse the designs and components you had within `GradeDistribution.js` but refactor it into components and add the functionality for the BarPercent.

# Implementation

- Added `AreaStatistics.js` component that holds the components for the area stats
- Added `BarPercent.js` which can render bars with different colors based on the percents of width.
  - This works for bars of size 1, 2, 3, 4 ... N types.
- Added `SingleStat.js` component which is just a gray background card looking thing
- Added a constants file in the js folder to map a climb type to a color in tailwind.
- Added a util function which will take all the climb nodes in a given area and compute the `percents` and `colors` for the AreaStatistics

# Example

![image](https://user-images.githubusercontent.com/1581329/120880405-f36e0100-c58f-11eb-8b39-58f048d4056d.png)
![image](https://user-images.githubusercontent.com/1581329/120880520-bc4c1f80-c590-11eb-8b8f-4e770ccca11a.png)

# Next Steps

Implement the grad distribution component.
Add unit test in the future?
Implement tooltip hovers on the components. 

