### PR TITLE
replace randomly generated 'climbs for you' value with actual total

### DIFF
--- a/src/components/finder/CragRow.tsx
+++ b/src/components/finder/CragRow.tsx
@@ -5,9 +5,11 @@ import { AreaType } from '../../js/types'
 import DTable from '../ui/DTable'
 import { MiniCrumbs } from '../ui/BreadCrumbs'
 import useResponsive from '../../js/hooks/useResponsive'
+import { cragFiltersStore } from '../../js/stores'
 
 /* eslint-disable-next-line */
-const CragRow = ({ id, area_name: _name, totalClimbs, metadata, aggregate, pathTokens}: Partial<AreaType>): JSX.Element => {
+const CragRow = ({ id, area_name: _name, totalClimbs, metadata, aggregate, pathTokens }: Partial<AreaType>): JSX.Element => {
+  const getClimbsForYou = cragFiltersStore.get.inMyRangeCount(aggregate)
   const name = sanitizeName(_name)
   const { isMobile } = useResponsive()
 
@@ -29,7 +31,7 @@ const CragRow = ({ id, area_name: _name, totalClimbs, metadata, aggregate, pathT
           <hr className='w-8 my-2' />
           <div className='text-secondary text-sm'>Climbs for you</div>
           <div className='flex justify-between items-center'>
-            {!isMobile && <div className='md:block w-24 h-24'><CounterPie total={totalClimbs} forYou={totalClimbs - getRandomInt(totalClimbs)} /></div>}
+            {!isMobile && <div className='md:block w-24 h-24'><CounterPie total={totalClimbs} forYou={getClimbsForYou} /></div>}
             <div>
               <DTable byDisciplineAgg={aggregate.byDiscipline} />
             </div>
@@ -38,10 +40,6 @@ const CragRow = ({ id, area_name: _name, totalClimbs, metadata, aggregate, pathT
       </a>
     </Link>
   )
-}
-
-function getRandomInt (max: number): number {
-  return Math.floor(Math.random() * max)
 }
 
 export default CragRow


### PR DESCRIPTION
addressing #274. there are other issues that are visible in the following screenshots, but i created separate issues (see #276 and #275) to address. 

previously, there was a randomly generated number populating the 'climbs for you' section of each crag row. I replaced it with an actual total that is calculated from the difficulty bands.

![image](https://user-images.githubusercontent.com/24685932/164293433-9d807b99-eb27-4537-8a2b-b7f602a0f587.png)
![image](https://user-images.githubusercontent.com/24685932/164293712-b75d133b-cc57-4f50-bbba-4866681981f1.png)
