### PR TITLE
Allow dev users to get API key for testing

### DIFF
--- a/src/components/users/APIKey.tsx
+++ b/src/components/users/APIKey.tsx
@@ -1,0 +1,21 @@
+import { KeyIcon } from '@heroicons/react/outline'
+import { useSession } from 'next-auth/react'
+
+export default function APIKey (): JSX.Element | null {
+  const { data } = useSession({ required: true })
+
+  const apiKey: string | undefined = (data?.accessToken as string) ?? undefined
+
+  if (data == null || apiKey == null) return null
+  return (
+    <div className='hidden lg:block tooltip tooltip-bottom tooltip-info' data-tip='Copy API key to clipboard'>
+      <button
+        className='block'
+        onClick={async () => {
+          await navigator.clipboard.writeText(apiKey)
+        }}
+      ><KeyIcon className='w-6 h-6' />
+      </button>
+    </div>
+  )
+}

--- a/src/components/users/PublicProfile.tsx
+++ b/src/components/users/PublicProfile.tsx
@@ -4,6 +4,7 @@ import ContentLoader from 'react-content-loader'
 
 import { IUserProfile } from '../../js/types/User'
 import EditProfileButton from './EditProfileButton'
+import APIKey from './APIKey'
 
 interface PublicProfileProps {
   userProfile: IUserProfile
@@ -32,11 +33,12 @@ export default function PublicProfile ({ userProfile: initialUserProfile }: Publ
       <div className='md:col-span-2 text-medium text-primary '>
         {nick == null && <TextPlaceholder uniqueKey={123} />}
 
-        <div className='flex flex-row items-center'>
+        <div className='flex flex-row items-center gap-x-2'>
           <div className='text-2xl font-bold mr-4'>
             {nick}
           </div>
           <EditProfileButton ownerProfile={initialUserProfile} />
+          {userProfile != null && <APIKey />}
         </div>
         <div className='mt-6 text-lg font-semibold'>{name}</div>
         <div className=''>{bio}</div>

--- a/src/components/users/__tests__/PublicProfile.tsx
+++ b/src/components/users/__tests__/PublicProfile.tsx
@@ -19,7 +19,9 @@ const userProfile: IUserProfile = {
   name: 'cat blue',
   nick: 'cool_nick_2022',
   avatar: 'something',
-  bio: 'totem eatsum'
+  bio: 'totem eatsum',
+  roles: [],
+  loginsCount: 1
 }
 
 let PublicProfile: typeof PublicProfileType
@@ -36,7 +38,7 @@ test('PublicProfile when the user has logged in', async () => {
 
   render(<PublicProfile userProfile={userProfile} />)
 
-  expect(mockedUseSession).toBeCalledTimes(1)
+  expect(mockedUseSession).toBeCalled()
   expect(screen.queryByRole('button')).toBeDefined()
 
   expect(screen.queryByText(userProfile.name)).not.toBeNull()
@@ -51,7 +53,7 @@ test('EditProfileButton null when the user hasn\'t logged in', async () => {
 
   render(<PublicProfile userProfile={userProfile} />)
 
-  expect(mockedUseSession).toBeCalledTimes(1)
+  expect(mockedUseSession).toBeCalled()
   expect(screen.queryByRole('button')).toBeNull()
 
   expect(screen.queryByText(userProfile.name)).not.toBeNull()


### PR DESCRIPTION
How to pass API key to API server during development

1.  Click on the key icon to copy your API key to the clipboard.
2.  Go to jwt.io and paste the key in the Encoded box to see the content
3.  In the graphql playground create an "authorization" header with content: `Bearer content_of_your_key` (there's a space between Bearer and the key)

<img width="740" alt="Screen Shot 2022-08-10 at 6 22 45 PM" src="https://user-images.githubusercontent.com/3805254/183962638-0d217ac2-2427-4ed5-a266-03265d08a0df.png">

### GraphQL playground

<img width="1023" alt="Screen Shot 2022-08-10 at 6 28 35 PM" src="https://user-images.githubusercontent.com/3805254/183964056-3638713e-be68-4169-afe6-bdfed7ecb7aa.png">

