### PR TITLE
use main image for seo on picture page

### DIFF
--- a/src/pages/p/[...slug].tsx
+++ b/src/pages/p/[...slug].tsx
@@ -44,7 +44,7 @@ const UserSinglePostView: NextPage<UserSinglePostViewProps> = ({ uid, postId = n
       <SeoTags
         description='Share your climbing adventure photos and contribute to the Wiki.'
         title={pageTitle}
-        images={pageImages}
+        images={serverMainMedia?.filename ? [serverMainMedia.filename] : pageImages}
         author={author}
       />
 


### PR DESCRIPTION
fix #443 

crawlers are not reliable about which image they pick when multiple
og:image tags are provided. When on a media page, one should use a
single image meta tag for the main image.
