### PR TITLE
Bug: Convert ISO time to date object.

### DIFF
--- a/src/components/media/UserMedia.tsx
+++ b/src/components/media/UserMedia.tsx
@@ -47,6 +47,7 @@ export default function UserMedia ({ index, uid, imageInfo, onClick, tagList, on
   const shareableUrl = `/p/${uid}/${basename(imageInfo.filename)}`
 
   const getUploadDate = (dateUploaded: Date): string => {
+    dateUploaded = new Date(dateUploaded)
     const currentTime = new Date()
     if (differenceInYears(currentTime, dateUploaded) >= 1) {
       return format(dateUploaded, 'MMM yyyy')


### PR DESCRIPTION
Tested viewing timestamp for an upload and found a bug. `imageInfo.ctime` is in ISO format. This needed to be converted to a javascript date object in order to compare with the current time (`const currentTime = new Date()`)