### PR TITLE
Climb page fixes

### DIFF
--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -56,7 +56,7 @@ const Body = ({ climb, mediaListWithUsernames }: ClimbPageProps): JSX.Element =>
           isClimbPage
         />
 
-        <div className='py-6 mt-32'>
+        <div className='py-6'>
           <PhotoMontage photoList={mediaListWithUsernames} />
         </div>
         <div className='md:flex'>

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -64,7 +64,7 @@ const Body = ({ climb, mediaListWithUsernames }: ClimbPageProps): JSX.Element =>
             id='Title Information'
             style={{ minWidth: '300px' }}
           >
-            <h1 className='text-4xl md:text-5xl'>{name}</h1>
+            <h1 className='text-4xl md:text-5xl mr-10'>{name}</h1>
             <div className='pl-1'>
               <div
                 className='flex items-center space-x-2 mt-6'

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -26,7 +26,7 @@ const ClimbPage: NextPage<ClimbPageProps> = (props) => {
       {!router.isFallback && <PageMeta {...props} />}
       <Layout
         showFilterBar={false}
-        contentContainerClass='content-default with-standard-y-margin h-screen'
+        contentContainerClass='content-default with-standard-y-margin'
       >
         {router.isFallback
           ? (


### PR DESCRIPTION
Tiny changes that fix some overflow issues.

Example problem climb page: https://tacos.openbeta.io/climbs/05ff66ef-9dbc-5a6d-a712-64735cb35e46

**Before**
![image](https://user-images.githubusercontent.com/3697804/173937554-37805f11-69e2-4a31-b7b4-651daa27211d.png)
![image](https://user-images.githubusercontent.com/3697804/173937599-1e9126a7-1773-4f78-917c-51835725200a.png)

It's especially noticeable on mobile
![image](https://user-images.githubusercontent.com/3697804/173937762-23e7533a-8073-42e0-ac9c-896aa5bf9b4e.png)

**After**
![image](https://user-images.githubusercontent.com/3697804/173937979-75fa52f4-3bca-4837-9207-c642c26a4adc.png)


Not sure why the `h-screen` class was originally added in https://github.com/OpenBeta/open-tacos/pull/332. Hopefully that doesn't mess with other screens.