### PR TITLE
add tests to DisciplineGroup and simplify cancel useEffect #243

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/user-event": "^14.0.4",
     "@types/js-yaml": "^4.0.5",
     "@types/react": "^17.0.38",
     "@types/supercluster": "^5.0.3",

--- a/src/components/DisciplineGroup.tsx
+++ b/src/components/DisciplineGroup.tsx
@@ -11,7 +11,7 @@ interface DisciplineGroupProps {
 const DisciplineGroup = ({ climbTypes, setClimbTypes, defaultTypes }: DisciplineGroupProps): JSX.Element => {
   useEffect(() => { // if doesn't match, set everything to default
     if (JSON.stringify(climbTypes) !== JSON.stringify(defaultTypes)) {
-      setClimbTypes({ ...climbTypes, sport: defaultTypes.sport, tr: defaultTypes.tr, trad: defaultTypes.trad, bouldering: defaultTypes.bouldering })
+      setClimbTypes({ ...defaultTypes })
     }
   }, [])
 

--- a/src/components/__tests__/DisciplineGroup.tsx
+++ b/src/components/__tests__/DisciplineGroup.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { act, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import DisciplineGroup from '../DisciplineGroup'
+
+const defaultTypes = {
+  trad: true,
+  sport: true,
+  tr: true,
+  bouldering: true
+}
+
+let climbTypes = {
+  trad: true,
+  sport: true,
+  tr: true,
+  bouldering: true
+}
+
+const setClimbTypes = (value): void => {
+  climbTypes = value
+}
+
+describe('DisciplineGroup', () => {
+  it('renders component without error', () => {
+    render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+  })
+
+  it('all 4 types selected by default', async () => {
+    const { container, getByRole, rerender } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    expect(container.getElementsByClassName('border-neutral-800').length).toBe(4)
+
+    const sportButton = getByRole('button', { name: /Sport/i })
+    console.log(sportButton)
+
+    await userEvent.click(sportButton)
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3))
+    })
+    rerender(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    expect(container.getElementsByClassName('border-neutral-800').length).toBe(3)
+
+    // expect(container).toMatchSnapshot()
+  })
+
+  it('changs values and resets to defaultTypes when component regenerated', () => {
+    // caused by cancel or click away
+    render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+  })
+})
+
+// possible tests
+
+// does it render without error
+// do all 4 types show by default
+// if not matches, does it reset to defaultTypes?

--- a/src/components/__tests__/DisciplineGroup.tsx
+++ b/src/components/__tests__/DisciplineGroup.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import DisciplineGroup from '../DisciplineGroup'
@@ -29,42 +29,30 @@ describe('DisciplineGroup', () => {
     render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
   })
 
-  it('all 4 types selected by default', async () => {
+  it('all 4 types selected by default', () => {
+    const { container } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    expect(container.getElementsByClassName('border-neutral-800').length).toBe(4)
+  })
+
+  it('changs values and resets to defaultTypes when component regenerated', async () => {
+    const clickButton = async (button): Promise<void> => {
+      await userEvent.click(button)
+      rerender(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    }
+
     const { container, getByRole, rerender } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
     expect(container.getElementsByClassName('border-neutral-800').length).toBe(4)
 
     const sportButton = getByRole('button', { name: /Sport/i })
+    const tradButton = getByRole('button', { name: /Trad/i })
+    const topRopeButton = getByRole('button', { name: /Top rope/i })
 
-    await userEvent.click(sportButton)
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 3))
-    })
-
-    rerender(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
-    expect(container.getElementsByClassName('border-neutral-800').length).toBe(3)
-
-    // expect(container).toMatchSnapshot()
-    // debug()
-  })
-
-  it('all 4 types selected by default mo', async () => {
-    const clickButton = async (index): Promise<void> => {
-      await userEvent.click(buttons[index])
-      rerender(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
-    }
-
-    const { container, getAllByRole, rerender } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
-    expect(container.getElementsByClassName('border-neutral-800').length).toBe(4)
-
-    const buttons = getAllByRole('button')
-
-    await clickButton(0)
-    await clickButton(1)
-    await clickButton(3)
+    await clickButton(sportButton)
+    await clickButton(tradButton)
+    await clickButton(topRopeButton)
 
     expect(container.getElementsByClassName('border-neutral-800').length).toBe(1)
-    await clickButton(3)
+    await clickButton(topRopeButton)
     expect(container.getElementsByClassName('border-neutral-800').length).toBe(2)
 
     // cancel and click away functionality.
@@ -74,15 +62,4 @@ describe('DisciplineGroup', () => {
     rerender2(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
     expect(recreatedContainer2.getElementsByClassName('border-neutral-800').length).toBe(4)
   })
-
-  it('changs values and resets to defaultTypes when component regenerated', () => {
-    // caused by cancel or click away
-    render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
-  })
 })
-
-// possible tests
-
-// does it render without error
-// do all 4 types show by default
-// if not matches, does it reset to defaultTypes?

--- a/src/components/__tests__/DisciplineGroup.tsx
+++ b/src/components/__tests__/DisciplineGroup.tsx
@@ -49,7 +49,7 @@ describe('DisciplineGroup', () => {
   })
 
   it('all 4 types selected by default mo', async () => {
-    const clickButton = async (index) => {
+    const clickButton = async (index): Promise<void> => {
       await userEvent.click(buttons[index])
       rerender(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
     }
@@ -64,6 +64,15 @@ describe('DisciplineGroup', () => {
     await clickButton(3)
 
     expect(container.getElementsByClassName('border-neutral-800').length).toBe(1)
+    await clickButton(3)
+    expect(container.getElementsByClassName('border-neutral-800').length).toBe(2)
+
+    // cancel and click away functionality.
+    const { container: recreatedContainer2, rerender: rerender2 } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+
+    // rerender needed so that useEffect [] runs.
+    rerender2(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    expect(recreatedContainer2.getElementsByClassName('border-neutral-800').length).toBe(4)
   })
 
   it('changs values and resets to defaultTypes when component regenerated', () => {

--- a/src/components/__tests__/DisciplineGroup.tsx
+++ b/src/components/__tests__/DisciplineGroup.tsx
@@ -30,36 +30,63 @@ describe('DisciplineGroup', () => {
   })
 
   it('all 4 types selected by default', () => {
-    const { container } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
-    expect(container.getElementsByClassName('border-neutral-800').length).toBe(4)
+    const { getByRole } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    const sportButton = getByRole('checkbox', { name: /Sport/i })
+    const tradButton = getByRole('checkbox', { name: /Trad/i })
+    const topRopeButton = getByRole('checkbox', { name: /Top rope/i })
+
+    expect(sportButton).toBeChecked()
+    expect(tradButton).toBeChecked()
+    expect(topRopeButton).toBeChecked()
   })
 
-  it('changs values and resets to defaultTypes when component regenerated', async () => {
+  it('changes values and resets to defaultTypes when component regenerated', async () => {
     const clickButton = async (button): Promise<void> => {
       await userEvent.click(button)
       rerender(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
     }
 
-    const { container, getByRole, rerender } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    const { container, getByRole, rerender, unmount } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
     expect(container.getElementsByClassName('border-neutral-800').length).toBe(4)
 
-    const sportButton = getByRole('button', { name: /Sport/i })
-    const tradButton = getByRole('button', { name: /Trad/i })
-    const topRopeButton = getByRole('button', { name: /Top rope/i })
+    const sportButton = getByRole('checkbox', { name: /Sport/i })
+    const tradButton = getByRole('checkbox', { name: /Trad/i })
+    const topRopeButton = getByRole('checkbox', { name: /Top rope/i })
 
+    // click buttons to remove from filter
+    // sportButton
+    expect(sportButton).toBeChecked()
     await clickButton(sportButton)
-    await clickButton(tradButton)
-    await clickButton(topRopeButton)
+    expect(sportButton).not.toBeChecked()
 
-    expect(container.getElementsByClassName('border-neutral-800').length).toBe(1)
+    // tradButton
+    expect(tradButton).toBeChecked()
+    await clickButton(tradButton)
+    expect(tradButton).not.toBeChecked()
+
+    // topRopeButton
+    expect(topRopeButton).toBeChecked()
     await clickButton(topRopeButton)
-    expect(container.getElementsByClassName('border-neutral-800').length).toBe(2)
+    expect(topRopeButton).not.toBeChecked()
+    await clickButton(topRopeButton)
+    expect(topRopeButton).toBeChecked()
 
     // cancel and click away functionality.
-    const { container: recreatedContainer2, rerender: rerender2 } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    unmount() // cancel/click-away unmounts <DisciplineGroup /> component
+
+    const { rerender: rerender2, getByRole: getByRole2 } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
 
     // rerender needed so that useEffect [] runs.
     rerender2(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
-    expect(recreatedContainer2.getElementsByClassName('border-neutral-800').length).toBe(4)
+
+    const sportButton2 = getByRole2('checkbox', { name: /Sport/i })
+    const tradButton2 = getByRole2('checkbox', { name: /Trad/i })
+    const topRopeButton2 = getByRole2('checkbox', { name: /Top rope/i })
+    const boulderingButton2 = getByRole2('checkbox', { name: /Bouldering/i })
+
+    expect(sportButton2).toBeChecked()
+    expect(tradButton2).toBeChecked()
+    expect(topRopeButton2).toBeChecked()
+    expect(boulderingButton2).toBeChecked()
   })
 })

--- a/src/components/__tests__/DisciplineGroup.tsx
+++ b/src/components/__tests__/DisciplineGroup.tsx
@@ -11,19 +11,20 @@ const defaultTypes = {
   tr: true,
   bouldering: true
 }
-
-let climbTypes = {
-  trad: true,
-  sport: true,
-  tr: true,
-  bouldering: true
-}
-
+let climbTypes
 const setClimbTypes = (value): void => {
   climbTypes = value
 }
 
 describe('DisciplineGroup', () => {
+  beforeEach(() => {
+    climbTypes = {
+      trad: true,
+      sport: true,
+      tr: true,
+      bouldering: true
+    }
+  })
   it('renders component without error', () => {
     render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
   })
@@ -33,17 +34,36 @@ describe('DisciplineGroup', () => {
     expect(container.getElementsByClassName('border-neutral-800').length).toBe(4)
 
     const sportButton = getByRole('button', { name: /Sport/i })
-    console.log(sportButton)
 
     await userEvent.click(sportButton)
 
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 3))
     })
+
     rerender(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
     expect(container.getElementsByClassName('border-neutral-800').length).toBe(3)
 
     // expect(container).toMatchSnapshot()
+    // debug()
+  })
+
+  it('all 4 types selected by default mo', async () => {
+    const clickButton = async (index) => {
+      await userEvent.click(buttons[index])
+      rerender(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    }
+
+    const { container, getAllByRole, rerender } = render(<DisciplineGroup defaultTypes={defaultTypes} climbTypes={climbTypes} setClimbTypes={setClimbTypes} />)
+    expect(container.getElementsByClassName('border-neutral-800').length).toBe(4)
+
+    const buttons = getAllByRole('button')
+
+    await clickButton(0)
+    await clickButton(1)
+    await clickButton(3)
+
+    expect(container.getElementsByClassName('border-neutral-800').length).toBe(1)
   })
 
   it('changs values and resets to defaultTypes when component regenerated', () => {

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -21,7 +21,7 @@ export function IconButton ({ onClick, children, active, text, className }) {
 
 export const FilterToggleButton = ({ selected, label, onClick }) => {
   return (
-    <button type='button' onClick={onClick} className={`border-2 rounded-2xl  btn-small active:scale-95 ${selected ? 'border-neutral-800 text-neutral-800' : 'border-neutral-400 text-neutral-400 hover:border-neutral-600'}`}>
+    <button type='button' role='checkbox' aria-checked={selected} onClick={onClick} className={`border-2 rounded-2xl  btn-small active:scale-95 ${selected ? 'border-neutral-800 text-neutral-800' : 'border-neutral-400 text-neutral-400 hover:border-neutral-600'}`}>
       {label}
     </button>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,6 +1527,11 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
+"@testing-library/user-event@^14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.0.4.tgz#5b430a9c27f25078bff4471661b755115d0db9d4"
+  integrity sha512-VBZe5lcUsmrQyOwIFvqOxLBoaTw1/Qy4Ek+VgmFYs719bs2SxUp42vbsb7ATlQDkHdj4OIQlucfpwxe5WoG1jA==
+
 "@tippyjs/react@^4.2.0", "@tippyjs/react@^4.2.5":
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.2.6.tgz#971677a599bf663f20bb1c60a62b9555b749cc71"


### PR DESCRIPTION
- simplify how cancelling works
- add some tests to verify that the DisciplineGroup popover works as expected

