### PR TITLE
Introduce mobile label for really small screens

### DIFF
--- a/src/components/finder/filters/BoulderRangeFilter.tsx
+++ b/src/components/finder/filters/BoulderRangeFilter.tsx
@@ -23,6 +23,7 @@ const BoulderRangeFilter = ({ isMobile = true }: BoulderRangeFilterProps): JSX.E
   const displayRange = cragFiltersStore.get.displayBoulderRange()
   return (
     <FilterPopover
+      mobileLabel='V Grade'
       label={`${displayRange[0]} - ${displayRange[1]}`}
       shortHeader='Grade range'
       header='Select a grade range'

--- a/src/components/finder/filters/DisciplineFilter.tsx
+++ b/src/components/finder/filters/DisciplineFilter.tsx
@@ -23,7 +23,8 @@ export default function DisciplineFilter ({ isMobile = true }: DisciplineProps):
 
   return (
     <FilterPopover
-      label='Disciplines'
+      mobileLabel='Types'
+      label='Types'
       shortHeader='Disciplines'
       header='Filter by climbing disciplines'
       onApply={applyFn}

--- a/src/components/finder/filters/RadiusFilter.tsx
+++ b/src/components/finder/filters/RadiusFilter.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-
+import { AdjustmentsIcon } from '@heroicons/react/outline'
 import { actions, cragFiltersStore } from '../../../js/stores'
 import { RadiusRangeSlider, radiusRangeToString, prettifyLabel } from '../../ui/RadiusRangeSlider'
 import FilterPopover, { MinMax } from '../../ui/FilterPopover'
@@ -21,6 +21,7 @@ const RadiusFilter = ({ isMobile = true }: RadiusFilterProps): JSX.Element => {
   const { min, max } = radiusRangeToString(range)
   return (
     <FilterPopover
+      mobileLabel={<AdjustmentsIcon className='w-4 h-4' />}
       label={prettifyLabel(initial)}
       shortHeader='Search radius'
       header='Select a search radius'

--- a/src/components/finder/filters/YDSFilter.tsx
+++ b/src/components/finder/filters/YDSFilter.tsx
@@ -22,6 +22,7 @@ const YDSFilter = ({ isMobile = true }: YDSFilterProps): JSX.Element => {
   const displayRange = cragFiltersStore.get.displayFreeRange()
   return (
     <FilterPopover
+      mobileLabel='YDS'
       label={`${displayRange[0]} - ${displayRange[1]}`}
       shortHeader='Grade range'
       header='Select a grade range'

--- a/src/components/ui/FilterPopover.tsx
+++ b/src/components/ui/FilterPopover.tsx
@@ -8,16 +8,17 @@ interface FilterPopoverProps {
   onApply?: Function
   minMax?: JSX.Element
   isMobile?: boolean
+  mobileLabel?: JSX.Element | string
 }
 /**
  * Base popover component for crag finder filter bar
  * @param FilterPopoverProps
  * @returns
  */
-export default function FilterPopover ({ label, header, shortHeader, children, onApply, minMax, isMobile = true }: FilterPopoverProps): JSX.Element {
+export default function FilterPopover ({ label, mobileLabel, header, shortHeader, children, onApply, minMax, isMobile = true }: FilterPopoverProps): JSX.Element {
   if (isMobile) {
     return (
-      <MobileFilterPopover btnLabel={label} title={shortHeader} onApply={onApply}>
+      <MobileFilterPopover mobileLabel={mobileLabel} btnLabel={label} title={shortHeader} onApply={onApply}>
         <MobileFilterPopover.ContentPanel>
           {minMax}
           {children}

--- a/src/components/ui/MobileFilterPopover.tsx
+++ b/src/components/ui/MobileFilterPopover.tsx
@@ -4,7 +4,7 @@ import MobilePage from './MobilePage'
 /**
  * Mobile popover component for grades, radius, disciplines selector
  */
-export default function MobileFilterPopover ({ btnLabel, title, onApply, children }): JSX.Element {
+export default function MobileFilterPopover ({ mobileLabel, btnLabel, title, onApply, children }): JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
   const onCloseHandler = (): void => {
     setIsOpen(false)
@@ -18,7 +18,10 @@ export default function MobileFilterPopover ({ btnLabel, title, onApply, childre
         className='border rounded-lg border-neutral-300 px-4 py-1.5 text-xs lg:text-sm whitespace-nowrap'
         onClick={() => setIsOpen(true)}
       >
-        {btnLabel}
+        <span className='sm:hidden'>
+          {mobileLabel}
+        </span>
+        <span className='hidden sm:inline'>{btnLabel}</span>
       </button>
       <MobilePage
         isOpen={isOpen}

--- a/src/components/ui/__tests__/FilterPopoverTest.tsx
+++ b/src/components/ui/__tests__/FilterPopoverTest.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { fireEvent, render, screen } from '@testing-library/react'
+import FilterPopover from '../FilterPopover'
+
+beforeEach(() => {
+  // IntersectionObserver isn't available in test environment
+  const mockIntersectionObserver = jest.fn()
+  mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    unobserve: () => null,
+    disconnect: () => null
+  })
+  window.IntersectionObserver = mockIntersectionObserver
+})
+
+test('FilterPopever on mobile responds to clicks', () => {
+  const onApplyFn = jest.fn()
+  render(
+    <FilterPopover
+      label='btn label'
+      mobileLabel='mobile label'
+      header='header1'
+      shortHeader='mobile short header'
+      onApply={onApplyFn}
+      isMobile
+    >
+      <div role='content'>my content</div>
+    </FilterPopover>)
+
+  expect(screen.queryByRole('content')).toBeNull()
+
+  fireEvent.click(screen.getByText(/btn label/i))
+
+  expect(screen.queryByRole('content')).toHaveTextContent('my content')
+  expect(screen.queryByRole('button', { name: /Apply/i })).toBeNull() // Apply button only exists on desktop
+
+  // click back button (aka Home)
+  fireEvent.click(screen.getByRole('button', { name: /Home/i }))
+
+  expect(onApplyFn).toBeCalledTimes(1)
+
+  expect(screen.queryByRole('content')).toBeNull()
+})
+
+test('FilterPopever on desktop responds to clicks', () => {
+  const onApplyFn = jest.fn()
+  render(
+    <FilterPopover
+      label='btn label'
+      mobileLabel='mobile label'
+      header='header1'
+      shortHeader='mobile short header'
+      onApply={onApplyFn}
+      isMobile={false}
+    >
+      <div role='content'>my content</div>
+    </FilterPopover>)
+
+  expect(screen.queryByRole('content')).toBeNull()
+
+  fireEvent.click(screen.getByText(/btn label/i))
+
+  expect(screen.queryByRole('content')).toHaveTextContent('my content')
+  expect(screen.queryByRole('button', { name: /Home/i })).toBeNull() // Home button only exists on mobile
+
+  fireEvent.click(screen.getByRole('button', { name: /Apply/i }))
+
+  expect(onApplyFn).toBeCalledTimes(1)
+
+  expect(screen.queryByRole('content')).toBeNull()
+})

--- a/src/components/ui/__tests__/MobilePage.tsx
+++ b/src/components/ui/__tests__/MobilePage.tsx
@@ -20,6 +20,7 @@ test('MobileFilterPopover', () => {
 
   render(
     <MobileFilterPopover
+      mobileLabel='mobile label'
       btnLabel='click me'
       title='my title 1'
       onApply={handleClick}
@@ -37,5 +38,3 @@ test('MobileFilterPopover', () => {
   fireEvent.click(screen.getByText(/Home/i))
   expect(handleClick).toBeCalledTimes(1)
 })
-
-// fireEvent.click(screen.getByText(/click me/i))


### PR DESCRIPTION
Fixing https://github.com/OpenBeta/open-tacos/issues/270

- [x] Introduce alternate `mobileLabel` prop for screens smaller than Tailwind `sm` breakpoint.
- [x] New mobile labels: YDS, V Grade,  Type

### screenshot 

less than < sm

<img width="427" alt="Screen Shot 2022-04-21 at 1 47 59 PM" src="https://user-images.githubusercontent.com/3805254/164455421-8e4a4f9e-2a1c-4fb3-9a42-0d37a3c59654.png">

more than `sm` less than `lg`

<img width="753" alt="Screen Shot 2022-04-21 at 2 13 48 PM" src="https://user-images.githubusercontent.com/3805254/164455853-aa598439-4c16-42fb-927f-b878287fb162.png">
