### PR TITLE
Try to fix 'Added non-passive event listener' warnings

### DIFF
--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -59,8 +59,12 @@ const Body = ({ climb, mediaListWithUsernames, leftClimb, rightClimb }: ClimbPag
     },
     onSwipedRight: () => {
       rightClimb !== null && router.push(`/climbs/${rightClimb.id}`)
-    }
-  })
+    },
+    swipeDuration: 250,
+    // touchEventOptions: { passive: true },
+    preventScrollOnSwipe: false
+  }
+  )
   useHotkeys('left', () => {
     leftClimb !== null && router.push(`/climbs/${leftClimb.id}`)
   }, [leftClimb])

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,6 @@ import { graphqlClient } from '../js/graphql/Client'
 import { IndexResponseType } from '../js/types'
 import FeatureCard from '../components/ui/FeatureCard'
 import HomeHero from '../components/HomeHero'
-import CTAEmailSignup from '../components/CTAEmailSignup'
 import useCanary from '../js/hooks/useCanary'
 
 interface HomePageType {
@@ -35,10 +34,10 @@ const Home: NextPage<HomePageType> = ({ exploreData, stats }) => {
           </div>
         </section>
         <section>
-          <h2 className='mt-16 mb-4 text-3xl h-padding-wide'>Follow our progress</h2>
+          {/* <h2 className='mt-16 mb-4 text-3xl h-padding-wide'>Follow our progress</h2>
           <div className='horizontal-center pb-8'>
             <CTAEmailSignup />
-          </div>
+          </div> */}
         </section>
       </Layout>
     </>


### PR DESCRIPTION
- Trying to fix [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
- Remove openbeta substack signup page in iframe due to google tracking and its potential usefulness