### PR TITLE
Updated FinancialBackers to remove Duplicate donor issue #547

### DIFF
--- a/src/components/home/FinancialBackers.tsx
+++ b/src/components/home/FinancialBackers.tsx
@@ -6,12 +6,8 @@ export interface FinancialBackersProps {
   donors: FinancialBackerAccountType[]
   totalRaised: string
 }
-
 export default function FinancialBackers({ donors, totalRaised }: FinancialBackersProps): JSX.Element {
-
-
-  const uniqDonors = uniq(donors, (donor) => donor.account.name)  // Using the underscore library to get unique donors, based on their name
-
+  const uniqDonors = uniq(donors, (donor) => donor.account.name) // Using the underscore library to get unique donors, based on their name
   return (
     <div className='text-primary text-center pb-10'>
       <h3>Thanks to our financial backers we've raised ${totalRaised}</h3>
@@ -20,7 +16,6 @@ export default function FinancialBackers({ donors, totalRaised }: FinancialBacke
           {uniqDonors?.map(donor => {
             const name = donor.account.name
             const imageUrl = donor.account.imageUrl
-
             return (
               <BackerCard key='name' name={name} imageUrl={imageUrl} />
             )

--- a/src/components/home/FinancialBackers.tsx
+++ b/src/components/home/FinancialBackers.tsx
@@ -1,18 +1,23 @@
-import { FinancialBackerAccountType } from '../../js/types'
 import BackerCard from '../ui/BackerCard'
+import { FinancialBackerAccountType } from '../../js/types'
+import { uniq } from 'underscore'
 
 export interface FinancialBackersProps {
   donors: FinancialBackerAccountType[]
   totalRaised: string
 }
 
-export default function FinancialBackers ({ donors, totalRaised }: FinancialBackersProps): JSX.Element {
+export default function FinancialBackers({ donors, totalRaised }: FinancialBackersProps): JSX.Element {
+
+
+  const uniqDonors = uniq(donors, (donor) => donor.account.name)  // Using the underscore library to get unique donors, based on their name
+
   return (
     <div className='text-primary text-center pb-10'>
       <h3>Thanks to our financial backers we've raised ${totalRaised}</h3>
       <div>
         <div className='grid grid-cols-4 gap-4 columns-xs'>
-          {donors?.map(donor => {
+          {uniqDonors?.map(donor => {
             const name = donor.account.name
             const imageUrl = donor.account.imageUrl
 

--- a/src/components/home/FinancialBackers.tsx
+++ b/src/components/home/FinancialBackers.tsx
@@ -6,7 +6,7 @@ export interface FinancialBackersProps {
   donors: FinancialBackerAccountType[]
   totalRaised: string
 }
-export default function FinancialBackers({ donors, totalRaised }: FinancialBackersProps): JSX.Element {
+export default function FinancialBackers ({ donors, totalRaised }: FinancialBackersProps): JSX.Element {
   const uniqDonors = uniq(donors, (donor) => donor.account.name) // Using the underscore library to get unique donors, based on their name
   return (
     <div className='text-primary text-center pb-10'>


### PR DESCRIPTION
#547 Using underscore Uniq added a Quick filter to take out duplicate names, would recommend that we have some kind of account id in case you run into the names being the same. Didn't know if that was coming from another entry point on the backend could only follow the typing back to the index and didn't find where it was being populated to add ids further up.