### PR TITLE
add lighthouse run on pull request

### DIFF
--- a/.github/workflows/lighthouse-on-pr.yml
+++ b/.github/workflows/lighthouse-on-pr.yml
@@ -1,0 +1,22 @@
+name: CI
+on: [pull_request]
+jobs:
+  lhci:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - uses: bahmutov/npm-install@v1
+      - name: npm install
+        run: npm install -g @lhci/cli@0.8.x
+      - name: npm build
+        run: npm run build
+      - name: run Lighthouse CI
+        run: lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ content
 .env.local
 *.pem
 .vscode/launch.json
+
+.lighthouseci

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,17 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3,
+      "//": "^ default is 3",
+      "startServerCommand": "npx next start",
+      "url": [
+        "http://localhost:3000",
+	"http://localhost:3000/areas/bea6bf11-de53-5046-a5b4-b89217b7e9bc"
+      ]
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}
+


### PR DESCRIPTION
Hi @vnugent , 
I ran a lighthouse score on the project home page and got a score of 50 for performance.

When looking at how to run the production server for this project
`npm run build`
`npx next start`

https://nextjs.org/docs/deployment
^ I noticed that document mentioned look at the lighthouse score to ensure prod configs are set up correctly.

This pr will currently give reports in the build output that you can open to see the report for the two different urls.
https://github.com/MichaelDimmitt/open-tacos/runs/6141317120?check_suite_focus=true
<img width="1023" alt="Screen Shot 2022-04-23 at 1 09 58 PM" src="https://user-images.githubusercontent.com/11463275/164916436-5d2faf0e-a0dc-4ba8-af87-ef4c8cf49221.png">


My repo has a pr that is linked to a github application, as you see when the build finishes and the app is in place it will give the scores in the pr itself.

https://github.com/MichaelDimmitt/open-tacos/pull/1

<img width="979" alt="Screen Shot 2022-04-23 at 1 03 17 PM" src="https://user-images.githubusercontent.com/11463275/164916192-fb4402c4-af0e-4cbe-9154-61e1559e3fdb.png">

to configure this app you need to authorize this:
https://github.com/apps/lighthouse-ci

save the secret.
go to
 organization home -> settings -> secrets -> actions -> new organization secret.
 give it a name of LHCI_GITHUB_APP_TOKEN and token for value.
 
 and future prs will have the github app working.