### PR TITLE
Remove check to account for early users

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -58,16 +58,14 @@ export default NextAuth({
         throw new Error('Missing user uuid and nickname from Auth provider')
       }
 
-      const loginsCount = token.userMetadata?.loginsCount ?? 0
       const { uuid } = token.userMetadata
-      if (loginsCount < 2) {
-        const username = await getUserNickFromMediaDir(uuid)
-        if (username == null) {
-          // id file doesn't exist
-          console.log(`Creating uid.json file for new user: ${uuid}`)
-          await addUserIdFile(`/u/${uuid}/uid.json`, token.userMetadata.nick)
-        }
+      const username = await getUserNickFromMediaDir(uuid)
+      if (username == null) {
+        // id file doesn't exist
+        console.log(`Creating uid.json file for new user: ${uuid}`)
+        await addUserIdFile(`/u/${uuid}/uid.json`, token.userMetadata.nick)
       }
+
       session.user.metadata = token.userMetadata
       session.accessToken = token.accessToken
       session.id = token.id


### PR DESCRIPTION
Fixing #428 
Some early users still don't have uid.json file and loginCounts check prevents the file from being created.  This PR removes the check.