### PR TITLE
Small style fix for text contrast in tabs

### DIFF
--- a/src/components/ui/TabsTrigger.tsx
+++ b/src/components/ui/TabsTrigger.tsx
@@ -17,7 +17,7 @@ export default function TabsTrigger ({ tabKey, activeKey, icon, label, hidden = 
           hidden ? 'hidden' : 'relative z-50 border-b-4 w-20',
           tabKey === activeKey
             ? 'border-gray-800 text-base-content'
-            : 'border-transparent hover:border-gray-400 text-base-200 hover:text-base-content')
+            : 'border-transparent hover:border-gray-400 text-base-300 hover:text-base-content')
       }
     >
       <div className='flex flex-col justify-center items-center'>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -81,7 +81,7 @@ const Home: NextPage<HomePageType> = ({ exploreData, tagsByMedia, mediaList }) =
                 classNames(
                   'z-10 mb-6 mx-4 flex gap-x-4 px-4 py-1',
                   activeTab === 'map'
-                    ? 'backdrop-blur-sm drop-shadow-md bg-gray-100 bg-opacity-60 ring-2 ring-gray-600 ring-offset-4 rounded'
+                    ? 'bg-white ring-2 ring-gray-600 ring-offset-4 rounded'
                     : '')
               }
             >


### PR DESCRIPTION
Super minor, just made the text a little darker for better contrast. I think in context the solid background will be more readable than the blurred background with unintended bleed.
![image](https://user-images.githubusercontent.com/64557383/188495951-67be0c7c-4da9-4ace-ad6d-2e060e2be7ca.png)
