### PR TITLE
New data export page

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -49,6 +49,10 @@ function Header() {
               route: `/history`,
               title: `History`,
             },
+            {
+              route: `/export`,
+              title: `Export`,
+            },
           ].map((link) => (
             <Link
               className="block no-underline lg:py-4 lg:inline-block lg:px-4 py-4 lg:py-0"

--- a/src/pages/export.md
+++ b/src/pages/export.md
@@ -1,0 +1,21 @@
+---
+title: OpenTacos data extracts
+keywords:
+ - OpenBeta
+ - rock climbing api
+---
+# OpenTacos Data Extracts 
+
+This page has weekly data extracts from the OpenTacos content catalog.
+
+| State      | Description | Link |
+| :-------- | :---------------------- | :---|
+| Oregon      | Leaf areas | [zip](https://gitlab.com/openbeta/exporter/-/jobs/artifacts/main/download?job=publish) |
+| Oregon      | Climbs | Comming soon |
+
+## License
+OpenTacos content (excluding photos) is licensed under [CreativeCommons Public Domain](https://creativecommons.org/share-your-work/public-domain/cc0/) (CC0).
+
+## Technical details
+- [Gitlab pipeline](https://gitlab.com/openbeta/exporter/-/pipeline_schedules)
+- [Exporter code](https://github.com/OpenBeta/exporter) 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -261,11 +261,18 @@ input:checked + label {
   @apply underline;
 }
 
-.history-table td {
-  padding: 15px;
+.markdown table {
+   @apply table-auto w-full;
 }
 
-.history-table th {
-  padding: 15px;
-  @apply text-left;
+.markdown table thead {
+  @apply bg-custom-green bg-opacity-50;
+}
+
+.markdown table th {
+  @apply p-2;
+}
+
+.markdown table td {
+  @apply p-2;
 }


### PR DESCRIPTION
Add a new page linking to the data export job

# screenshot

<img width="498" alt="Screen Shot 2021-12-09 at 8 20 10 AM" src="https://user-images.githubusercontent.com/3805254/145344633-aa4ed698-d280-44b7-a46c-4f1e52ee83c8.png">
