### PR TITLE
fixed NextJS compilation warning re stylesheet

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -16,10 +16,7 @@ function Layout ({ contentContainerClass = 'content-fullscreen-tablet', rootCont
         <title>Climbing Route Catalog</title>
         <meta name='description' content='Open license climbing route catalog' />
         <link rel='icon' href='/favicon.ico' />
-        <link
-          href='/fonts/fonts.css'
-          rel='stylesheet'
-        />
+
         <SeoTags
           keywords={['openbeta', 'rock climbing', 'climbing api']}
           description='Climbing route catalog'


### PR DESCRIPTION
no ref needed in layout component. _app.tsx already provides it as its parent

Notable is [This doc](https://nextjs.org/docs/basic-features/built-in-css-support#adding-a-global-stylesheet) which say imports at this level are global