### PR TITLE
Toast concept that might be useful to us

### DIFF
--- a/src/components/ui/toast/README.md
+++ b/src/components/ui/toast/README.md
@@ -1,0 +1,28 @@
+# Toast mini-mod
+
+minimal implementation of https://github.com/fkhadra/react-toastify#readme using the UI components we already have access to.
+
+There are instances where an error boundary is so far from the scope of what you are presently working on that you just ignore updating the UI at all for errors, maybe just throw a console.error and move on. For instances like that, consider using this instead. A toast will be shown no matter where in the (client side) program it is called. No error / success state, just simple.
+
+Calling this from the server-side will do absolutely nothing, but you COULD potentially build a queue that displays the messages as soon as hydration finishes.
+
+Let's say you're writing something quick, and you realize something might throw an error. You can do
+
+```js
+fetch('/api/dangerous')
+    .then(setData)
+    .catch(() => toast.error("Oh snap! That wasn't supposed to happen"))
+```
+
+You could add a button to send the user straight to the github issues list like
+
+```js
+fetch('/api/dangerous')
+    .then(setData)
+    .catch(() => toast.error("Oh snap! That wasn't supposed to happen", { 
+        onAction: () => window.navigate('url'), 
+        actionButton: 'Github Issues'
+        }))
+```
+
+The toast event lifecycle will work under the hood to render this for you, without any janky dom-injection.

--- a/src/components/ui/toast/Toast.tsx
+++ b/src/components/ui/toast/Toast.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react'
+import * as ToastPrimitive from '@radix-ui/react-toast'
+import cx from 'classnames'
+import toast, { ToastEvent } from './toastControl'
+
+interface Props {
+  toast: ToastEvent
+}
+
+export default function Toast (props: Props): JSX.Element {
+  const [isOpen, setIsOpen] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    setIsOpen(true)
+
+    // If we're not waiting for dismiss, then we close this toast automatically
+    // after 6 seconds
+    if (props.toast.ops.showDismiss !== true) {
+      setTimeout(() => setIsOpen(false), 6000)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isOpen !== false) return
+
+    setTimeout(() => toast._removeToast(props.toast), 500)
+  }, [open])
+
+  // More guardrails against weird behavior outside of bounds
+  if (props.toast.ttl !== undefined && new Date().getTimezoneOffset() > props.toast.ttl.getTime()) {
+    toast._removeToast(props.toast)
+    return <div />
+  }
+
+  return (
+    <ToastPrimitive.Root
+      open={isOpen === true}
+      onOpenChange={o => { if (!o) toast._removeToast(props.toast) }}
+      className={cx(
+        'relative z-50 inset-x-4 w-auto md:left-auto md:w-full md:max-w-sm shadow-lg rounded-lg',
+        'bg-white mt-1',
+        'radix-state-open:animate-toast-slide-in-bottom md:radix-state-open:animate-toast-slide-in-right',
+        'radix-state-closed:animate-toast-hide',
+        'radix-swipe-end:animate-toast-swipe-out',
+        'translate-x-radix-toast-swipe-move-x',
+        'radix-swipe-cancel:translate-x-0 radix-swipe-cancel:duration-200 radix-swipe-cancel:ease-[ease]',
+        'focus:outline-none focus-visible:ring focus-visible:ring-ob-primary-500 focus-visible:ring-opacity-75',
+        props.toast.className
+      )}
+    >
+      <div className='flex'>
+        <div className='w-0 flex-1 flex items-center pl-5 py-4'>
+          <div className='w-full radix'>
+            {props.toast.ops.title !== undefined && (
+              <ToastPrimitive.Title className='text-sm font-medium text-gray-900'>
+                {props.toast.ops.title}
+              </ToastPrimitive.Title>
+            )}
+
+            <ToastPrimitive.Description className='mt-1 text-sm text-gray-700'>
+              {props.toast.msg}
+            </ToastPrimitive.Description>
+
+          </div>
+        </div>
+
+        <div className='flex'>
+          <div className='flex flex-col px-3 py-2 space-y-1'>
+            <div className='h-0 flex-1 flex'>
+              {props.toast.ops.onAccept !== undefined && (
+                <ToastPrimitive.Action
+                  altText='view now'
+                  className='w-full border border-transparent rounded-lg px-3 py-2 flex items-center
+                    justify-center text-sm font-medium text-ob-primary-600
+                    hover:bg-gray-50 focus:z-10 focus:outline-none
+                    focus-visible:ring focus-visible:ring-ob-primary-500 focus-visible:ring-opacity-75'
+                  onClick={() => { if (props.toast.ops.onAccept !== undefined) props.toast.ops.onAccept() }}
+                >
+                  {props.toast.ops.actionButton}
+                </ToastPrimitive.Action>
+              )}
+            </div>
+
+            <div className='h-0 flex-1 flex'>
+              <ToastPrimitive.Close
+                className='w-full border border-transparent rounded-lg px-3 py-2 flex items-center
+                justify-center text-sm font-medium text-gray-700 hover:bg-gray-50
+                focus:z-10 focus:outline-none focus-visible:ring focus-visible:ring-ob-primary-500
+                focus-visible:ring-opacity-75'
+              >
+                Dismiss
+              </ToastPrimitive.Close>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ToastPrimitive.Root>
+  )
+}

--- a/src/components/ui/toast/ToastContainer.tsx
+++ b/src/components/ui/toast/ToastContainer.tsx
@@ -1,0 +1,57 @@
+import * as ToastPrimitive from '@radix-ui/react-toast'
+import React, { useEffect, useState } from 'react'
+import Toast from './Toast'
+import toast, { ToastEvent } from './toastControl'
+
+/**
+ * Simply handles effects for toast events without leaking events
+ * all over the place
+ */
+function useToastQueue (): [ToastEvent[]] {
+  const [queue, setQueue] = useState<ToastEvent[]>(Array.from(toast.tq))
+
+  const deleteToast = (id: string): void => {
+    setQueue(queue.filter(y => y.id !== id))
+  }
+
+  // Handle effects inside this component
+  useEffect(() => {
+    // Always re-filter
+    queue.forEach(t => {
+      if (t.ttl !== undefined && new Date().getTime() > t.ttl.getTime()) {
+        toast._removeToast(t)
+      }
+    })
+
+    const handler = (t: ToastEvent): void => {
+      if (t.lifecycle === 'mustdie') {
+        deleteToast(t.id)
+      } else {
+        setQueue([...queue, t])
+      }
+    }
+
+    toast._addListener(handler)
+
+    return () => {
+      toast._clearListener(handler)
+    }
+  }, [queue, setQueue, deleteToast])
+
+  return [queue]
+}
+
+export default function ToastContainer (): JSX.Element {
+  const [queue] = useToastQueue()
+
+  return (
+    <div className='right-0 top-4 fixed z-50 w-96'>
+      <ToastPrimitive.Provider>
+        {queue.map((t) => (
+          <Toast key={t.id} toast={t} />
+        ))}
+        <ToastPrimitive.Viewport />
+      </ToastPrimitive.Provider>
+    </div>
+  )
+}

--- a/src/components/ui/toast/toastControl.ts
+++ b/src/components/ui/toast/toastControl.ts
@@ -1,0 +1,66 @@
+
+interface ToastProps {
+  showDismiss?: boolean
+  /**
+     * The toast may carry a button payload (in addition to the showDismiss action),
+     * you may choose to stick a callback on that interaction
+     */
+  onAccept?: () => void
+  /**
+     * Set a plain string label for the default button
+     */
+  actionButton?: string | JSX.Element
+
+  /** optionally supply a title to render */
+  title?: string
+}
+
+export interface ToastEvent {
+  msg: string
+  ops: ToastProps
+  className: string
+  id: string
+  lifecycle: 'alive'| 'mustdie'
+  ttl?: Date
+}
+
+type ToastEventListener = (t: ToastEvent) => void
+
+function makeToast (msg: string, ops: ToastProps, className: string): void {
+  const t: ToastEvent = { msg, ops, className, id: `toast - ${new Date().getTime()}`, lifecycle: 'alive' }
+  if (ops.showDismiss !== true) {
+    // Immediately set a maximum ttl for this toast
+    const time = new Date()
+    time.setSeconds(time.getSeconds() + 7)
+    t.ttl = time
+  }
+
+  toast.tq.add(t)
+  toast.ll.forEach(listener => listener(t))
+}
+
+/**
+ * Very simple event architechture for sending events from arbitrary contexts
+ * and injecting it into the ToastContainer state. This is a singleton-instance
+ * so this should be safe **enough** with reacts impure state model.
+ */
+const toast = {
+  // Event listeners
+  ll: new Set<ToastEventListener>([]),
+  tq: new Set<ToastEvent>([]),
+
+  _clearListener: (cb: ToastEventListener) => toast.ll.delete(cb),
+  _addListener: (cb: ToastEventListener) => toast.ll.add(cb),
+  _removeToast: (t: ToastEvent) => {
+    toast.tq.delete(t)
+    toast.ll.forEach(listener => listener({ ...t, lifecycle: 'mustdie' }))
+  },
+  // success: (msg: string, ops?: ToastProps): void => { },
+  // error: (msg: string, ops?: ToastProps): void => { },
+  // warn: (msg: string, ops?: ToastProps): void => { },
+  info: (msg: string, ops?: ToastProps): void => {
+    makeToast(msg, ops ?? {}, '')
+  }
+}
+
+export default toast

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,7 @@ import TabsTrigger from '../components/ui/TabsTrigger'
 import { RecentTagsProps } from '../components/home/RecentMedia'
 import { enhanceMediaListWithUsernames } from '../js/usernameUtil'
 import { getImagesByFilenames } from '../js/sirv/SirvClient'
+import ToastContainer from '../components/ui/toast/ToastContainer'
 
 const allowedViews = ['explore', 'newTags', 'map', 'edit']
 
@@ -127,6 +128,8 @@ const Home: NextPage<HomePageType> = ({ exploreData, tagsByMedia, mediaList }) =
           </Tabs.Root>
         </section>
       </Layout>
+
+      <ToastContainer />
     </>
   )
 }


### PR DESCRIPTION
Really not sure if we need to re-invent the wheel but this is a super small module compared to react-toastify. The API is **similar** but trimmed to what we really need. If we need complex APIs then react-toastify is better for our needs

Let's say you're writing something quick, and you realize something might throw an error. You can do

```js
fetch('/api/dangerous')
    .then(setData)
    .catch(() => toast.error("Oh snap! That wasn't supposed to happen"))
```

You could add a button to send the user straight to the github issues list like

```js
fetch('/api/dangerous')
    .then(setData)
    .catch(() => toast.error("Oh snap! That wasn't supposed to happen", { 
        onAction: () => window.navigate('url'), 
        actionButton: 'Github Issues'
        }))
```