### PR TITLE
Make mobile menu larger and fix z-index order 

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -47,7 +47,7 @@ export default function Header (props: HeaderProps): JSX.Element {
   }
 
   return (
-    <div id={NAV_BAR_IDENTIFIER}>
+    <div id={NAV_BAR_IDENTIFIER} className='relative z-50'>
       {isTablet || isMobile
         ? <MobileTabletAppBar includeFilters={includeFilters} />
         : <DesktopAppBar

--- a/src/components/MobileAppBar.tsx
+++ b/src/components/MobileAppBar.tsx
@@ -69,9 +69,10 @@ const More = (): JSX.Element => {
 
       <Popover.Panel className='absolute z-20 right-0 mt-2 p-6 bg-white rounded-md'>
         <div className='grid'>
-          {status === 'authenticated' ? <Button onClick={async () => await signOut({ callbackUrl: `${window.origin}/api/auth/logout` })} label='Logout' /> : <Button onClick={async () => await signIn()} label='Login' />}
-          <Button href='/about' label='About' />
+          {status === 'authenticated' ? <Button size='lg' onClick={async () => await signOut({ callbackUrl: `${window.origin}/api/auth/logout` })} label='Logout' /> : <Button size='lg' onClick={async () => await signIn()} label='Login' />}
+          <Button size='lg' href='/about' label='About' />
           <Button
+            size='lg'
             href='https://discord.gg/2A2F6kUtyh'
             label='Discord'
             variant={ButtonVariant.SOLID_SECONDARY}

--- a/src/components/ui/BaseButton.tsx
+++ b/src/components/ui/BaseButton.tsx
@@ -6,7 +6,7 @@ interface BaseButtonProps {
   onClick?: any
   label: string | JSX.Element
   variant?: ButtonVariant
-  size?: 'sm'|'md'
+  size?: 'sm'|'md' | 'lg'
   href?: string
   type?: 'button' | 'reset' | 'submit'
   disabled?: boolean
@@ -30,6 +30,9 @@ export const BaseButton = React.forwardRef<HTMLInputElement, BaseButtonProps>(({
         break
       case 'md':
         sz = 'mdRounded'
+        break
+      case 'lg':
+        sz = 'lgRounded'
         break
       default:
         sz = 'mdRounded'
@@ -83,7 +86,7 @@ export const Button = ({
   }
   return (
     <BaseButton
-      onClick={onClick} label={label} variant={variant} type={type} disabled={disable} ariaLabel={ariaLabel}
+      onClick={onClick} label={label} variant={variant} type={type} disabled={disable} ariaLabel={ariaLabel} size={size}
     />
   )
 }
@@ -91,8 +94,10 @@ export const Button = ({
 const SIZE = {
   sm: 'px-2 py-0.5 text-sm',
   md: 'px-2.5 py-1 text-base',
+  lg: 'px-3 py-1.5 text-lg',
   smRounded: 'p-0.5',
-  mdRounded: 'p-1.5'
+  mdRounded: 'p-1.5',
+  lgRounded: 'p-2'
 }
 
 export enum ButtonVariant {

--- a/src/components/ui/MobileNavBar.tsx
+++ b/src/components/ui/MobileNavBar.tsx
@@ -9,7 +9,7 @@ interface MNavBarProps {
 
 export default function MobileNavBar ({ branding, home, search, profile, more }: MNavBarProps): JSX.Element {
   return (
-    <header className='xl:hidden'>
+    <header className='xl:hidden relative z-20'>
       <Bar className='max-w-screen-xl gap-x-8 px-4' backgroundClass='bg-default' borderBottom>
         <div className='hidden md:block w-12'>{branding}</div>
         <div className='md:hidden w-12'>{home}</div>


### PR DESCRIPTION
Addresses: #375

Details:
- Move mobile nav above image on /area/[id]
- Move mobile nav above the popover filter
- Add large size to BaseButton
- Increase size of mobile menu buttons
