### PR TITLE
Make mobile search more usable

### DIFF
--- a/src/components/search/Autocomplete.tsx
+++ b/src/components/search/Autocomplete.tsx
@@ -26,7 +26,7 @@ export const Autocomplete = (props): JSX.Element => {
       defaultActiveItemId: 0,
       container: containerRef.current,
       renderer: { createElement, Fragment },
-      detachedMediaQuery: 'none',
+      detachedMediaQuery: (props.isMobile as boolean) ? '' : 'none',
       render ({ children }, root) {
         render(children, root)
       },
@@ -38,8 +38,10 @@ export const Autocomplete = (props): JSX.Element => {
     }
   }, [props])
 
-  const isMobile: boolean = props.isMobile
+  // const isMobile: boolean = props.isMobile
   return (
-    <div className={classNames('max-w-lg z-50 mx-auto', isMobile ? 'scale-75' : '')} ref={containerRef} />
+    <div className={classNames('max-w-lg z-50 mx-auto')} ref={containerRef} />
   )
 }
+
+//  isMobile ? 'scale-75' : ''

--- a/src/components/search/ClimbSearch.tsx
+++ b/src/components/search/ClimbSearch.tsx
@@ -64,7 +64,7 @@ const ClimbSearch = ({ expanded, onClick, onClickOutside }: ClimbSearchProps): J
 
 export const FakeSearchBox = ({ placeholder = 'Start your search', onClick, expanded = false }: {placeholder?: string, onClick: any, expanded: boolean}): JSX.Element => {
   return (
-    <div onClick={onClick} className='pointer-events-auto cursor-pointer border border-gray-200 shadow-lg shadow-inner rounded-full flex flex-row justify-between items-center gap-x-4 py-1 bg-white'>
+    <div onClick={onClick} className='pointer-events-auto cursor-pointer border border-gray-200 shadow-lg shadow-inner rounded-lg flex flex-row justify-between items-center gap-x-4 py-1 bg-white'>
       <div className='pl-4 pr-8 text-sm'>{placeholder}</div>
       <div className='rounded-full bg-custom-primary p-2 mr-1'>
         <SearchIcon className='stroke-white' />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -265,16 +265,34 @@ input:checked + label {
 */
 
 .aa-Autocomplete {
-  @apply z-50 w-full !important;
+  @apply z-50 max-h-7 lg:max-h-full w-full border border-black rounded-lg overflow-hidden !important;
 }
 
 .aa-Form {
-  @apply ring-0 rounded-full bg-white !important;
+  @apply ring-0 bg-white border-black overflow-hidden  !important;
 }
 
 .aa-SubmitButton {
-  @apply rounded-full bg-custom-primary !important;
+  @apply bg-custom-primary !important;
 }
+.aa-DetachedSearchButton {
+  @apply max-h-7 lg:max-h-full text-sm rounded-lg bg-neutral-100 border-0 !important;
+}
+
+.aa-DetachedSearchButtonIcon {
+  @apply bg-neutral-100 !important;
+}
+
+.aa-DetachedSearchButtonIcon .aa-SubmitIcon {
+  @apply h-4 w-4 text-ob-primary -ml-4 -mt-0.5 !important;
+}
+
+.aa-DetachedSearchButtonPlaceholder {
+  @apply text-xs;
+}
+
+
+
 .aa-SubmitIcon {
   @apply text-white !important;
 }


### PR DESCRIPTION
- [x] Fix https://github.com/OpenBeta/open-tacos/issues/264
- [x] Change widget to less rounded to make mobile and desktop consistent

see also Autocomplete.detachMediaQuery mode: https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-js/autocomplete/#param-detachedmediaquery
### Mobile

<img width="653" alt="Screen Shot 2022-04-22 at 5 03 32 PM" src="https://user-images.githubusercontent.com/3805254/164741659-78d1a727-018a-4bdb-82e9-76bfe0750543.png">

---

user clicking on search bar -> search bar on full screen modal

<img width="324" alt="Screen Shot 2022-04-22 at 5 03 59 PM" src="https://user-images.githubusercontent.com/3805254/164741888-35ffb24f-1791-4ac9-a5f4-a3f5a173a994.png">

