### PR TITLE
fix: #230 correcting the breadcrumb link for the crag url when on the climb page

### DIFF
--- a/src/components/ui/BreadCrumbs.tsx
+++ b/src/components/ui/BreadCrumbs.tsx
@@ -35,27 +35,26 @@ function BreadCrumbs ({ pathTokens, ancestors, isClimbPage = false }: BreakCrumb
         return (
           <span key={index}>
             <span className='text-secondary mx-1.5'>/</span>
-            {isLastElement && !isClimbPage
-              ? (
-                <span className=''>{sanitizeName(place)}</span>
-                )
-              : isLastElement && isClimbPage
-                ? (
-                  <span className='text-secondary'>
-                    <Link href={climbPageLastUrl}>
-                      <a className='hover:underline hover:text-gray-900'>
-                        {sanitizeName(place)}
-                      </a>
-                    </Link>
-                  </span>
-                  )
-                : (
-                  <span className='text-secondary'>
-                    <Link href={url}>
-                      <a className='hover:underline hover:text-gray-900'>{sanitizeName(place)}</a>
-                    </Link>
-                  </span>
-                  )}
+            {/* last element but not currently on the climb page */}
+            {isLastElement && !isClimbPage && <span className=''>{sanitizeName(place)}</span>}
+
+            {/* last element and currently on the climb page, so /crag/ url used */}
+            {isLastElement && isClimbPage &&
+              <span className='text-secondary'>
+                <Link href={climbPageLastUrl}>
+                  <a className='hover:underline hover:text-gray-900'>
+                    {sanitizeName(place)}
+                  </a>
+                </Link>
+              </span>}
+
+            {/* all links before last element when on climb page to get /areas/ url */}
+            {!isLastElement && isClimbPage &&
+              <span className='text-secondary'>
+                <Link href={url}>
+                  <a className='hover:underline hover:text-gray-900'>{sanitizeName(place)}</a>
+                </Link>
+              </span>}
           </span>
         )
       })}

--- a/src/components/ui/BreadCrumbs.tsx
+++ b/src/components/ui/BreadCrumbs.tsx
@@ -31,6 +31,7 @@ function BreadCrumbs ({ pathTokens, ancestors, isClimbPage = false }: BreakCrumb
         const isLastElement = array.length - 1 === index
         const path = ancestors[index]
         const url = `/areas/${path}`
+        const climbPageLastUrl = `/crag/${path}`
         return (
           <span key={index}>
             <span className='text-secondary mx-1.5'>/</span>
@@ -38,13 +39,23 @@ function BreadCrumbs ({ pathTokens, ancestors, isClimbPage = false }: BreakCrumb
               ? (
                 <span className=''>{sanitizeName(place)}</span>
                 )
-              : (
-                <span className='text-secondary'>
-                  <Link href={url}>
-                    <a className='hover:underline hover:text-gray-900'>{sanitizeName(place)}</a>
-                  </Link>
-                </span>
-                )}
+              : isLastElement && isClimbPage
+                ? (
+                  <span className='text-secondary'>
+                    <Link href={climbPageLastUrl}>
+                      <a className='hover:underline hover:text-gray-900'>
+                        {sanitizeName(place)}
+                      </a>
+                    </Link>
+                  </span>
+                  )
+                : (
+                  <span className='text-secondary'>
+                    <Link href={url}>
+                      <a className='hover:underline hover:text-gray-900'>{sanitizeName(place)}</a>
+                    </Link>
+                  </span>
+                  )}
           </span>
         )
       })}

--- a/src/components/ui/BreadCrumbs.tsx
+++ b/src/components/ui/BreadCrumbs.tsx
@@ -35,11 +35,14 @@ function BreadCrumbs ({ pathTokens, ancestors, isClimbPage = false }: BreakCrumb
         return (
           <span key={index} className='text-secondary'>
             <span className='mx-1.5'>/</span>
-            <Link href={isLastElement && isClimbPage ? climbPageLastUrl : url}>
-              <a className='hover:underline hover:text-gray-900'>
-                {sanitizeName(place)}
-              </a>
-            </Link>
+            {(isLastElement && !isClimbPage && <span className=''>{sanitizeName(place)}</span>) ||
+            (
+              <Link href={isLastElement && isClimbPage ? climbPageLastUrl : url}>
+                <a className='hover:underline hover:text-gray-900'>
+                  {sanitizeName(place)}
+                </a>
+              </Link>
+            )}
           </span>
         )
       })}

--- a/src/components/ui/BreadCrumbs.tsx
+++ b/src/components/ui/BreadCrumbs.tsx
@@ -33,28 +33,13 @@ function BreadCrumbs ({ pathTokens, ancestors, isClimbPage = false }: BreakCrumb
         const url = `/areas/${path}`
         const climbPageLastUrl = `/crag/${path}`
         return (
-          <span key={index}>
-            <span className='text-secondary mx-1.5'>/</span>
-            {/* last element but not currently on the climb page */}
-            {isLastElement && !isClimbPage && <span className=''>{sanitizeName(place)}</span>}
-
-            {/* last element and currently on the climb page, so /crag/ url used */}
-            {isLastElement && isClimbPage &&
-              <span className='text-secondary'>
-                <Link href={climbPageLastUrl}>
-                  <a className='hover:underline hover:text-gray-900'>
-                    {sanitizeName(place)}
-                  </a>
-                </Link>
-              </span>}
-
-            {/* all links before last element when on climb page to get /areas/ url */}
-            {!isLastElement && isClimbPage &&
-              <span className='text-secondary'>
-                <Link href={url}>
-                  <a className='hover:underline hover:text-gray-900'>{sanitizeName(place)}</a>
-                </Link>
-              </span>}
+          <span key={index} className='text-secondary'>
+            <span className='mx-1.5'>/</span>
+            <Link href={isLastElement && isClimbPage ? climbPageLastUrl : url}>
+              <a className='hover:underline hover:text-gray-900'>
+                {sanitizeName(place)}
+              </a>
+            </Link>
           </span>
         )
       })}


### PR DESCRIPTION
This fixes #230 where the breadcrumb links to /areas/{id} instead of /crag/{id} while on the climb page

i basically added another condition where if both `isLastElement` and `isClimbPage` are both true, then use the `/crag/`in the url, and the rest of the previous breadcrumb urls will continue to use `/areas/`. 

with fix you can see the url being hovered over is now going to link to `/crag/{id}` (my pointer is not getting captured in the screenshot, but you can see the url being hovered over in bottom left of screenshot and the hovered breadcrumb is underlined):

![image](https://user-images.githubusercontent.com/24685932/159185225-08950db7-dd79-4fa2-8be4-b91a4918dd34.png)

all previous breadcrumb link beyond the last link to /areas/{id}:
![image](https://user-images.githubusercontent.com/24685932/159185295-aed9eac9-c63b-4dfb-acf2-bbf3ca3ea61e.png)

Please let me know if there are improvements that can be made. Thanks!

