### PR TITLE
Generate user id mapping file for new users

### DIFF
--- a/AuthProvider/postLoginAction.js
+++ b/AuthProvider/postLoginAction.js
@@ -4,7 +4,7 @@
 * @param {Event} event - Details about the user and the context in which they are logging in.
 * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
 */
-exports.onExecutePostLogin = async ({ user }, api) => {
+exports.onExecutePostLogin = async ({ user, authorization, stats }, api) => {
   const { v4: uuidv4 } = require('uuid')
   const { uniqueNamesGenerator, adjectives, colors, animals } = require('unique-names-generator')
 
@@ -12,14 +12,21 @@ exports.onExecutePostLogin = async ({ user }, api) => {
   user.user_metadata.bio = user.user_metadata?.bio ?? ''
   user.user_metadata.uuid = user.user_metadata?.uuid ?? uuidv4()
   user.user_metadata.name = user.user_metadata?.name ?? user?.nickname ?? ''
+  user.user_metadata.loginsCount = stats?.logins_count ?? 0
 
   api.user.setUserMetadata('name', user.user_metadata.name)
   api.user.setUserMetadata('bio', user.user_metadata.bio)
   api.user.setUserMetadata('uuid', user.user_metadata.uuid)
   api.user.setUserMetadata('nick', user.user_metadata.nick)
+  api.user.setUserMetadata('loginsCount', user.user_metadata.loginsCount)
 
   const ns = 'https://tacos.openbeta.io/'
   api.idToken.setCustomClaim(ns + 'user_metadata', user.user_metadata)
+
+  if (authorization != null) {
+    api.idToken.setCustomClaim(`${ns}roles`, authorization.roles)
+    api.accessToken.setCustomClaim(`${ns}roles`, authorization.roles)
+  }
 }
 
 /**

--- a/src/components/basecamp/Users.tsx
+++ b/src/components/basecamp/Users.tsx
@@ -42,16 +42,16 @@ export default function Users (): JSX.Element {
             <div className='col-span-2' />
 
             <div className='' />
-            <div className='w-full bg-pink-200'>Login</div>
+            <div className='w-full bg-pink-200'>Last Login</div>
             <div className='w-full bg-pink-200'>Counts</div>
             <div className='w-full bg-yellow-200'>Created</div>
-            {users?.map((user, index) => {
+            {users?.map((user, index: number) => {
               // eslint-disable-next-line
               const { user_metadata, last_login, created_at, logins_count, user_id } = user
               const { nick, uuid } = user_metadata as IUserMetadata ?? { nick: null, uuid: null }
               return (
                 <React.Fragment key={user_id}>
-                  <div>{index}</div>
+                  <div>{index + 1}</div>
                   <div className='col-span-2'>{user.email}</div>
                   <div className='col-span-2'>{nick == null ? 'n/a' : <LinkProfile nick={nick} />}</div>
                   <div className=''>

--- a/src/js/auth/ManagementClient.ts
+++ b/src/js/auth/ManagementClient.ts
@@ -44,7 +44,8 @@ export const reshapeAuth0UserToProfile = (user: User): IUserProfile => {
     email: user.email ?? '',
     avatar: user?.picture ?? '',
     bio: umeta?.bio ?? '',
-    roles: umeta?.roles ?? []
+    roles: umeta?.roles ?? [],
+    loginsCount: umeta?.loginsCount ?? 0
   }
 }
 

--- a/src/js/types/User.ts
+++ b/src/js/types/User.ts
@@ -1,6 +1,7 @@
 export interface IReadOnlyUserMetadata {
   uuid: string
   roles: string[]
+  loginsCount: number
 }
 
 export interface IWritableUserMetadata {

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -3,6 +3,7 @@ import Auth0Provider from 'next-auth/providers/auth0'
 
 import { AUTH_CONFIG_SERVER } from '../../../Config'
 import { IUserMetadata } from '../../../js/types/User'
+import { addUserIdFile } from '../../../js/sirv/SirvClient'
 
 const CustomClaimsNS = 'https://tacos.openbeta.io/'
 const CustomClaimUserMetadata = CustomClaimsNS + 'user_metadata'
@@ -53,6 +54,12 @@ export default NextAuth({
         token?.userMetadata?.uuid == null || token?.userMetadata?.nick == null) {
         // we must have user uuid and nickname for everything to work
         throw new Error('Missing user uuid and nickname from Auth provider')
+      }
+
+      const loginsCount = token.userMetadata?.loginsCount ?? 0
+      if (loginsCount < 2) {
+        console.log('Creating uid.json file for new user')
+        await addUserIdFile(`/u/${token.userMetadata.uuid}/uid.json`, token.userMetadata.nick)
       }
       session.user.metadata = token.userMetadata
       session.accessToken = token.accessToken

--- a/src/pages/api/user/metadataClient.ts
+++ b/src/pages/api/user/metadataClient.ts
@@ -37,13 +37,6 @@ const createMetadataClient = async (
     return null
   }
 
-  // const currentUserManagementClient = new ManagementClient<any, Auth0UserMetadata>({
-  //   domain: AUTH_CONFIG_SERVER?.issuer.replace('https://', '') ?? '',
-  //   clientId: AUTH_CONFIG_SERVER?.clientId,
-  //   clientSecret: AUTH_CONFIG_SERVER?.clientSecret,
-  //   scope: 'read:users update:users'
-  // })
-
   const getUserMetadata = async (): Promise<Auth0UserMetadata> => {
     const user = await auth0ManagementClient.getUser({ id })
     return reshapeAuth0UserToProfile(user)

--- a/src/pages/u/[...slug].tsx
+++ b/src/pages/u/[...slug].tsx
@@ -61,7 +61,7 @@ const UserHomePage: NextPage<UserHomeProps> = ({ uid, postId = null, serverMedia
               <div className='border rounded-md px-6 py-2 shadow'>
                 <ul className='list-disc'>
                   <li>Please upload 3 photos to complete your profile {mediaList?.length >= 3 && <span>&#10004;</span>}</li>
-                  <li>Remember to upload only your own photos</li>
+                  <li>Upload only your own photos</li>
                   <li>Keep it <b>Safe For Work</b> and climbing-related</li>
                 </ul>
               </div>


### PR DESCRIPTION
Automatically create `uid.json` file on the user's image folder when they first sign in.  Before we piggyback the action with the profile update call. If they decide to never change their user name then we won't be able to link image tags to their profile. 