### PR TITLE
Use new Typesense tenant

### DIFF
--- a/.env
+++ b/.env
@@ -34,10 +34,10 @@ NEXT_PUBLIC_API_SERVER=https://stg-api.openbeta.io
 NEXT_TELEMETRY_DISABLED=1
 
 # Typesense nodes (handle a single node for now)
-NEXT_PUBLIC_TYPESENSE_NODES=4wknoyspjq6l7c9fp-1.a1.typesense.net
+NEXT_PUBLIC_TYPESENSE_NODES=lj2nqsybtrcxp5kmp-1.a1.typesense.net
 
 # Typesense RO API key
-NEXT_PUBLIC_TYPESENSE_API_KEY=1VywOzT4pj7dzJMYLjkiWI8FqpSicqZL
+NEXT_PUBLIC_TYPESENSE_API_KEY=nBvjNVojLn792SX9sOLhLlpQ7BQJo5ok
 
 # Mapbox Geocoder token
 NEXT_PUBLIC_MAPBOX_API_KEY=pk.eyJ1IjoibWFwcGFuZGFzIiwiYSI6ImNrMW1nZTY2ODAwaGszbmxzdmV1dzNvZTcifQ.aI_avtcHh5F1QBW1UvUhLA


### PR DESCRIPTION
After switching to Typesense team account, I didn't know you have to enter new payment info.  They deleted the trial tenant after the free allotted minutes expired. 
We're now using a new tenant with payment info.