### PR TITLE
Bring back heatmap layer to give users more context

### DIFF
--- a/src/components/finder/CragHighlightPopover.tsx
+++ b/src/components/finder/CragHighlightPopover.tsx
@@ -9,7 +9,7 @@ import DTable from '../ui/DTable'
 import { actions } from '../../js/stores'
 
 function CragHighlightPopover (props: AreaType | undefined): JSX.Element {
-  if (props === undefined) return null
+  if (props == null) return null
   const { areaName, aggregate, metadata } = props
   const name = sanitizeName(areaName)
   const { areaId } = metadata

--- a/src/components/finder/Download.tsx
+++ b/src/components/finder/Download.tsx
@@ -14,6 +14,6 @@ export default function DownloadLink (): JSX.Element {
 }
 
 const saveFile = (): void => {
-  const blob = new Blob([JSON.stringify(store.filters.geojsonify())], { type: 'text/plain;charset=utf-8' })
+  const blob = new Blob([JSON.stringify(store.filters.allGeoJson())], { type: 'text/plain;charset=utf-8' })
   saveAs(blob, 'climbing-data.geojson')
 }

--- a/src/components/maps/BaseMap.tsx
+++ b/src/components/maps/BaseMap.tsx
@@ -53,7 +53,9 @@ export default function BaseMap ({
       mapboxAccessToken='pk.eyJ1IjoibWFwcGFuZGFzIiwiYSI6ImNqcDdzbW12aTBvOHAzcW82MGg0ZTRrd3MifQ.MYiNJHklgMkRzapAKuTQNg'
       onMouseMove={onHover}
       onClick={onClick}
-      interactiveLayerIds={InteractiveLayerIDs} // Important! onClick/hover won't work properly without layer id
+      // Important! if you want MapGL to pass custom layer data to onClick/onHover,
+      // you need to provide the layer id to MapGL via interactiveLayerIds
+      interactiveLayerIds={InteractiveLayerIDs}
       onMove={onViewStateChange}
       interactive
     >

--- a/src/components/maps/BaseMap.tsx
+++ b/src/components/maps/BaseMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Map, MapLayerMouseEvent, ViewStateChangeEvent, ViewState } from 'react-map-gl'
-import { LayerId } from './MarkerLayer'
+import { InteractiveLayerIDs } from './MarkerLayer'
 
 export const DEFAULT_INITIAL_VIEWSTATE = {
   width: 300,
@@ -53,7 +53,7 @@ export default function BaseMap ({
       mapboxAccessToken='pk.eyJ1IjoibWFwcGFuZGFzIiwiYSI6ImNqcDdzbW12aTBvOHAzcW82MGg0ZTRrd3MifQ.MYiNJHklgMkRzapAKuTQNg'
       onMouseMove={onHover}
       onClick={onClick}
-      interactiveLayerIds={[LayerId]} // Important! onClick/hover won't work properly without layer id
+      interactiveLayerIds={InteractiveLayerIDs} // Important! onClick/hover won't work properly without layer id
       onMove={onViewStateChange}
       interactive
     >

--- a/src/components/maps/CragsMap.tsx
+++ b/src/components/maps/CragsMap.tsx
@@ -4,6 +4,7 @@ import BaseMap from './BaseMap'
 import CragHighlightPopover from '../finder/CragHighlightPopover'
 import { store, actions } from '../../js/stores'
 import MarkerLayer from './MarkerLayer'
+import HeatmapLayer from './HeatmapLayer'
 import InteractiveMarker
   from './InteractiveMarker'
 import useAutoSizing from '../../js/hooks/finder/useMapAutoSizing'
@@ -62,6 +63,7 @@ export default function CragsMap (): JSX.Element {
           onClick={onClickHandler}
           onHover={onHoverHandler}
         >
+          <HeatmapLayer />
           <MarkerLayer geojson={geojson} />
           <InteractiveMarker
             lnglat={hoverMarker}

--- a/src/components/maps/CragsMap.tsx
+++ b/src/components/maps/CragsMap.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useState, useCallback } from 'react'
 
 import BaseMap from './BaseMap'
 import CragHighlightPopover from '../finder/CragHighlightPopover'
@@ -13,11 +13,7 @@ import useAutoSizing from '../../js/hooks/finder/useMapAutoSizing'
  * Make a map of crag markers.
  */
 export default function CragsMap (): JSX.Element {
-  const crags = store.filters.crags()
-
-  const geojson = useMemo(
-    () => store.filters.geojsonify()
-    , [crags])
+  const geojson = store.filters.allGeoJson()
 
   const [viewstate, height, setViewState] = useAutoSizing({ geojson })
 
@@ -63,7 +59,7 @@ export default function CragsMap (): JSX.Element {
           onClick={onClickHandler}
           onHover={onHoverHandler}
         >
-          <HeatmapLayer />
+          <HeatmapLayer geojson={geojson} />
           <MarkerLayer geojson={geojson} />
           <InteractiveMarker
             lnglat={hoverMarker}

--- a/src/components/maps/HeatmapLayer.tsx
+++ b/src/components/maps/HeatmapLayer.tsx
@@ -1,14 +1,13 @@
 import { Source, Layer, LayerProps } from 'react-map-gl'
-
-import { cragFiltersStore } from '../../js/stores'
+import { Properties, FeatureCollection } from '@turf/helpers'
 
 export const LayerId = 'heatmap'
 
 const layerStyle: LayerProps = {
-  id: 'earthquakes-heat',
+  id: 'all-areas-heat',
   type: 'heatmap',
-  source: 'earthquakes',
-  maxzoom: 14,
+  source: 'all-areas',
+  maxzoom: 15,
   paint: {
     // Increase the heatmap weight based on frequency and property magnitude
     'heatmap-weight': [
@@ -66,19 +65,21 @@ const layerStyle: LayerProps = {
       'interpolate',
       ['linear'],
       ['zoom'],
-      12,
-      0.35,
+      8,
+      0.45,
       16,
       1
     ]
   }
 }
 
+interface MarkerLayerProps {
+  geojson: FeatureCollection<GeoJSON.Geometry, Properties>
+}
 /**
  * Build a heatmap layer using native Mapbox GL style.
  */
-export default function HeatmapLayer (): JSX.Element {
-  const geojson = cragFiltersStore.get.geojsonify(false)
+export default function HeatmapLayer ({ geojson }: MarkerLayerProps): JSX.Element {
   return (
     <Source
       id='heatmap'

--- a/src/components/maps/HeatmapLayer.tsx
+++ b/src/components/maps/HeatmapLayer.tsx
@@ -1,0 +1,91 @@
+import { Source, Layer, LayerProps } from 'react-map-gl'
+
+import { cragFiltersStore } from '../../js/stores'
+
+export const LayerId = 'heatmap'
+
+const layerStyle: LayerProps = {
+  id: 'earthquakes-heat',
+  type: 'heatmap',
+  source: 'earthquakes',
+  maxzoom: 14,
+  paint: {
+    // Increase the heatmap weight based on frequency and property magnitude
+    'heatmap-weight': [
+      'interpolate',
+      ['linear'],
+      ['get', 'totalClimbs'],
+      0,
+      0,
+      40,
+      1
+    ],
+    // Increase the heatmap color weight weight by zoom level
+    // heatmap-intensity is a multiplier on top of heatmap-weight
+    'heatmap-intensity': [
+      'interpolate',
+      ['linear'],
+      ['zoom'],
+      0,
+      1,
+      9,
+      3
+    ],
+    // Color ramp for heatmap.  Domain is 0 (low) to 1 (high).
+    // Begin color ramp at 0-stop with a 0-transparancy color
+    // to create a blur-like effect.
+    'heatmap-color': [
+      'interpolate',
+      ['linear'],
+      ['heatmap-density'],
+      0,
+      'rgba(198, 219, 239,0)',
+      0.2,
+      '#9ecae1',
+      0.4,
+      '#6baed6',
+      0.6,
+      '#4292c6',
+      0.8,
+      '#2171b5',
+      1,
+      '#084594'
+    ],
+    // Adjust the heatmap radius by zoom level
+    'heatmap-radius': [
+      'interpolate',
+      ['linear'],
+      ['zoom'],
+      0,
+      2,
+      9,
+      20
+    ],
+    // Transition from heatmap to circle layer by zoom level
+    'heatmap-opacity': [
+      'interpolate',
+      ['linear'],
+      ['zoom'],
+      12,
+      0.35,
+      16,
+      1
+    ]
+  }
+}
+
+/**
+ * Build a heatmap layer using native Mapbox GL style.
+ */
+export default function HeatmapLayer (): JSX.Element {
+  const geojson = cragFiltersStore.get.geojsonify(false)
+  return (
+    <Source
+      id='heatmap'
+      type='geojson'
+      data={geojson}
+    >
+      <Layer id='heatmap' {...layerStyle} />
+    </Source>
+  )
+}

--- a/src/components/maps/MarkerLayer.tsx
+++ b/src/components/maps/MarkerLayer.tsx
@@ -1,12 +1,11 @@
 import { Properties, FeatureCollection } from '@turf/helpers'
 import { Source, Layer, LayerProps } from 'react-map-gl'
 
-export const LayerId = 'area-labels'
-
 const layerStyle: LayerProps = {
-  id: LayerId,
+  id: 'my-areas',
   type: 'symbol',
   source: 'areas',
+  filter: ['==', 'isInMyRange', true],
   layout: {
     'icon-size': ['interpolate', ['linear'], ['zoom'], 8, 1.25, 12, 1],
     'symbol-spacing': 5,
@@ -14,15 +13,47 @@ const layerStyle: LayerProps = {
     'text-variable-anchor': ['bottom', 'left', 'right'],
     'text-radial-offset': 1,
     'text-justify': 'auto',
-    'icon-image': 'circle',
-    'text-size': ['interpolate', ['linear'], ['zoom'], 8, 14, 14, 12],
-    'icon-allow-overlap': true
+    'icon-image': [
+      'case',
+      ['boolean', ['get', 'isInMyRange'], false],
+      'circle',
+      'dot-11'
+    ],
+    'text-size': ['interpolate', ['linear'], ['zoom'], 8, 12, 14, 14],
+    'icon-allow-overlap': false
   },
   paint: {
     'text-halo-blur': 4,
-    'text-halo-width': 2,
+    'text-halo-width': 1,
     'text-color': '#ffffff',
+    'text-halo-color': '#262626'
+  }
+}
+
+const closeupLayerStyle: LayerProps = {
+  id: 'all-markers',
+  type: 'symbol',
+  source: 'areas',
+  minzoom: 14,
+  filter: ['==', 'isInMyRange', false],
+  layout: {
+    'icon-size': ['interpolate', ['linear'], ['zoom'], 8, 0.75, 12, 1],
+    'symbol-spacing': 10,
+    'text-field': ['get', 'name'],
+    'text-variable-anchor': ['bottom', 'left', 'right'],
+    'text-radial-offset': 1,
+    'text-justify': 'auto',
+    'icon-image': 'dot-11',
+    'text-size': ['interpolate', ['linear'], ['zoom'], 8, 12, 14, 10],
+    'icon-allow-overlap': false
+  },
+  paint: {
+    'icon-color': '#ffffff',
+    'text-halo-blur': 4,
+    'text-halo-width': 2,
+    'text-color': '#a3a3a3',
     'text-halo-color': '#334455'
+    // 'text-opacity':
   }
 }
 
@@ -40,7 +71,10 @@ export default function MarkerLayer ({ geojson }: MarkerLayerProps): JSX.Element
       type='geojson'
       data={geojson}
     >
+      <Layer id='closeup-markers' {...closeupLayerStyle} />
       <Layer id='crag-markers' {...layerStyle} />
     </Source>
   )
 }
+
+export const InteractiveLayerIDs = [layerStyle.id, closeupLayerStyle.id]

--- a/src/components/maps/MarkerLayer.tsx
+++ b/src/components/maps/MarkerLayer.tsx
@@ -16,8 +16,8 @@ const layerStyle: LayerProps = {
     'icon-image': [
       'case',
       ['boolean', ['get', 'isInMyRange'], false],
-      'circle',
-      'dot-11'
+      'circle', // more important - larger marker
+      'dot-11' // small marker
     ],
     'text-size': ['interpolate', ['linear'], ['zoom'], 8, 12, 14, 14],
     'icon-allow-overlap': false
@@ -53,7 +53,6 @@ const closeupLayerStyle: LayerProps = {
     'text-halo-width': 2,
     'text-color': '#a3a3a3',
     'text-halo-color': '#334455'
-    // 'text-opacity':
   }
 }
 
@@ -77,4 +76,6 @@ export default function MarkerLayer ({ geojson }: MarkerLayerProps): JSX.Element
   )
 }
 
+// Important! Pass these IDs to Mapbox GL so that onClick/onHover receives
+// the active Geojson object
 export const InteractiveLayerIDs = [layerStyle.id, closeupLayerStyle.id]

--- a/src/js/graphql/Client.ts
+++ b/src/js/graphql/Client.ts
@@ -14,7 +14,7 @@ export const graphqlClient = new ApolloClient({
           keyFields: ['placeId', '_id']
         },
         Area: {
-          keyFields: ['id']
+          keyFields: ['uuid']
         },
         AreaMetadata: {
           keyFields: ['areaId']

--- a/src/js/graphql/api.ts
+++ b/src/js/graphql/api.ts
@@ -1,7 +1,8 @@
 import { gql } from '@apollo/client'
+
 import { AreaType } from '../types'
 import { graphqlClient } from './Client'
-
+import { CORE_CRAG_FIELDS } from './fragments'
 interface CragsDetailsNearType {
   data: Array<Partial<AreaType>>
   placeId: string
@@ -41,67 +42,38 @@ export const getCragDetailsNear = async (
   }
 }
 
-const CRAGS_NEAR = gql`query CragsNear($placeId: String, $lng: Float, $lat: Float, $minDistance: Int, $maxDistance: Int, $includeCrags: Boolean) {
+const CRAGS_NEAR = gql`
+  ${CORE_CRAG_FIELDS}
+  query CragsNear($placeId: String, $lng: Float, $lat: Float, $minDistance: Int, $maxDistance: Int, $includeCrags: Boolean) {
   cragsNear(placeId: $placeId, lnglat: {lat: $lat, lng: $lng}, minDistance: $minDistance, maxDistance: $maxDistance, includeCrags: $includeCrags) {
       count
       _id 
       placeId
       crags {
-        areaName
-        id
-        totalClimbs
-        pathTokens
-        metadata {
-          lat
-          lng
-          areaId
-        }
-        aggregate {
-          byDiscipline {
-            sport {
-              total
-              bands {
-                advance
-                beginner
-                expert
-                intermediate
-              }
-            }
-            trad {
-              total
-              bands {
-                advance
-                beginner
-                expert
-                intermediate
-              }
-            }
-            boulder {
-              total
-              bands {
-                advance
-                beginner
-                expert
-                intermediate
-              }
-            }
-            tr {
-              total
-              bands {
-                advance
-                beginner
-                expert
-                intermediate
-              }
-            }
-          }
-          byGradeBand {
-            advance
-            beginner
-            expert
-            intermediate
-          }
-        }
+        ...CoreCragFields
       }
   }
 }`
+
+/**
+ * Fetch an area by uuid from the cache
+ * @param uuid
+ * @returns Area or null if not found
+ */
+export const getAreaByUUID = (uuid: string): AreaType | null => {
+  try {
+    const queryId = `Area:{"uuid":"${uuid}"}` // Very strange looking id, but this is how Apollo works
+    const query = graphqlClient.readFragment({
+      id: queryId,
+      fragment: CORE_CRAG_FIELDS
+    }
+    )
+    if (query !== null) {
+      return query
+    }
+  } catch (e) {
+    console.log(e)
+    return null
+  }
+  return null
+}

--- a/src/js/graphql/fragments.ts
+++ b/src/js/graphql/fragments.ts
@@ -1,0 +1,62 @@
+import { gql } from '@apollo/client'
+
+export const CORE_CRAG_FIELDS = gql`
+  fragment CoreCragFields on Area {
+    areaName
+    id
+    uuid
+    totalClimbs
+    pathTokens
+    metadata {
+      lat
+      lng
+      areaId
+    }
+    aggregate {
+      byDiscipline {
+        sport {
+          total
+          bands {
+            advance
+            beginner
+            expert
+            intermediate
+          }
+        }
+        trad {
+          total
+          bands {
+            advance
+            beginner
+            expert
+            intermediate
+          }
+        }
+        boulder {
+          total
+          bands {
+            advance
+            beginner
+            expert
+            intermediate
+          }
+        }
+        tr {
+          total
+          bands {
+            advance
+            beginner
+            expert
+            intermediate
+          }
+        }
+      }
+      byGradeBand {
+        advance
+        beginner
+        expert
+        intermediate
+      }
+    }
+  }
+`

--- a/src/js/stores/util.ts
+++ b/src/js/stores/util.ts
@@ -1,4 +1,7 @@
+import { point, Feature, Point } from '@turf/helpers'
+
 import { AreaType } from '../types'
+import { sanitizeName } from '../utils'
 
 interface CalculatePaginationProps {
   itemOffset: number
@@ -25,4 +28,18 @@ export const calculatePagination = (
     itemOffset,
     currentPage
   }
+}
+
+export const geojsonifyCrag = (crag, isInMyRange): Feature<Point> => {
+  const { areaName, metadata, totalClimbs } = crag
+  const { areaId } = metadata
+  const props = {
+    id: areaId,
+    name: sanitizeName(areaName),
+    lng: metadata.lng,
+    lat: metadata.lat,
+    totalClimbs,
+    isInMyRange
+  }
+  return point([metadata.lng, metadata.lat], props, { id: areaId })
 }

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -87,6 +87,7 @@ export interface AggregateType {
 }
 export interface AreaType {
   id: string
+  uuid: string
   areaName: string
   pathTokens: string[]
   metadata: AreaMetadataType

--- a/src/pages/areas/[id].tsx
+++ b/src/pages/areas/[id].tsx
@@ -114,6 +114,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const query = gql`query getAreaById($uuid: ID) {
     area(uuid: $uuid) {
       id
+      uuid
       areaName
       ancestors
       pathTokens
@@ -129,6 +130,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       } 
       children {
         id
+        uuid
         areaName
         totalClimbs
         metadata {

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -93,6 +93,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const query = gql`query ClimbByUUID($uuid: ID) {
     climb(uuid: $uuid) {
       id
+      uuid
       name
       fa
       yds

--- a/src/pages/crag/[id].tsx
+++ b/src/pages/crag/[id].tsx
@@ -164,6 +164,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const query = gql`query AreaByID($uuid: ID) {
     area(uuid: $uuid) {
       id
+      uuid
       areaName
       metadata {
         areaId

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,6 +56,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   let query = gql`query UsaAreas( $filter: Filter) {
     areas(filter: $filter, sort: { totalClimbs: -1 }) {
       id
+      uuid
       areaName
       pathTokens
       totalClimbs


### PR DESCRIPTION
(Re)introduce the heatmap layer to give users more context of what there is in the area regardless of user's filters.  The heatmap layer can also be used for other pages.

<img width="319" alt="Screen Shot 2022-04-23 at 3 03 16 PM" src="https://user-images.githubusercontent.com/3805254/164896033-b0c11e4d-6ac9-4bf3-b08f-92a58503f387.png">

---

### close up view (zoomed in)
- turn off heatmap
- show areas not in user preferences in smaller font and marker

<img width="322" alt="Screen Shot 2022-04-23 at 3 05 35 PM" src="https://user-images.githubusercontent.com/3805254/164896034-4461ef06-03c4-471b-88e6-a5bc29ead070.png">
