### PR TITLE
Adjust filter popover text color (fixes #584)

### DIFF
--- a/src/components/ui/FilterPopover.tsx
+++ b/src/components/ui/FilterPopover.tsx
@@ -28,7 +28,7 @@ export default function FilterPopover ({ label, mobileLabel, header, shortHeader
   }
   return (
     <LeanPopover
-      btnClz='border-2 rounded-2xl btn-small border-neutral-100 lg:text-neutral-100 flex flex-row space-x-1.5 center-items'
+      btnClz='border-2 rounded-2xl whitespace-nowrap py-1 px-4 border-primary-contrast lg:text-primary-contrast flex flex-row space-x-1.5 items-center'
       btnLabel={label}
     >
       <LeanPopover.ContentPanel


### PR DESCRIPTION
Hello, I tried to fix #584 as part of hacktoberfest, could you please review?

While at it, I also fixed the cantering of the dropdown icon, which was broken.

This is the result. Please let me know if you have any questions/ideas

<img width="737" alt="image" src="https://user-images.githubusercontent.com/15055321/198884764-b9196067-985b-4f6e-bc60-97b1139c1a8e.png">
