### PR TITLE
Temp fix for areas with many photos

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "next": "12.3.0",
     "next-auth": "4.10.3",
     "nprogress": "^0.2.0",
+    "probe-image-size": "^7.2.3",
     "raw-body": "^2.5.1",
     "rc-slider": "^10.0.0-alpha.5",
     "react": "^18.0.0",

--- a/src/js/stores/media.ts
+++ b/src/js/stores/media.ts
@@ -154,8 +154,6 @@ export const userMediaStore = createStore('userMedia')(INITIAL_STATE, STORE_OPTS
      * @returns
      */
     setPhotoList: async (photoList: MediaBaseTag[] | []) => {
-      console.log(photoList)
-
       set.photoList(photoList)
     }
   }))

--- a/src/js/utils/hacks.ts
+++ b/src/js/utils/hacks.ts
@@ -1,0 +1,30 @@
+import probe from 'probe-image-size'
+import { MediaBaseTag } from '../types'
+import { SIRV_CONFIG } from '../sirv/SirvClient'
+
+/**
+ * Use a 3rd-party lib to get image width and height at build time
+ * @param mediaList
+ * @returns media list with width & height
+ */
+export const getImageDimensionsHack = async (mediaList: MediaBaseTag[]): Promise<any[]> => {
+  return await Promise.all(mediaList.map(async (entry) => {
+    try {
+      const img = await probe(`${SIRV_CONFIG.baseUrl}${entry.mediaUrl}`)
+      return {
+        ...entry,
+        mediaInfo: {
+          meta: {
+            width: img.width,
+            height: img.height
+          }
+        }
+      }
+    } catch (e) {
+      return {
+        ...entry,
+        mediaInfo: null
+      }
+    }
+  }))
+}

--- a/src/pages/areas/[id].tsx
+++ b/src/pages/areas/[id].tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react'
 import { NextPage, GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
-// import { indexBy } from 'underscore'
 
 import { QUERY_AREA_BY_ID } from '../../js/graphql/gql/areaById'
 import { AreaType, MediaBaseTag, ChangesetType } from '../../js/types'
@@ -17,7 +16,6 @@ import PhotoMontage from '../../components/media/PhotoMontage'
 import { enhanceMediaListWithUsernames } from '../../js/usernameUtil'
 import { useAreaSeo } from '../../js/hooks/seo'
 import AreaEditTrigger from '../../components/edit/AreaEditTrigger'
-// import { getImagesByFilenames } from '../../js/sirv/SirvClient'
 import { getImageDimensionsHack } from '../../js/utils/hacks'
 
 interface AreaPageProps {

--- a/src/pages/areas/[id].tsx
+++ b/src/pages/areas/[id].tsx
@@ -122,37 +122,19 @@ const Body = ({ area, mediaListWithUsernames: enhancedMediaList, history }: Area
   )
 }
 
-// This function gets called at build time.
-// Nextjs uses the result to decide which paths will get pre-rendered at build time
+/**
+ * This function gets called at build time.
+ * Nextjs uses the result to decide which paths will get pre-rendered at build time
+ */
 export async function getStaticPaths (): Promise<any> {
-  // Temporarily disable pre-rendering
-  // https://github.com/OpenBeta/openbeta-graphql/issues/26
-  // const rs = await graphqlClient.query<AreaResponseType>({
-  //   query: gql`query EdgeAreasQuery($filter:Filter) {
-  //   areas(filter: $filter) {
-  //     area_name
-  //     metadata {
-  //       area_id
-  //     }
-  //   }
-  // }`,
-  //   variables: {
-  //     filter: { leaf_status: { isLeaf: false } }
-  //   }
-  // })
-
-  // // Get the paths we want to pre-render based on posts
-  // const paths = rs.data.areas.map((area: AreaType) => ({
-  //   params: { id: area.metadata.area_id }
-  // }))
-
-  // We'll pre-render only these paths at build time.
-  // { fallback: true } means render on first reques for those that are not in `paths`
   return {
     paths: [
-      { params: { id: 'bea6bf11-de53-5046-a5b4-b89217b7e9bc' } },
-      { params: { id: 'decc1251-4a67-52b9-b23f-3243e10e93d0' } },
-      { params: { id: '78da26bc-cd94-5ac8-8e1c-815f7f30a28b' } }
+      { params: { id: 'bea6bf11-de53-5046-a5b4-b89217b7e9bc' } }, // Red Rock
+      { params: { id: '78da26bc-cd94-5ac8-8e1c-815f7f30a28b' } }, // Red River Gorge
+      { params: { id: '1db1e8ba-a40e-587c-88a4-64f5ea814b8e' } }, // USA
+      { params: { id: 'ab48aed5-2e8d-54bb-b099-6140fe1f098f' } }, // Colorado
+      { params: { id: 'decc1251-4a67-52b9-b23f-3243e10e93d0' } }, // Boulder
+      { params: { id: 'f166e672-4a52-56d3-94f1-14c876feb670' } } // Indian Creek
     ],
     fallback: true
   }

--- a/src/pages/areas/[id].tsx
+++ b/src/pages/areas/[id].tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from 'react'
 import { NextPage, GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
-import { indexBy } from 'underscore'
+// import { indexBy } from 'underscore'
+
 import { QUERY_AREA_BY_ID } from '../../js/graphql/gql/areaById'
-import { AreaType, MediaBaseTag, MediaType, ChangesetType } from '../../js/types'
+import { AreaType, MediaBaseTag, ChangesetType } from '../../js/types'
 import { graphqlClient } from '../../js/graphql/Client'
 import Layout from '../../components/layout'
 import SeoTags from '../../components/SeoTags'
@@ -16,7 +17,9 @@ import PhotoMontage from '../../components/media/PhotoMontage'
 import { enhanceMediaListWithUsernames } from '../../js/usernameUtil'
 import { useAreaSeo } from '../../js/hooks/seo'
 import AreaEditTrigger from '../../components/edit/AreaEditTrigger'
-import { getImagesByFilenames } from '../../js/sirv/SirvClient'
+// import { getImagesByFilenames } from '../../js/sirv/SirvClient'
+import { getImageDimensionsHack } from '../../js/utils/hacks'
+
 interface AreaPageProps {
   area: AreaType
   history: ChangesetType[]
@@ -164,56 +167,33 @@ export const getStaticProps: GetStaticProps<AreaPageProps, {id: string}> = async
     }
   }
 
-  let rs
-  try {
-    rs = await graphqlClient.query<{ area: AreaType, getAreaHistory: ChangesetType[] }>({
-      query: QUERY_AREA_BY_ID,
-      variables: {
-        uuid: params.id
-      },
-      fetchPolicy: 'no-cache'
-    })
+  const rs = await graphqlClient.query<{ area: AreaType, getAreaHistory: ChangesetType[] }>({
+    query: QUERY_AREA_BY_ID,
+    variables: {
+      uuid: params.id
+    },
+    fetchPolicy: 'no-cache'
+  })
 
-    if (rs.data.area == null) {
-      return {
-        notFound: true,
-        revalidate: 10
-      }
-    }
-
-    let mediaListWithUsernames: MediaBaseTag[] = rs.data.area.media
-    try {
-      mediaListWithUsernames = await enhanceMediaListWithUsernames(rs.data.area.media)
-    } catch (e) {
-      console.log('Error when trying to add username to image data', e)
-    }
-
-    /**
-     * Call Sirv API to get image metadata.  We should probably store metadata in the db.
-     */
-    const mediaListWithMetadata = await getImagesByFilenames(mediaListWithUsernames.map(entry => entry.mediaUrl))
-
-    const mediaMetaDict = indexBy<MediaType[]>(mediaListWithMetadata.mediaList, 'mediaId')
-
-    // Pass Area & edit history data to the page via props
+  if (rs.data.area == null) {
     return {
-      props: {
-        area: rs.data.area,
-        history: rs.data.getAreaHistory,
-        mediaListWithUsernames: mediaListWithUsernames.map(entry => ({ ...entry, mediaInfo: mediaMetaDict?.[entry.mediaUuid] ?? null }))
-      },
-      revalidate: 10
-    }
-  } catch (e) {
-    console.log('#GraphQL exception:', e)
-    console.log('#', e?.result)
-    return {
-      // TODO: the area may be in the db but we're having some issue.
-      // As an improvement, maybe return empty props and display a friendlier error page than 404
       notFound: true,
-
       revalidate: 10
     }
+  }
+
+  const mediaListWithUsernames = await enhanceMediaListWithUsernames(rs.data.area.media)
+
+  const mediaListWithDimensions = await getImageDimensionsHack(mediaListWithUsernames)
+
+  // Pass Area & edit history data to the page via props
+  return {
+    props: {
+      area: rs.data.area,
+      history: rs.data.getAreaHistory,
+      mediaListWithUsernames: mediaListWithDimensions
+    },
+    revalidate: 10
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,6 +2780,13 @@ debounce-promise@^3.1.0:
   resolved "https://registry.yarnpkg.com/debounce-promise/-/debounce-promise-3.1.2.tgz#320fb8c7d15a344455cd33cee5ab63530b6dc7c5"
   integrity sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg==
 
+debug@2, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -2787,14 +2794,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
-debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.2.7:
+debug@^3.2.6, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -3869,7 +3869,7 @@ i18n-iso-countries@^7.5.0:
   dependencies:
     diacritics "1.3.0"
 
-iconv-lite@0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5165,6 +5165,15 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+needle@^2.5.2:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.9.1.tgz#22d1dffbe3490c2b83e301f7709b6736cd8f2684"
+  integrity sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
 next-auth@4.10.3:
   version "4.10.3"
   resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.10.3.tgz#0a952dd5004fd2ac2ba414c990922cf9b33951a3"
@@ -5673,6 +5682,15 @@ prismjs@^1.27.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
+probe-image-size@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-7.2.3.tgz#d49c64be540ec8edea538f6f585f65a9b3ab4309"
+  integrity sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==
+  dependencies:
+    lodash.merge "^4.6.2"
+    needle "^2.5.2"
+    stream-parser "~0.3.1"
 
 progress@^2.0.0:
   version "2.0.3"
@@ -6253,7 +6271,7 @@ sax@1.2.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
   integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
 
-sax@>=0.6.0:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -6463,6 +6481,13 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+stream-parser@~0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/stream-parser/-/stream-parser-0.3.1.tgz#1618548694420021a1182ff0af1911c129761773"
+  integrity sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==
+  dependencies:
+    debug "2"
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Issue #646 
- Use an [image probing lib](https://www.npmjs.com/package/probe-image-size) to get width & height at build time for area page, bypassing Sirv API.
- Let NextJS handle exceptions in getStaticProps()