### PR TITLE
Visual clarity + Fixed profile editing

### DIFF
--- a/src/components/ui/TextField.tsx
+++ b/src/components/ui/TextField.tsx
@@ -2,13 +2,19 @@ import React from 'react'
 import { Field, FieldMetaProps } from 'formik'
 
 interface TextFieldProps {
+  /** key name for data */
   name: string
+  /** HTML label rendered for this input */
   label: string
+  /** Is this text input multiple lines? */
   multiline?: boolean
+  /** (If multiline) how many rows should this input have */
   rows?: number
   spellcheck?: boolean
+  /** Wait until submit to validate, or perform the validation immediately */
   validateImmediately?: boolean
-  validate?: (value: any) => Promise<undefined|string> // return an error message or undefined for valid input
+  /** return an error message or undefined for valid input */
+  validate?: (value: any) => Promise<undefined|string>
 }
 
 interface FieldType {
@@ -17,38 +23,40 @@ interface FieldType {
 }
 
 /**
- * Responsive Formik-textfield
- * @param name key name for data
- * @param label text label
- * @param multiline
- * @param validate Optional validate function
- * @param validateImmediately Set to true if you want immediate validation as the user is typing.  Default behvavoir is to run validation on blur.
+ * Responsive Formik-textfield with some added utility for our purposes.
+ * fullwidth by intent, and design. designed to be vertically stacked
+ * and labelled.
  */
-const TextField = ({ name, label, multiline = false, rows = 3, validate, spellcheck = false, validateImmediately = false }: TextFieldProps): JSX.Element => (
-  <div className='edit-form-row '>
-    <label className='font-semibold md:w-36 md:-mt-2' htmlFor={name}>
-      {label}
+const TextField = (props: TextFieldProps): JSX.Element => (
+  <div className='edit-form-row w-full'>
+    <label className='font-semibold md:w-36 md:-mt-2' htmlFor={props.name}>
+      {props.label}
     </label>
-    <Field id={name} name={name} {...validate != null ? { validate } : null}>
+
+    <Field
+      id={props.name}
+      name={props.name}
+      {...props.validate != null ? { validate: props.validate } : null}
+    >
       {({ field, meta }: FieldType) => (
         <div className='w-full'>
 
-          {multiline
+          {props.multiline === true
             ? (<textarea
                 className='w-full edit-input'
-                rows={rows}
+                rows={props.rows}
                 {...field}
-                spellCheck={spellcheck}
+                spellCheck={props.spellcheck}
                />)
             : (<input
                 className='w-full edit-input'
                 type='text'
                 {...field}
-                spellCheck={spellcheck}
+                spellCheck={props.spellcheck}
                />)}
 
           <div className='h-3 text-sm pt-1 px-3 text-pink-600'>
-            {(validateImmediately || meta.touched) && (meta?.error ?? '')}
+            {(props.validateImmediately === true || meta.touched) && (meta?.error ?? '')}
           </div>
         </div>
       )}

--- a/src/components/users/account/ProfileEditForm.tsx
+++ b/src/components/users/account/ProfileEditForm.tsx
@@ -66,9 +66,12 @@ export default function ProfileEditForm (): ReactElement {
     const profile = await updateUserProfile(newValues)
 
     if (profile != null) {
+      setProfile(profile)
       setJustSubmitted(true)
       // Also trigger a page rebuild
       void revalidateServePage(profile.nick)
+    } else {
+      console.error('Profile object was supposed to not be null!')
     }
   }, [])
 

--- a/src/components/users/account/ProfileEditForm.tsx
+++ b/src/components/users/account/ProfileEditForm.tsx
@@ -39,7 +39,14 @@ const UserProfileSchema = Yup.object().shape({
     })
 }, [['website', 'website']])
 
+/**
+ * Allow users to edit their profile data (held in Auth0 metadata store).
+ *
+ * Presents as a simple form with freetext fields for the various edit-able
+ * attributes present on the user's profile.
+ */
 export default function ProfileEditForm (): ReactElement {
+  const [loadingName, setLoadingUser] = useState(false)
   const [justSubmitted, setJustSubmitted] = useState(false)
   const [profile, setProfile] = useState<IWritableUserMetadata>({
     name: '',
@@ -56,7 +63,7 @@ export default function ProfileEditForm (): ReactElement {
     void asyncLoad()
   }, [])
 
-  const submitHandler = useCallback(async (newValues) => {
+  const submitHandler = useCallback(async (newValues: IWritableUserMetadata) => {
     const profile = await updateUserProfile(newValues)
     if (profile != null) {
       setJustSubmitted(true)
@@ -65,17 +72,32 @@ export default function ProfileEditForm (): ReactElement {
     }
   }, [])
 
+  /**
+   * Usernames are globally unique in the openbeta environment, so we check
+   * ahead of time if the user has filled out a taken username.
+   */
   const checkUsernameHandler = useCallback(async (value: string|undefined) => {
-    if (value == null) return undefined
+    setLoadingUser(true)
+    if (value == null) {
+      setLoadingUser(false) // reset to default state
+      return undefined
+    }
+
     // only check if nick has changed from the original
     if (profile.nick !== value && await doesUsernameExist(value)) {
+      setLoadingUser(false)
       return 'User name is already taken!'
     }
+    setLoadingUser(false)
     return undefined
   }, [profile.nick])
 
   return (
     <div data-lpignore='true'>
+      <h3 className='text-center mb-6'>
+        Edit your profile details
+      </h3>
+
       <Formik
         initialValues={profile}
         validationSchema={UserProfileSchema}
@@ -83,24 +105,42 @@ export default function ProfileEditForm (): ReactElement {
         enableReinitialize
       >{({ isValid, isSubmitting, dirty }) => (
         <Form>
-          <TextField
-            name='nick'
-            label='Username'
-            validate={checkUsernameHandler}
-            validateImmediately
-          />
+          <div className='flex relative justify-end'>
+            <TextField
+              name='nick'
+              label='Username'
+              validate={checkUsernameHandler}
+              validateImmediately
+            />
+
+            {loadingName && (
+              <div className='absolute bg-ob-primary p-1 rounded-full text-white -right-2 top-2 animate-spin'>
+                <svg xmlns='http://www.w3.org/2000/svg' className='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={2}>
+                  <path strokeLinecap='round' strokeLinejoin='round' d='M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15' />
+                </svg>
+              </div>
+            )}
+          </div>
+
           <TextField name='name' label='Name' />
           <TextField name='bio' label='Bio' multiline rows={3} spellcheck />
           <TextField name='website' label='Website (optional)' />
-          <div>
+          <div className='flex justify-end'>
             <Button
-              label={isSubmitting ? 'Saving...' : 'Save'} type='submit' variant={ButtonVariant.SOLID_DEFAULT}
-              disabled={(dirty && !isValid) || isSubmitting}
+              label={isSubmitting ? 'Saving...' : 'Save'}
+              type='submit'
+              variant={ButtonVariant.SOLID_DEFAULT}
+              disabled={(dirty && !isValid) || isSubmitting || loadingName}
             />
           </div>
         </Form>)}
       </Formik>
-      <Snackbar open={justSubmitted} message='Profile updated!' onClose={() => setJustSubmitted(false)} />
+
+      <Snackbar
+        open={justSubmitted}
+        message='Profile updated!'
+        onClose={() => setJustSubmitted(false)}
+      />
     </div>
   )
 }

--- a/src/components/users/account/ProfileEditForm.tsx
+++ b/src/components/users/account/ProfileEditForm.tsx
@@ -4,7 +4,6 @@ import * as Yup from 'yup'
 
 import { getUserProfile, updateUserProfile } from '../../../js/auth/CurrentUserClient'
 import TextField from '../../ui/TextField'
-import { Button, ButtonVariant } from '../../ui/BaseButton'
 import Snackbar from '../../ui/Snackbar'
 import { IWritableUserMetadata } from '../../../js/types/User'
 import { doesUsernameExist } from '../../../js/userApi/user'
@@ -65,6 +64,7 @@ export default function ProfileEditForm (): ReactElement {
 
   const submitHandler = useCallback(async (newValues: IWritableUserMetadata) => {
     const profile = await updateUserProfile(newValues)
+
     if (profile != null) {
       setJustSubmitted(true)
       // Also trigger a page rebuild
@@ -125,22 +125,27 @@ export default function ProfileEditForm (): ReactElement {
           <TextField name='name' label='Name' />
           <TextField name='bio' label='Bio' multiline rows={3} spellcheck />
           <TextField name='website' label='Website (optional)' />
-          <div className='flex justify-end'>
-            <Button
-              label={isSubmitting ? 'Saving...' : 'Save'}
-              type='submit'
-              variant={ButtonVariant.SOLID_DEFAULT}
-              disabled={(dirty && !isValid) || isSubmitting || loadingName}
+          <div className='flex justify-center pt-6'>
+            <Snackbar
+              open={justSubmitted}
+              message='Profile updated!'
+              onClose={() => setJustSubmitted(false)}
             />
+          </div>
+
+          <div className='flex justify-end pt-4'>
+            <button
+              title='Commit these changes to your profile'
+              type='submit'
+              disabled={(dirty && !isValid) || isSubmitting}
+              className='btn btn-primary w-40'
+            >
+              {isSubmitting ? 'Saving...' : 'Save'}
+            </button>
           </div>
         </Form>)}
       </Formik>
 
-      <Snackbar
-        open={justSubmitted}
-        message='Profile updated!'
-        onClose={() => setJustSubmitted(false)}
-      />
     </div>
   )
 }

--- a/src/js/auth/ManagementClient.ts
+++ b/src/js/auth/ManagementClient.ts
@@ -74,6 +74,10 @@ export const doesUserNameExist = async (nick: string): Promise<boolean> => {
   throw new Error('Unable to search the user database')
 }
 
+/**
+ * For an object of any shape, return only those fields that are write-able.
+ * Prevents users from injecting arbitrary data into the medatada object.
+ */
 export const extractUpdatableMetadataFromProfile = ({ name, nick, bio, website, collections }: IWritableUserMetadata): IWritableUserMetadata => ({
   name,
   nick,

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -153,13 +153,17 @@ const regUsernameKeywords = /openbeta|0penbeta|admin/i
 
 /**
  * Username validation
+ * Only does format validation, does not check against database
+ * or anything like that.
+ *
  * @param uid
  * @returns true if has valid format
  */
-export const checkUsername = (uid: string): boolean =>
-  uid != null && uid.length <= 30 &&
+export const checkUsername = (uid: string): boolean => {
+  return uid != null && uid.length <= 30 &&
   !regUsernameKeywords.test(uid) &&
   regUsername.test(uid)
+}
 
 export const saveAsFile = (data: any, filename: string): void => {
   const blob = new Blob([data], { type: 'text/plain;charset=utf-8' })

--- a/src/pages/account/edit.tsx
+++ b/src/pages/account/edit.tsx
@@ -12,7 +12,10 @@ const edit: INextPageWithAuth = () => {
       </Head>
 
       <Layout contentContainerClass='content-default with-standard-y-margin' showFilterBar={false}>
-        <section className='mx-auto max-w-screen-sm w-full rounded-md md:border p-0 md:p-16'>
+        <section
+          className='mx-auto max-w-screen-sm w-full md:rounded-xl md:shadow-lg md:border p-4 md:p-16'
+          style={{ minHeight: '90vh' }}
+        >
           <ProfileEditForm />
         </section>
       </Layout>

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -30,6 +30,7 @@ const updateMyProfile: Handler = async (req, res) => {
   }
 
   try {
+    // Only validate username
     if (!checkUsername(req.body?.nick)) {
       throw new Error('Bad username')
     }


### PR DESCRIPTION
- added some small documentation
- updateUserMetadata now works, previously would not commit if old nick had not been changed

fix for #376, documentation is in code but there is the critical discovery I made
```ts
// The auth0 management client only touches properties that
// are actually specified in metadata. So an undefined property
// is passed over, not nulled, by Auth0
const currentMeta = await getUserMetadata()
if (currentMeta.nick === metadata.nick) {
  delete currentMeta.nick
}

// Actually write this new data into the users profile.
const user = await auth0ManagementClient.updateUserMetadata(
  { id },
  metadata
)
```

Solution evidenced by https://github.com/auth0/node-auth0/blob/2e09f288cd6fc385e699a163e4c10b8692666d91/src/RetryRestClient.js#L53 and https://auth0.com/docs/manage-users/user-accounts/user-profiles/root-attributes/update-root-attributes-for-users Which suggest that patch will not touch props not defined in the object (must be explicitly set to null for deletion)
