### PR TITLE
Client-side url mapping

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -54,13 +54,10 @@ export default function SearchBar({ className }) {
 }
 
 const navigateTo = (data) => {
-  const { meta_mp_route_id, name } = data;
-  navigate(build_url(meta_mp_route_id, name));
-  //console.log(data);
+  const { meta_mp_route_id } = data;
+  navigate(build_url(meta_mp_route_id));
 };
 
-const build_url = (meta_mp_route_id, name) => {
-  return `/climbs/${meta_mp_route_id}/${slugify(name, {
-    lower: true,
-  })}`;
+const build_url = (meta_mp_route_id) => {
+  return `/climbs/${meta_mp_route_id}`;
 };

--- a/src/pages/climbs/[id].js
+++ b/src/pages/climbs/[id].js
@@ -1,0 +1,46 @@
+import React from "react";
+import { useStaticQuery, graphql, navigate, Link } from "gatsby";
+
+function Climbs({ id }) {
+  let allClimbingRoutes = useStaticQuery(graphql`
+    query {
+      allMdx(
+        filter: { fields: { collection: { eq: "climbing-routes" } } }
+        sort: { fields: frontmatter___metadata___legacy_id }
+      ) {
+        edges {
+          node {
+            fields {
+              slug
+            }
+            frontmatter {
+              metadata {
+                legacy_id
+              }
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const list = allClimbingRoutes.allMdx.edges;
+
+  const foundNode = list.find(
+    ({ node }) => id === node.frontmatter.metadata.legacy_id
+  );
+
+  // console.log("# props", allClimbingRoutes)
+  if (foundNode) {
+    const { node } = foundNode;
+    navigate(node.fields.slug);
+  }
+
+  return (
+    <div className="mt-12">
+      Climb not found. <Link className="btn btn-text" to="/">Continue</Link>
+    </div>
+  );
+}
+
+export default Climbs;


### PR DESCRIPTION
PR https://github.com/OpenBeta/open-tacos/pull/66 introduces a breaking change to permanent URL for climb and area page.  This PR provides client side mapping, redirect old url (generated by the search widget) `/climb/106157138` to `/usa/oregon/central-oregon/smith-rock/j-rope-de-dope-block`