### PR TITLE
Fix null byte error in file path during build

### DIFF
--- a/prebuild.sh
+++ b/prebuild.sh
@@ -29,6 +29,6 @@ then
   rsync -aR ./USA/Nevada/Southern\ Nevada/Red\ Rock $target
   popd
 else
-  echo "Creating a symlink to entire content repo"
-  ln -s opentacos-content/content content
+  echo "Make entire repo available to build"
+  mv opentacos-content/content content
 fi


### PR DESCRIPTION
Strange error during build.  I suspect it's caused by the symlink.
```
Error: TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string   
or Uint8Array without null bytes. 
Received '/builds/B2goyrEA/0/openbeta/opent  acos-content-ci/open-tacos/\x00/builds/B2goyrEA/0/openbeta/opentacos-content-c  i/open-tacos/con...
```