### PR TITLE
Bugfix - move photo montage grid out of flexbox

### DIFF
--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -56,8 +56,10 @@ const Body = ({ climb, mediaListWithUsernames }: ClimbPageProps): JSX.Element =>
           isClimbPage
         />
 
-        <div className='md:flex py-6 mt-32'>
+        <div className='py-6 mt-32'>
           <PhotoMontage photoList={mediaListWithUsernames} />
+        </div>
+        <div className='md:flex'>
           <div
             id='Title Information'
             style={{ minWidth: '300px' }}


### PR DESCRIPTION
Fixes #358.

Not sure how the desktop page looked before, but flexbox doesn't seem to play nicely with a grid here. Moving the photo montage out of the flexbox allows the image to show up on top.

![image](https://user-images.githubusercontent.com/3697804/173700019-7cf43433-9530-402b-b6f7-f63e710f1378.png)
![image](https://user-images.githubusercontent.com/3697804/173700108-5406bb8b-4b66-4958-89be-788ef5060f5e.png)
