### PR TITLE
Adding read more / read less behavior to areas (#629)

### DIFF
--- a/src/components/area/panel/panelHeader.tsx
+++ b/src/components/area/panel/panelHeader.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
-import { useMemo } from 'react'
-import { summarize } from '../../crag/cragSummary'
+import Description from '../../ui/Description'
 
-export interface PanelHeaderProps{
+export interface PanelHeaderProps {
   title: string
   latitude: number
   longitude: number
@@ -23,17 +22,7 @@ function getMapHref (lat: number, lng: number): string {
 
 export function PanelHeader (props: PanelHeaderProps): JSX.Element {
   const maxWordsInSummary = 50
-
-  // This will truncate longer descriptions so that users aren't assaulted with a
-  // massive block of text. In the sprit of progressive disclosure I'd say there
-  // should be a button somewhere below to view the full version. This is more of
-  // a "Summary"
-  let [content] =
-  useMemo(() => summarize(props.description, maxWordsInSummary), [props.description])
-
-  if (content === '' || content === null) {
-    content = ''
-  }
+  const { description } = props
 
   return (
     <div className='w-full'>
@@ -58,19 +47,19 @@ export function PanelHeader (props: PanelHeaderProps): JSX.Element {
       <div className='border-slate-500 border-l-2 mx-6 md:mx-8 lg:mx-16' />
 
       {
-      // We only show description if such data is available. In the future it will make
-      // sense to allow users to add or edit these descriptions if they feel the need to.
-      content !== ''
-        ? (
-          <div className='mt-2'>
-            <h3 className='font-semibold tracking-tight'>Description</h3>
-            <div className='my-2 whitespace-pre-line'>
-              {content}
+        // We only show description if such data is available. In the future it will make
+        // sense to allow users to add or edit these descriptions if they feel the need to.
+        description !== ''
+          ? (
+            <div className='mt-2'>
+              <h3 className='font-semibold tracking-tight'>Description</h3>
+              <div className='my-2 whitespace-pre-line'>
+                <Description cont={description} maxLength={maxWordsInSummary} />
+              </div>
             </div>
-          </div>
-          )
-        : ''
-}
+            )
+          : ''
+      }
 
     </div>
   )

--- a/src/components/crag/cragSummary.tsx
+++ b/src/components/crag/cragSummary.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo, useRef, useState } from 'react'
+import React from 'react'
 import { AreaMetadataType, CountByGroupType } from '../../js/types'
+import Description from '../ui/Description'
 // import FavouriteButton from '../users/FavouriteButton'
 
 export interface CragHeroProps {
@@ -82,59 +83,6 @@ function getMapHref (lat: number, lng: number): string {
   return `https://www.google.com/maps/search/${lng},+${lat}`
 }
 
-function Description ({ cont }: {cont: string}): JSX.Element {
-  const maxLength = 100 // words
-  const [showFull, setShow] = useState(false)
-  const [content, overflowText] = useMemo(() => summarize(cont, maxLength), [cont])
-  const overflow = overflowText.length > 0
-  const descRef = useRef<HTMLParagraphElement>(null)
-
-  if (overflow) {
-    const overflowHeight = descRef.current !== null ? descRef.current?.clientHeight : 500
-    return (
-      <div className='transition'>
-        <p>
-          {content}
-          {' '}
-          <button
-            onClick={() => setShow(!showFull)}
-            className={`text-blue-600 underline transition
-            ${showFull ? 'opacity-0' : 'opacity-1'}`}
-          >
-            See full description
-          </button>
-        </p>
-
-        <div
-          className='overflow-y-hidden'
-          style={{
-            transition: 'max-height 0.2s ease-in-out',
-            maxHeight: !showFull ? '0px' : `${overflowHeight}px`
-          }}
-        >
-          <p ref={descRef}>
-            {overflowText}
-            {' '}
-            <button
-              onClick={() => setShow(!showFull)}
-              className={`text-blue-600 underline transition
-          ${showFull ? 'opacity-1' : 'opacity-0'}`}
-            >
-              Hide full description
-            </button>
-          </p>
-        </div>
-
-      </div>
-    )
-  }
-  return (
-    <div>
-      {content !== '' ? content : 'This crag has no description'}
-    </div>
-  )
-}
-
 /**
  * Responsive summary of major attributes for a crag / boulder.
  * This could actually be extended to giving area summaries as well.
@@ -165,7 +113,7 @@ export default function CragSummary (props: CragHeroProps): JSX.Element {
       </div> */}
 
       <div className='mt-6'>
-        <Description cont={props.description} />
+        <Description cont={props.description} maxLength={100} />
       </div>
     </div>
   )

--- a/src/components/ui/Description.tsx
+++ b/src/components/ui/Description.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo, useRef, useState } from 'react'
+import { summarize } from '../crag/cragSummary'
+
+interface Props { cont: string, maxLength: number }
+
+/**
+ * A description component with view more / view less behavior
+ * * `cont`: content to display in paragraph
+ * * `maxLength`: max number of words until truncated to nearest sentence
+ */
+function Description ({ cont, maxLength }: Props): JSX.Element {
+  const [showFull, setShow] = useState(false)
+  const [content, overflowText] = useMemo(() => summarize(cont, maxLength), [cont])
+  const overflow = overflowText.length > 0
+  const descRef = useRef<HTMLParagraphElement>(null)
+
+  if (overflow) {
+    const overflowHeight = descRef.current !== null ? descRef.current?.clientHeight : 500
+    return (
+      <div data-testid='description' className='transition'>
+        <p>
+          {content}&nbsp;
+          <button
+            data-testid='show-button'
+            onClick={() => setShow(!showFull)}
+            className={`text-blue-600 underline transition
+              ${showFull ? 'opacity-0' : 'opacity-1'}`}
+          >
+            See full description
+          </button>
+        </p>
+
+        <div
+          data-testid='description-hidden-section'
+          className='overflow-y-hidden'
+          style={{
+            transition: 'max-height 0.2s ease-in-out',
+            maxHeight: !showFull ? '0px' : `${overflowHeight}px`
+          }}
+        >
+          <p ref={descRef} aria-hidden={!showFull ? 'true' : 'false'}>
+            {overflowText}&nbsp;
+            <button
+              data-testid='hide-button'
+              onClick={() => setShow(!showFull)}
+              className={`text-blue-600 underline transition
+            ${showFull ? 'opacity-1' : 'opacity-0'}`}
+            >
+              Hide full description
+            </button>
+          </p>
+        </div>
+
+      </div>
+    )
+  }
+  return (
+    <div>
+      {content !== '' ? content : 'No description found'}
+    </div>
+  )
+}
+
+export default Description

--- a/src/components/ui/__tests__/Description.tsx
+++ b/src/components/ui/__tests__/Description.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+import Description from '../Description'
+
+const loremIpsum49Words = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Aenean sed adipiscing diam donec adipiscing tristique risus. Vestibulum sed arcu non odio. Praesent semper feugiat nibh sed pulvinar proin gravida hendrerit lectus. Amet consectetur adipiscing elit duis tristique sollicitudin. '
+
+test('Description renders and shows words', async () => {
+  render(
+    <Description cont={loremIpsum49Words} maxLength={50} />
+  )
+  const paragraphContent = screen.getByText(/sed do eiusmod tempor incididunt ut labore et dolore magna aliqua/i)
+  expect(paragraphContent).toBeInTheDocument()
+})
+
+test('See full description link not present when content less than 50 words', async () => {
+  render(
+    <Description cont={loremIpsum49Words} maxLength={50} />
+  )
+  const paragraphContent = screen.queryByText(/See full description/i)
+  expect(paragraphContent).not.toBeInTheDocument()
+})
+
+test('See/hide full description link not present when content less than maxLength', async () => {
+  render(
+    <Description cont={loremIpsum49Words} maxLength={49} />
+  )
+  const seeFullDescription = screen.queryByText(/See full description/i)
+  const hideFullDescription = screen.queryByText(/Hide full description/i)
+  expect(seeFullDescription).not.toBeInTheDocument()
+  expect(hideFullDescription).not.toBeInTheDocument()
+})


### PR DESCRIPTION
I repurposed the Description from the crag summary components since it had a read more/less behavior.

@vnugent Is this approach of using transitions of maxheight to show/hide text instead of removing it from the dom preferred? I suppose this approach gives us the ability to have smooth transitions where other approaches wouldn't. 