### PR TITLE
Use climb name, disciplines, area name for climb search for tagging

### DIFF
--- a/src/js/typesense/TypesenseClient.ts
+++ b/src/js/typesense/TypesenseClient.ts
@@ -31,8 +31,8 @@ export const typesenseSearch = async (query: string): Promise<any> => {
 export const climbSearchByName = async (query: string): Promise<any> => {
   const rs = await typesenseClient.collections('climbs').documents().search({
     q: query,
-    query_by: 'climbName,areaNames,climbDesc,fa',
-    exclude_fields: 'climbDesc'
+    query_by: 'climbName,disciplines,areaNames',
+    exclude_fields: 'climbDesc,fa'
   })
   return rs?.hits?.map(hit => hit.document) ?? []
 }


### PR DESCRIPTION
The search box for tagging is now optimized for the following format:

<climb name> <discipline> <area>

<img width="344" alt="Screen Shot 2022-06-07 at 3 14 23 PM" src="https://user-images.githubusercontent.com/3805254/172389062-6334433a-c674-4d21-a421-a567e1bbfa7c.png">
