### PR TITLE
adding our public trello board to the about page

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -30,6 +30,10 @@ We want contributing to the project be fun and educational.  All contributions a
 
 No worries, you can ask questions on the community [message board](https://community.openbeta.io) or on [OpenBeta Discord](https://discord.gg/w2KpQu2ca5) chat server.
 
+## To see what we're working on
+
+Check out our public [Trello board](https://trello.com/b/Ir8emiyR/openbeta-project)
+
 ## How to submit an edit
 
 We host this project on GitHub.com, a popular source code hosting platform.


### PR DESCRIPTION
# Task

Wanted to share our public trello board on the about page. 

# Implementation

Added a header and a link to the trello board on the about page. 