### PR TITLE
fix #445

### DIFF
--- a/.github/workflows/lighthouse-on-pr.yml
+++ b/.github/workflows/lighthouse-on-pr.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [pull_request]
+on: [push]
 jobs:
   lhci:
     name: Lighthouse

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: 'tests'
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,9 +1,10 @@
-name: 'tests'
+name: 'CI'
 
 on: [push, pull_request]
 
 jobs:
   build:
+    name: Test build
     runs-on: 'ubuntu-latest'
     environment: "Preview"
     steps:
@@ -35,7 +36,7 @@ jobs:
           SIRV_CLIENT_SECRET_RO: ${{ secrets.SIRV_CLIENT_SECRET_RO }}
         if: ${{ github.event_name != 'pull_request' }}
 
-      - name: Test build
+      - name: Build project
         run: yarn build
         env:
           SIRV_CLIENT_SECRET_RO: ${{ secrets.SIRV_CLIENT_SECRET_RO }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,14 +24,22 @@ jobs:
         run: yarn lint
 
       - name: Run unit tests
+        run: yarn test
+        env:
+          SIRV_CLIENT_SECRET_RO: ${{ secrets.SIRV_CLIENT_SECRET_RO }}
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Run unit & e2e tests
         run: yarn test-all
         env:
           SIRV_CLIENT_SECRET_RO: ${{ secrets.SIRV_CLIENT_SECRET_RO }}
+        if: ${{ github.event_name != 'pull_request' }}
 
       - name: Test build
         run: yarn build
         env:
           SIRV_CLIENT_SECRET_RO: ${{ secrets.SIRV_CLIENT_SECRET_RO }}
+        if: ${{ github.event_name != 'pull_request' }}
 
   test-docker-compose:
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,6 @@ services:
     environment:
       - NODE_ENV=development
       - NEXT_TELEMETRY_DISABLED=1
-      - SIRV_CLIENT_SECRET_RO=$${SIRV_CLIENT_SECRET_RO}
-      - SIRV_CLIENT_SECRET_RW=$${SIRV_CLIENT_SECRET_RW}
-      - NEXTAUTH_SECRET=$${NEXTAUTH_SECRET}
-      - AUTH0_CLIENT_SECRET=$${AUTH0_CLIENT_SECRET}
-      - AUTH0_MGMT_CLIENT_SECRET=$${AUTH0_MGMT_CLIENT_SECRET}
     healthcheck:
       test: curl --fail http://web:3000 || exit 1
       interval: 1m

--- a/src/pages/p/[...slug].tsx
+++ b/src/pages/p/[...slug].tsx
@@ -44,7 +44,7 @@ const UserSinglePostView: NextPage<UserSinglePostViewProps> = ({ uid, postId = n
       <SeoTags
         description='Share your climbing adventure photos and contribute to the Wiki.'
         title={pageTitle}
-        images={serverMainMedia?.filename ? [serverMainMedia.filename] : pageImages}
+        images={serverMainMedia?.filename != null ? [serverMainMedia.filename] : pageImages}
         author={author}
       />
 


### PR DESCRIPTION
Fixes https://github.com/OpenBeta/open-tacos/issues/445

I did some digging into this, and I think something's creating a recursive loop due to these interpolations in the compose config file:

```
      - SIRV_CLIENT_SECRET_RO=$${SIRV_CLIENT_SECRET_RO}
      - SIRV_CLIENT_SECRET_RW=$${SIRV_CLIENT_SECRET_RW}
      - NEXTAUTH_SECRET=$${NEXTAUTH_SECRET}
      - AUTH0_CLIENT_SECRET=$${AUTH0_CLIENT_SECRET}
      - AUTH0_MGMT_CLIENT_SECRET=$${AUTH0_MGMT_CLIENT_SECRET}
```

(That were added in https://github.com/OpenBeta/open-tacos/commit/4910eb46538dcf0968cd222d1d41d5bdbae3e66c#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3 ).

I think the double `$$` means that these are not interpolated by docker-compose, but instead are escaped (so the internal env is getting something like `SIRV_CLIENT_SECRET_RO=${SIRV_CLIENT_SECRET_RO}` See that mentioned here: https://docs.docker.com/compose/environment-variables/

next.js has some automagic variable expansion when it tries to apply the env. See here: https://nextjs.org/docs/basic-features/environment-variables

I think when trying to load the env, it takes the values passed in through docker-compose, it gets into an infinite loop trying to substitute them.

I'm not sure what the intent of adding these interpolated variables to that PR was. It seems like there's already a mechanism for passing these values into the container (the .env file), and it shouldn't be needed to also add them to the docker-compose file. Also, not sure why they were doubly-escaped.