### PR TITLE
Make e2e tests optional

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ jobs:
         run: yarn lint
 
       - name: Run unit tests
-        run: yarn test
+        run: yarn test-all
         env:
           SIRV_CLIENT_SECRET_RO: ${{ secrets.SIRV_CLIENT_SECRET_RO }}
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "local": "NEXT_PUBLIC_API_SERVER=http://localhost:4000 node ./src/server.js ",
     "develop": "next dev",
     "start": "next start",
-    "test": "jest",
+    "test": "jest --testPathIgnorePatterns=/tests/e2e/",
+    "test-all": "jest",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/src/tests/e2e/__tests__/SirvClient.ts
+++ b/src/tests/e2e/__tests__/SirvClient.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/extend-expect'
-import { getToken, getUserImages, SIRV_CONFIG } from '../SirvClient'
+import { getToken, getUserImages, SIRV_CONFIG } from '../../../js/sirv/SirvClient'
 
 beforeAll(() => {
   expect(SIRV_CONFIG.clientSecret).not.toBeNull()
@@ -7,7 +7,7 @@ beforeAll(() => {
   expect(SIRV_CONFIG.clientId).not.toBeNull()
 })
 
-test('Sirv client', async () => {
+test('Sirv API can read photos', async () => {
   const token = await getToken()
   const list = await getUserImages('abe96612-2742-43b0-a128-6b19d4e4615f', token)
   expect(list.mediaList.length).toBeGreaterThan(0)


### PR DESCRIPTION
Our pre-commit hook requires `yarn test` to pass.  In order to not expose SIRV API key unnecessarily, we will now skip e2e tests in local dev mode, unless you know the key and put it in '.env.test.local' (key is given offline  to active contributors)

- `yarn test`  will skip '/tests/e2e' dir
- `yarn test-all`will run all tests (we run this curing CI build)

No actions are required.