### PR TITLE
Fix area location google map link.

### DIFF
--- a/src/components/area/panel/panelHeader.tsx
+++ b/src/components/area/panel/panelHeader.tsx
@@ -18,7 +18,7 @@ export interface PanelHeaderProps{
  * a query lookup
  */
 function getMapHref (lat: number, lng: number): string {
-  return `https://www.google.com/maps/search/${lng},+${lat}`
+  return `https://www.google.com/maps/place/${lat},${lng}`
 }
 
 export function PanelHeader (props: PanelHeaderProps): JSX.Element {


### PR DESCRIPTION
Closes #635 

I have changed the return link from the getMapHref function to correctly locate the area location on google map.
(`https://www.google.com/maps/place/${lat},${lng}`)

**_Additional comments_**
While running the development version, I spotted that the latitude and longitude shown on the _crag_ page are swapped but the google map link locates that crag correctly. 
Additionally, the production version seems to work just fine so I didn't do anything about it.
____
This is one of my very first contributions for open-source project.
Every comment is appreciated! Thank you.