### PR TITLE
Help apollo client cache data

### DIFF
--- a/src/components/ui/FeatureCard/FeatureImage.tsx
+++ b/src/components/ui/FeatureCard/FeatureImage.tsx
@@ -4,8 +4,8 @@ import LicenseIcons from './LicenseIcons'
 export function DefaultImage (): JSX.Element {
   return (
     <div
-      style={{ height: '250px', backgroundRepeat: 'no-repeat', backgroundSize: '35%', backgroundPosition: 'center', backgroundImage: 'url("tortilla.png")' }}
-      className='overflow-hidden items-end flex flex-col-reverse'
+      style={{ backgroundRepeat: 'no-repeat', backgroundSize: '35%', backgroundPosition: 'center', backgroundImage: 'url("tortilla.png")' }}
+      className='aspect-[4/3] overflow-hidden items-end flex flex-col-reverse'
     />
   )
 }

--- a/src/js/graphql/Client.ts
+++ b/src/js/graphql/Client.ts
@@ -15,6 +15,12 @@ export const graphqlClient = new ApolloClient({
         },
         Area: {
           keyFields: ['id']
+        },
+        AreaMetadata: {
+          keyFields: false
+        },
+        Climb: {
+          keyFields: ['id']
         }
       }
     }

--- a/src/pages/areas/[id].tsx
+++ b/src/pages/areas/[id].tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps } from 'next'
 import { gql } from '@apollo/client'
-
+import { useRouter } from 'next/router'
 import { AreaType } from '../../js/types'
 import { graphqlClient } from '../../js/graphql/Client'
 import Link from 'next/link'
@@ -16,6 +16,10 @@ interface AreaPageProps {
   area: AreaType
 }
 const Area = ({ area }: AreaPageProps): JSX.Element => {
+  const router = useRouter()
+  if (router.isFallback) {
+    return <div>Loading...</div>
+  }
   const { id, area_name: areaName, children, metadata, content, pathTokens, ancestors } = area
 
   return (
@@ -109,7 +113,7 @@ export async function getStaticPaths (): Promise<any> {
   // { fallback: true } means render on first reques for those that are not in `paths`
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { GetStaticProps } from 'next'
+import { useRouter } from 'next/router'
 import { gql } from '@apollo/client'
 import { graphqlClient } from '../../js/graphql/Client'
 import Layout from '../../components/layout'
@@ -15,6 +16,11 @@ interface ClimbProps {
 }
 
 function Climbs ({ climb }: ClimbProps): JSX.Element {
+  const router = useRouter()
+
+  if (router.isFallback) {
+    return <div>Loading...</div>
+  }
   const { name, fa, yds, type, content, safety, id, ancestors, pathTokens } = climb
   return (
     <Layout contentContainerClass='content-default with-standard-y-margin'>
@@ -78,13 +84,14 @@ export async function getStaticPaths (): Promise<any> {
 
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const query = gql`query ClimbByUUID($id: ID) {
     climb(id: $id) {
+      id
       name
       fa
       yds

--- a/src/pages/crag/[id].tsx
+++ b/src/pages/crag/[id].tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { GetStaticProps } from 'next'
 import { gql } from '@apollo/client'
+import { useRouter } from 'next/router'
 import { graphqlClient } from '../../js/graphql/Client'
 import Link from 'next/link'
 import Layout from '../../components/layout'
@@ -25,6 +26,10 @@ interface CragSortType {
 }
 
 const Crag = ({ area }: CragProps): JSX.Element => {
+  const router = useRouter()
+  if (router.isFallback) {
+    return <div>Loading...</div>
+  }
   const { area_name: areaName, climbs, metadata, content, ancestors, pathTokens } = area
 
   const [selectedClimbSort, setSelectedClimbSort] = useState(0)
@@ -151,7 +156,7 @@ export async function getStaticPaths (): Promise<any> {
 
   return {
     paths: [],
-    fallback: 'blocking'
+    fallback: true
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/OpenBeta/open-tacos/issues/263

- [x] Defined a key to help Apollo client organize the cache
- [x]  Switch Next.js page generation to "fallback=true" mode to improve page load time

More info on the feature:

https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#when-is-fallback-true-useful
https://dev.to/tomdohnal/blocking-fallback-for-getstaticpaths-new-next-js-10-feature-1727