### PR TITLE
Rename build job to activate deployment again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,8 @@ variables:
   GIT_DEPTH: 1
   DOCKER_DRIVER: overlay2
 
-gatsby-build:
+# Job name must be 'pages' in order for GitLab to deploy to static site
+pages:
   only: # Only run for these branches
   - develop
   - main

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -7,7 +7,9 @@
 #     Specify 'full' include the entire dataset
 #
 
-rm -rf content/*
+rm -rf content
+mkdir content
+
 rm -rf opentacos-content
 
 git clone --depth 1 --branch develop \
@@ -23,8 +25,10 @@ then
   find . -mindepth 2 -maxdepth 4  -name "index*"  -exec rsync -aR "{}" $target \;
 
   # Copy only a few specific areas
-  mkdir -p $target/$target
   rsync -aR ./USA/Oregon/Central\ Oregon/Smith\ Rock $target
   rsync -aR ./USA/Nevada/Southern\ Nevada/Red\ Rock $target
   popd
+else
+  # create a symlink to the entire content repo
+  ln -s opentacos-content/content content
 fi

--- a/prebuild.sh
+++ b/prebuild.sh
@@ -8,7 +8,6 @@
 #
 
 rm -rf content
-mkdir content
 
 rm -rf opentacos-content
 
@@ -17,10 +16,10 @@ git clone --depth 1 --branch develop \
 
 if [ "$1" != "full" ];
 then
+  mkdir content
   echo "Copying selected content..."
   pushd opentacos-content/content
   export target="../../content"
-
   # Copy only the first and 2nd level index.md for each state 
   find . -mindepth 2 -maxdepth 4  -name "index*"  -exec rsync -aR "{}" $target \;
 
@@ -29,6 +28,6 @@ then
   rsync -aR ./USA/Nevada/Southern\ Nevada/Red\ Rock $target
   popd
 else
-  # create a symlink to the entire content repo
+  echo "Creating a symlink to entire content repo"
   ln -s opentacos-content/content content
 fi


### PR DESCRIPTION
GitLab build job must be named `pages` in order for the GitLab Pages feature to work.  A week ago I renamed the job to something else, and as a result, all code changes have since stopped appearing on https://tacos.openbeta.io.   The auto deployment is back to normal.

From the [doc](https://docs.gitlab.com/ee/user/project/pages/#how-it-works)

> A specific job called pages in the configuration file makes GitLab aware that you’re deploying a GitLab Pages website.