### PR TITLE
[issue 246] Upgraded headlessui lib to v1.6.0 and Corrected Button Props

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@deck.gl/core": "^8.7.0 ",
     "@deck.gl/layers": "^8.7.0",
     "@deck.gl/react": "^8.7.0",
-    "@headlessui/react": "^1.5.0",
+    "@headlessui/react": "^1.6.0",
     "@heroicons/react": "^1.0.6",
     "@math.gl/web-mercator": "^3.5.6",
     "@mdx-js/loader": "^1.6.22",

--- a/src/components/ui/LeanPopver.tsx
+++ b/src/components/ui/LeanPopver.tsx
@@ -30,11 +30,12 @@ const ContentPanel = ({ className, onApply, btnApplyLabel = 'Apply', children })
         <Popover.Button className='text-secondary hover:underline'>
           Cancel
         </Popover.Button>
-        <div onClick={onApply}>
-          <Popover.Button className='text-primary-contrast bg-slate-800 rounded-md px-2 py-0.5'>
-            {btnApplyLabel}
-          </Popover.Button>
-        </div>
+        <Popover.Button
+          className='text-primary-contrast bg-slate-800 rounded-md px-2 py-0.5'
+          onClick={onApply}
+        >
+          {btnApplyLabel}
+        </Popover.Button>
       </footer>
     </div>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,10 +940,10 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
-"@headlessui/react@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
-  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
+"@headlessui/react@^1.6.0":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.6.1.tgz#d822792e589aac005462491dd62f86095e0c3bef"
+  integrity sha512-gMd6uIs1U4Oz718Z5gFoV0o/vD43/4zvbyiJN9Dt7PK9Ubxn+TmJwTmYwyNJc5KxxU1t0CmgTNgwZX9+4NjCnQ==
 
 "@heroicons/react@^1.0.6":
   version "1.0.6"


### PR DESCRIPTION
Issue: https://github.com/OpenBeta/open-tacos/issues/246

Found that the `headlessui` feature required in the `open-tacos` issue (PR [#1265](https://github.com/tailwindlabs/headlessui/pull/1265)) was released in `headlessui` [v1.6.0](https://github.com/tailwindlabs/headlessui/releases/tag/%40headlessui%2Freact%40v1.6.0), so I upgraded the lib to that version.

Updated the `LeanPopover` file to place the `onClick` handler directly on the button.