### PR TITLE
feat(nav): add shadow to breadcrumbs sticky

### DIFF
--- a/src/components/crag/StickyHeader.tsx
+++ b/src/components/crag/StickyHeader.tsx
@@ -1,20 +1,40 @@
+import { useRef } from 'react'
+import { useIntersection } from 'react-use'
+import clx from 'classnames'
+
 import BreadCrumbs from '../ui/BreadCrumbs'
 
 interface StickyBreadCrumbsProps {
   isClimbPage?: boolean
   ancestors: string[]
   pathTokens: string[]
+  /** Additional form action to be display along side with the breadcrumbs */
   formAction: JSX.Element
 }
 
 /**
- * Sticky header containing breadcrumbs and save/reset button in edit mode
+ * Sticky header containing breadcrumbs and save/reset button in edit mode.
+ *
+ * More on intersecton observer: https://css-tricks.com/an-explanation-of-how-the-intersection-observer-watches/ for
  */
 export const StickyHeader = ({ isClimbPage = false, ancestors, pathTokens, formAction }: StickyBreadCrumbsProps): JSX.Element => {
+  const intersectionRef = useRef(null)
+
+  /**
+   * Creating an intersection hook to be notified when div reaches become 'sticky'
+   * aka reaches the top.
+   */
+  const intersection = useIntersection(intersectionRef, {
+    root: null,
+    rootMargin: '0px 0px -100% 0px'
+  })
+  const atTop = intersection?.isIntersecting ?? false
+
   return (
-    <div className='sticky top-0 z-40 py-2 lg:min-h-[4rem] block lg:flex lg:items-center lg:justify-between bg-base-100 -mx-4 px-4'>
+    <div ref={intersectionRef} className={clx('sticky top-0 z-40 py-2 lg:min-h-[4rem] block lg:flex lg:items-center lg:justify-between bg-base-100 md:-mx-6 md:px-6', atTop ? 'border-b bottom-shadow backdrop-blur-sm bg-opacity-90' : '')}>
       <BreadCrumbs isClimbPage={isClimbPage} ancestors={ancestors} pathTokens={pathTokens} />
       <div className='hidden lg:block'>
+        {/* only visible at lg or wider */}
         {formAction}
       </div>
     </div>

--- a/src/components/crag/StickyHeader.tsx
+++ b/src/components/crag/StickyHeader.tsx
@@ -31,7 +31,7 @@ export const StickyHeader = ({ isClimbPage = false, ancestors, pathTokens, formA
   const atTop = intersection?.isIntersecting ?? false
 
   return (
-    <div ref={intersectionRef} className={clx('sticky top-0 z-40 py-2 lg:min-h-[4rem] block lg:flex lg:items-center lg:justify-between bg-base-100 md:-mx-6 md:px-6', atTop ? 'border-b bottom-shadow backdrop-blur-sm bg-opacity-90' : '')}>
+    <div ref={intersectionRef} className={clx('sticky top-0 z-40 py-2 lg:min-h-[4rem] block lg:flex lg:items-center lg:justify-between bg-base-100 -mx-6 px-6', atTop ? 'border-b bottom-shadow backdrop-blur-sm bg-opacity-90' : '')}>
       <BreadCrumbs isClimbPage={isClimbPage} ancestors={ancestors} pathTokens={pathTokens} />
       <div className='hidden lg:block'>
         {/* only visible at lg or wider */}

--- a/src/styles/defaults.css
+++ b/src/styles/defaults.css
@@ -365,6 +365,9 @@ input:checked + label {
   animation: fadeIn 1s;
 }
 
+.bottom-shadow {
+  box-shadow: 0 4px 2px -2px rgb(240, 240, 240);
+}
 /* make nprogress bar thicker */
 #nprogress .bar {
   height: 8px !important;


### PR DESCRIPTION
A follow up PR to visually elevate the sticky header (introduced by https://github.com/OpenBeta/open-tacos/pull/657) 


Before
---
<img width="411" alt="Screen Shot 2023-01-25 at 9 36 46 AM" src="https://user-images.githubusercontent.com/3805254/214516750-f30503df-4602-4cdc-8a5f-38b0777cc55e.png">


---

After
---
<img width="484" alt="Screen Shot 2023-01-25 at 9 28 07 AM" src="https://user-images.githubusercontent.com/3805254/214516237-b9b21aad-e9da-49db-983d-298201594863.png">
