### PR TITLE
stack route stat components in  RouteCard (#203)

### DIFF
--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -21,7 +21,7 @@ function Chip ({ type }: ChipProps): JSX.Element {
   return (
     <span
       aria-label='climb-discipline'
-      className={`font-extralight font-mono rounded-sm py-1 mr-4 px-2 text-xs uppercase border-2 ${ChipType[type]}`}
+      className={`font-extralight font-mono rounded-sm py-1 mr-3 px-2 my-1 text-xs uppercase border-2 ${ChipType[type]}`}
     >
       {type}
     </span>

--- a/src/components/ui/RouteCard.tsx
+++ b/src/components/ui/RouteCard.tsx
@@ -27,10 +27,10 @@ function RouteCard ({ routeName, type, safety, yds, fa = '', pathTokens }: Route
       </div>
       {fa !== null ? (<div className='text-xs font-light text-slate-500'>{fa}</div>) : null}
       <div className='mt-4 flex justify-between items-center'>
-        <div>
-          <RouteGradeGip yds={yds} safety={safety} />
-          <RouteTypeChips type={type} />
-        </div>
+        <RouteGradeGip yds={yds} safety={safety} />
+      </div>
+      <div className='mt-4 flex justify-between items-center'>
+        <RouteTypeChips type={type} />
       </div>
     </Card>
   )

--- a/src/components/ui/RouteCard.tsx
+++ b/src/components/ui/RouteCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Card from './Card'
 import RouteTypeChips from './RouteTypeChips'
-import RouteGradeGip from './RouteGradeChip'
+import RouteGradeChip from './RouteGradeChip'
 import { MiniCrumbs } from './BreadCrumbs'
 import { ClimbDisciplineRecord, SafetyType } from '../../js/types'
 
@@ -27,7 +27,7 @@ function RouteCard ({ routeName, type, safety, yds, fa = '', pathTokens }: Route
       </div>
       {fa !== null ? (<div className='text-xs font-light text-slate-500'>{fa}</div>) : null}
       <div className='mt-4 flex justify-between items-center'>
-        <RouteGradeGip yds={yds} safety={safety} />
+        <RouteGradeChip yds={yds} safety={safety} />
       </div>
       <div className='mt-4 flex justify-between items-center'>
         <RouteTypeChips type={type} />

--- a/src/components/ui/RouteTypeChips.tsx
+++ b/src/components/ui/RouteTypeChips.tsx
@@ -7,7 +7,7 @@ interface ChipProps {
 }
 function RouteTypeChips ({ type }: ChipProps): JSX.Element {
   return (
-    <div className='inline'>
+    <div className='flex flex-wrap'>
       {type?.trad && <Chip type='trad' />}
       {type?.sport && <Chip type='sport' />}
       {type?.tr && <Chip type='tr' />}


### PR DESCRIPTION
There is more room for both of these components (RouteGradeGip, RouteTypeChips) if they are stacked on top of eachother. 
![image](https://user-images.githubusercontent.com/24685932/163521871-50d03232-9012-48cf-8029-6a2fff3654e8.png)

This also seems to handle larger climb type children here too. See below for rendering all chips (just for testing).
![image](https://user-images.githubusercontent.com/24685932/163531162-9d910354-91ca-41f2-ba1b-6e86a5c0ed6f.png)


mobile view:
![image](https://user-images.githubusercontent.com/24685932/163531128-c9e3c087-719c-4f0e-8429-e61547351430.png)

