### PR TITLE
Coco/photo upload context

### DIFF
--- a/src/components/NewPostOnTaggable.tsx
+++ b/src/components/NewPostOnTaggable.tsx
@@ -1,0 +1,155 @@
+import { useCallback } from 'react'
+import { useSession } from 'next-auth/react'
+import { PlusIcon, DotsHorizontalIcon } from '@heroicons/react/solid'
+
+import usePhotoUploader from '../js/hooks/usePhotoUploader'
+import { Button, ButtonVariant } from './ui/BaseButton'
+import { userMediaStore } from '../js/stores/media'
+import { MediaBaseTag } from '../js/types'
+import { useMutation } from '@apollo/client'
+import { graphqlClient } from '../js/graphql/Client'
+import { MUTATION_ADD_AREA_TAG_TO_MEDIA, MUTATION_ADD_CLIMB_TAG_TO_MEDIA } from '../js/graphql/fragments'
+
+interface NewPostOnTaggableProps {
+  isMobile?: boolean
+  areaId?: string
+  climbId?: string
+  /**
+   * You can optionally override the rendered button content by composing
+   * it as a child of this component.
+   */
+  children?: any
+
+  onTagAdded?: (tags: MediaBaseTag) => void
+}
+
+const MobileButton = (props: {uploading: boolean}): JSX.Element => (
+  <Button
+    disabled={props.uploading}
+    label={
+      <span className='border-2 text-white rounded-md border-white'>
+        {props.uploading ? <DotsHorizontalIcon className='w-6 h-6' /> : <PlusIcon className='w-6 h-6' />}
+      </span>
+                }
+  />
+)
+
+const DefaultButton = (props: {uploading: boolean}): JSX.Element => (
+  <Button
+    disabled={props.uploading}
+    label={
+      <div className='flex no-wrap items-center space-x-2 px-4'>
+        {props.uploading
+          ? <DotsHorizontalIcon className='w-5 h-5 stroke-white stroke-2 animate-pulse' />
+          : <PlusIcon className='stroke-white stroke-2 w-5 h-5' />}
+        <span className='mt-0.5 px-2'>Photo</span>
+      </div>
+          }
+    variant={ButtonVariant.SOLID_PRIMARY}
+  />
+)
+
+/**
+ * Button allowing users to upload a photo and immediately tag it with the current area or climb
+ * that the button is contextually linked to.
+ */
+export default function NewPostOnTaggable (props: NewPostOnTaggableProps): JSX.Element | null {
+  const [tagPhotoWithClimb] = useMutation(
+    MUTATION_ADD_CLIMB_TAG_TO_MEDIA, {
+      client: graphqlClient,
+      errorPolicy: 'none',
+      onCompleted: (d: any) => {
+        console.log(d)
+        if (props.onTagAdded !== undefined) {
+          props.onTagAdded(d.setTag)
+        }
+      }
+    }
+
+  )
+  const [tagPhotoWithArea] = useMutation(
+    MUTATION_ADD_AREA_TAG_TO_MEDIA, {
+      client: graphqlClient,
+      errorPolicy: 'none',
+      onCompleted: (d: any) => {
+        console.log(d)
+        if (props.onTagAdded !== undefined) {
+          props.onTagAdded(d.setTag)
+        }
+      }
+    }
+  )
+
+  const { status, data } = useSession()
+
+  const onUploaded = useCallback(async (url: string): Promise<void> => {
+    if (data?.user?.metadata == null) {
+      console.log('## Error: user metadata not found')
+      return
+    }
+
+    const { nick, uuid } = data.user.metadata
+
+    if (uuid != null && nick != null) {
+      const imageInfo = await userMediaStore.set.addImage(nick, uuid, url, true)
+
+      if (imageInfo === undefined) {
+        console.error('No image info returned from addImage')
+        return
+      }
+
+      for (const imi of imageInfo) {
+        if (props.climbId !== undefined) {
+          await tagPhotoWithClimb({
+            variables: {
+              mediaUuid: imi.mediaId,
+              mediaUrl: imi.filename,
+              srcUuid: props.climbId
+            }
+          })
+        }
+
+        // Note that the back end does not support area tagging at the time of committing
+        if (props.areaId !== undefined) {
+          await tagPhotoWithArea({
+            variables: {
+              mediaUuid: imi.mediaId,
+              mediaUrl: imi.filename,
+              srcUuid: props.areaId
+            }
+          })
+        }
+      }
+    }
+  }, [])
+
+  const { uploading, getRootProps, getInputProps } = usePhotoUploader({ onUploaded })
+
+  const Default = props.isMobile === true ? MobileButton : DefaultButton
+
+  if (status === 'authenticated') {
+    return (
+      <>
+        <div {...getRootProps()}>
+          <input {...getInputProps()} />
+          {props.children !== undefined
+            ? (
+              <button
+                className='w-full'
+                disabled={uploading}
+              >
+                {
+                uploading
+                  ? 'uploading files...'
+                  : props.children
+                }
+              </button>
+              )
+            : <Default uploading={uploading} />}
+        </div>
+      </>
+    )
+  }
+
+  return null
+}

--- a/src/components/crag/cragLayout.tsx
+++ b/src/components/crag/cragLayout.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { AreaMetadataType, Climb, CountByGroupType } from '../../js/types'
+import React, { useState } from 'react'
+import { AreaMetadataType, Climb, CountByGroupType, MediaBaseTag } from '../../js/types'
 import PhotoMontage from '../media/PhotoMontage'
 import CragSummary, { CragHeroProps } from './cragSummary'
 import CragTable from './cragTable'
@@ -13,12 +13,14 @@ interface CragLayoutProps extends CragHeroProps {
 }
 
 export default function CragLayout (props: CragLayoutProps): JSX.Element {
+  const [addedTags, setAddedTags] = useState<MediaBaseTag[]>([])
+
   return (
     <div className='w-full'>
-      <PhotoMontage isHero photoList={props.media} />
+      <PhotoMontage isHero photoList={[...props.media, ...addedTags]} />
 
       <div className='mt-8'>
-        <CragSummary {...props} />
+        <CragSummary {...props} onTagAdded={tag => setAddedTags([...addedTags, tag])} />
       </div>
 
       <div className='mt-6'>

--- a/src/components/crag/cragSummary.tsx
+++ b/src/components/crag/cragSummary.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useState } from 'react'
-import { AreaMetadataType, CountByGroupType } from '../../js/types'
+import { AreaMetadataType, CountByGroupType, MediaBaseTag } from '../../js/types'
 import FavouriteButton from '../users/FavouriteButton'
 
 export interface CragHeroProps {
@@ -11,6 +11,7 @@ export interface CragHeroProps {
   aggregate: CountByGroupType[]
   media: any[]
   areaMeta: AreaMetadataType
+  onTagAdded?: (tag: MediaBaseTag) => void
 }
 
 /**  For a given number of allowed words, quantize to the nearest
@@ -146,21 +147,44 @@ export default function CragSummary (props: CragHeroProps): JSX.Element {
         {props.title}
       </h1>
 
-      <a
-        href={getMapHref(props.latitude, props.longitude)}
-        target='blank'
+      <div
+        className='text-slate-700 tracking-wider text-sm flex'
+        title='Click to view on google maps'
       >
-        <div
-          className='text-slate-700 tracking-wider hover:underline
-          hover:text-blue-700 cursor-pointer text-sm'
-          title='Click to view on google maps'
+        <a
+          className='hover:text-blue-700 hover:underline'
+          href={getMapHref(props.latitude, props.longitude)}
+          target='blank'
         >
           {props.latitude}, {props.longitude}
-        </div>
-      </a>
+        </a>
+      </div>
 
-      <div className='flex-1 flex justify-end'>
-        <FavouriteButton areaId={props.areaMeta.areaId} />
+      <div className='flex-1 flex justify-end gap-2'>
+
+        <div>
+          {/**
+           * The back end does not currently support area image tagging. When it does, this will plug in
+           * without trouble.
+
+           <NewPostOnTaggable areaId={props.areaMeta.areaId} onTagAdded={props.onTagAdded}>
+            <div className='flex gap-2 justify-center p-2 rounded-xl border-2 border-ob-secondary text-ob-secondary'>
+              <svg xmlns='http://www.w3.org/2000/svg' className='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={2}>
+                <path strokeLinecap='round' strokeLinejoin='round' d='M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z' />
+                <path strokeLinecap='round' strokeLinejoin='round' d='M15 13a3 3 0 11-6 0 3 3 0 016 0z' />
+              </svg>
+
+              <div>
+                Upload Photos of area
+              </div>
+            </div>
+          </NewPostOnTaggable>
+        */}
+        </div>
+
+        <div className='w-64'>
+          <FavouriteButton areaId={props.areaMeta.areaId} />
+        </div>
       </div>
 
       <div className='mt-6'>

--- a/src/components/ui/micro/DialogWithContent.tsx
+++ b/src/components/ui/micro/DialogWithContent.tsx
@@ -1,0 +1,132 @@
+import { Transition } from '@headlessui/react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import cx from 'classnames'
+import React, { Fragment, useState } from 'react'
+
+interface Props {
+  /**
+    * What renders for the clickable element that opens the dialog.
+    * if undefined, no clickable element is rendered and the dialog
+    * state must be controlled by a parent state.
+    */
+  button?: string | JSX.Element
+
+  title?: string
+  description?: string
+
+  confirmText?: string
+  cancelText?: string
+
+  children?: any
+  onConfirm?: () => void
+
+  hideTitle?: boolean
+
+  /** If button is null, you need to supply this for controlling open state */
+  open: boolean
+  /**
+   * If you want proper behavior, you will set this. Otherwise the dialog
+   * cannot respond in the expected way.
+  */
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Composes the children of this compoenent into the content of a dialog that is
+ * shown to the user either based on a provided renderable trigger element or by
+ * being controlled by parent state.
+ *
+ * Unlike an alert dialog, this is not a window asking the user for confirm-reject,
+ * but rather a container for implmenting more complex behavior like internal forms
+ * and suchlike.
+ *
+ * This kind of dialog may never hide the ability for the user to exit without
+ * committing changes, and may also never hide the button that commits their changes
+ */
+export default function DialogWithContent (props: Props): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <DialogPrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
+      <DialogPrimitive.Trigger asChild>
+        <button>Click</button>
+      </DialogPrimitive.Trigger>
+
+      <Transition.Root show={isOpen}>
+        <Transition.Child
+          as={Fragment}
+          enter='ease-out duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'
+        >
+          <DialogPrimitive.Overlay
+            forceMount
+            className='fixed inset-0 z-20 bg-black/50'
+          />
+        </Transition.Child>
+        <Transition.Child
+          as={Fragment}
+          enter='ease-out duration-300'
+          enterFrom='opacity-0 scale-95'
+          enterTo='opacity-100 scale-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100 scale-100'
+          leaveTo='opacity-0 scale-95'
+        >
+          <DialogPrimitive.Content
+            forceMount
+            className={cx(
+              'fixed z-50',
+              'w-[95vw] max-w-md rounded-lg p-4 md:w-full',
+              'top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%]',
+              'bg-white dark:bg-gray-800',
+              'focus:outline-none focus-visible:ring focus-visible:ring-purple-500 focus-visible:ring-opacity-75'
+            )}
+          >
+            {props.title !== undefined && (
+              <DialogPrimitive.Title className='text-sm font-medium text-gray-900 dark:text-gray-100'>
+                {props.title}
+              </DialogPrimitive.Title>
+            )}
+
+            {props.description !== undefined && (
+              <DialogPrimitive.Description className='mt-2 text-sm font-normal text-gray-700 dark:text-gray-400'>
+                {props.description}
+              </DialogPrimitive.Description>
+            )}
+
+            {props.children}
+
+            <div className='mt-4 flex justify-end'>
+              <DialogPrimitive.Close
+                onClick={() => { if (props.onConfirm != null) props.onConfirm() }}
+                className={cx(
+                  'inline-flex select-none justify-center rounded-md px-4 py-2 text-sm font-medium',
+                  'bg-ob-primary text-white hover:bg-ob-primary dark:bg-ob-primary dark:text-gray-100 dark:hover:ob-primary',
+                  'border border-transparent',
+                  'focus:outline-none focus-visible:ring focus-visible:ob-primary focus-visible:ring-opacity-75'
+                )}
+              >
+                Save
+              </DialogPrimitive.Close>
+            </div>
+
+            <DialogPrimitive.Close
+              className={cx(
+                'absolute top-3.5 right-3.5 inline-flex items-center justify-center rounded-full p-1',
+                'focus:outline-none focus-visible:ring focus-visible:ring-ob-secondary focus-visible:ring-opacity-75'
+              )}
+            >
+              <svg xmlns='http://www.w3.org/2000/svg' className='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={2}>
+                <path strokeLinecap='round' strokeLinejoin='round' d='M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z' />
+              </svg>
+            </DialogPrimitive.Close>
+          </DialogPrimitive.Content>
+        </Transition.Child>
+      </Transition.Root>
+    </DialogPrimitive.Root>
+  )
+};

--- a/src/components/users/FavouriteButton.tsx
+++ b/src/components/users/FavouriteButton.tsx
@@ -96,7 +96,7 @@ export default function FavouriteButton ({ climbId, areaId }: Props): JSX.Elemen
       onClick={toggle}
       className='text-center p-2 border-2 rounded-xl border-ob-primary transition
         text-ob-primary hover:bg-ob-primary hover:ring hover:ring-ob-primary ring-offset-2
-        hover:text-white w-64 font-bold'
+        hover:text-white font-bold w-full'
     >
       {loading
         ? (

--- a/src/js/graphql/fragments.ts
+++ b/src/js/graphql/fragments.ts
@@ -62,7 +62,9 @@ export const CORE_CRAG_FIELDS = gql`
 `
 
 /**
- * Create a media <--> climb (or area) association
+ * Create a media <--> climb association
+ *
+ * dest type is 0 for climb and 1 for area
  */
 export const MUTATION_ADD_CLIMB_TAG_TO_MEDIA = gql`
   mutation tagPhotoWithClimb($mediaUuid: ID!, $mediaUrl: String!, $srcUuid: ID!) {
@@ -71,6 +73,35 @@ export const MUTATION_ADD_CLIMB_TAG_TO_MEDIA = gql`
         mediaUuid: $mediaUuid,
         mediaUrl: $mediaUrl,
         mediaType: 0,
+        destinationId: $srcUuid,
+        destType: 0
+      }
+    ) {
+        ... on ClimbTag {
+          mediaUuid
+          mediaUrl
+          climb {
+            id
+            name
+          }
+        }
+      }
+  }`
+
+/**
+ * Create a media <-->  area association
+ *
+ * Explanation as to why there are two mutations:
+ *  I don't know why, but the API was not happy with me generalizing the logic.
+ *  I kept getting a 400-code error, I didn't track down why.
+ */
+export const MUTATION_ADD_AREA_TAG_TO_MEDIA = gql`
+  mutation tagPhotoWithArea($mediaUuid: ID!, $mediaUrl: String!, $srcUuid: ID!) {
+    setTag(
+      input: {
+        mediaUuid: $mediaUuid,
+        mediaUrl: $mediaUrl,
+        mediaType: 1,
         destinationId: $srcUuid,
         destType: 0
       }

--- a/src/js/hooks/usePhotoUploader.ts
+++ b/src/js/hooks/usePhotoUploader.ts
@@ -46,14 +46,14 @@ export default function usePhotoUploader ({ onUploaded }: UploaderProps): PhotoU
       imageData = Buffer.from(imageData)
     }
 
-    let retry = 3
+    let retry = 1
     while (retry !== 0) {
       try {
         const url = await uploadPhoto(filename, imageData)
         await onUploaded(url)
         return // success, no err
-      } catch {
-
+      } catch (err) {
+        console.error(err)
       } finally {
         retry -= 1
       }

--- a/src/js/stores/media.ts
+++ b/src/js/stores/media.ts
@@ -29,7 +29,6 @@ export const userMediaStore = createStore('userMedia')(INITIAL_STATE, STORE_OPTS
      * @param uuid
      * @param imageUrl
      * @param revalidateSSR
-     * @returns
      */
     addImage: async (uid, uuid: string, imageUrl: string, revalidateSSR: boolean) => {
       const newMediaUuid = uuidv5(imageUrl, uuidv5.URL)
@@ -68,6 +67,8 @@ export const userMediaStore = createStore('userMedia')(INITIAL_STATE, STORE_OPTS
       if (revalidateSSR) {
         await revalidateServePage(uid)
       }
+
+      return newList
     },
     removeImage: async (mediaId: string) => {
       const currentList = await get.imageList()

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -16,6 +16,7 @@ import { useClimbSeo } from '../../js/hooks/seo/useClimbSeo'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useSwipeable } from 'react-swipeable'
 import FavouriteButton from '../../components/users/FavouriteButton'
+import NewPostOnTaggable from '../../components/NewPostOnTaggable'
 
 interface ClimbPageProps {
   climb: Climb
@@ -52,11 +53,18 @@ const ClimbPage: NextPage<ClimbPageProps> = (props: ClimbPageProps) => {
 
 export default ClimbPage
 
-const Body = ({ climb, mediaListWithUsernames, leftClimb, rightClimb }: ClimbPageProps): JSX.Element => {
+const Body = ({
+  climb,
+  mediaListWithUsernames,
+  leftClimb,
+  rightClimb
+}: ClimbPageProps): JSX.Element => {
   const router = useRouter()
   const { name, fa, yds, type, content, safety, metadata, ancestors, pathTokens } = climb
   const { climbId } = metadata
   useState([leftClimb, rightClimb])
+
+  const [addedTags, setAddedTags] = useState<MediaBaseTag[]>([])
 
   const swipeHandlers = useSwipeable({
     onSwipedLeft: () => {
@@ -87,8 +95,9 @@ const Body = ({ climb, mediaListWithUsernames, leftClimb, rightClimb }: ClimbPag
         />
 
         <div className='py-6'>
-          <PhotoMontage photoList={mediaListWithUsernames} />
+          <PhotoMontage photoList={[...mediaListWithUsernames, ...addedTags]} />
         </div>
+
         <div className='md:flex'>
           <div
             id='Title Information'
@@ -110,8 +119,29 @@ const Body = ({ climb, mediaListWithUsernames, leftClimb, rightClimb }: ClimbPag
                 <strong>FA: </strong>{fa}
               </div>
 
-              <div className='flex pt-8'>
-                <FavouriteButton climbId={climbId} />
+              <div className='pr-6'>
+
+                <div className='flex pt-8'>
+                  <FavouriteButton climbId={climbId} />
+                </div>
+
+                <div className='pt-4'>
+                  <NewPostOnTaggable
+                    climbId={climb.id}
+                    onTagAdded={(tags) => setAddedTags([...addedTags, tags])}
+                  >
+                    <div className='flex gap-2 justify-center p-2 rounded-xl border-2 border-ob-secondary text-ob-secondary'>
+                      <svg xmlns='http://www.w3.org/2000/svg' className='h-6 w-6' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={2}>
+                        <path strokeLinecap='round' strokeLinejoin='round' d='M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z' />
+                        <path strokeLinecap='round' strokeLinejoin='round' d='M15 13a3 3 0 11-6 0 3 3 0 016 0z' />
+                      </svg>
+
+                      <div>
+                        Upload Photos of climb
+                      </div>
+                    </div>
+                  </NewPostOnTaggable>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
#499 Asked for something adjacent to this, I think this is a decent stepping stone

![image](https://user-images.githubusercontent.com/64557383/185948480-ff5a1907-95f5-4731-87d3-55fc634ed403.png)

Adds a button to upload-and-tag at once. It will work for area tagging as well, when the setTag mutation supports it