### PR TITLE
Use custom build image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ cache:
     - .cache
     - public
 
-image: node:16.3-buster-slim
+image: registry.gitlab.com/openbeta/openbeta-nodejs-docker:16.3
 
 variables:
   GIT_DEPTH: 1
@@ -23,7 +23,6 @@ pages:
   - docker
 
   before_script:
-  - apt-get update && apt-get install -y git rsync
   - yarn install --no-progress
   - ./prebuild.sh # fetch content repo
 


### PR DESCRIPTION
Use our own [Docker image](https://gitlab.com/openbeta/openbeta-nodejs-docker) so we don't install git and rsync for each build