### PR TITLE
fix: added position relative to the anchor tag containing the post image

### DIFF
--- a/src/components/home/RecentMediaCard.tsx
+++ b/src/components/home/RecentMediaCard.tsx
@@ -19,7 +19,10 @@ interface RecentImageCardProps {
 /**
  * Image card for the home page
  */
-export const RecentImageCard = ({ imageInfo, tagList }: RecentImageCardProps): JSX.Element => {
+export const RecentImageCard = ({
+  imageInfo,
+  tagList
+}: RecentImageCardProps): JSX.Element => {
   const [loaded, setLoaded] = useState(false)
   const { filename, meta } = imageInfo
   const { width, height } = meta
@@ -30,7 +33,7 @@ export const RecentImageCard = ({ imageInfo, tagList }: RecentImageCardProps): J
       header={<PostHeader username={tagList[0].uid} />}
       image={
         <Link href={firstUrl ?? '#'}>
-          <a>
+          <a className='relative'>
             <img
               src={MobileLoader({
                 src: filename,
@@ -41,7 +44,16 @@ export const RecentImageCard = ({ imageInfo, tagList }: RecentImageCardProps): J
               sizes='100vw'
               onLoad={() => setLoaded(true)}
             />
-            <div className={clx('absolute top-0 left-0 w-full h-full', loaded ? 'bg-transparent' : 'bg-gray-50 bg-opacity-60 border animate-pulse')}>{loaded}</div>
+            <div
+              className={clx(
+                'absolute top-0 left-0 w-full h-full',
+                loaded
+                  ? 'bg-transparent'
+                  : 'bg-gray-50 bg-opacity-60 border animate-pulse'
+              )}
+            >
+              {loaded}
+            </div>
           </a>
         </Link>
       }
@@ -58,10 +70,9 @@ export const RecentImageCard = ({ imageInfo, tagList }: RecentImageCardProps): J
             <span className='uppercase text-xs text-base-200'>
               {getUploadDateSummary(imageInfo.ctime)}
             </span>
-
           </section>
         </>
-}
+      }
     />
   )
 }


### PR DESCRIPTION
Fix for #688 

The `loaded` component in `RecentMediaCard.tsx` has a `position : absolute` and takes the entire width and height of its first parent element with a position of relative.

 `<div className={clx('absolute top-0 left-0 w-full h-full', loaded ? 'bg-transparent' : 'bg-gray-50 bg-opacity-60 border animate-pulse')}>{loaded}</div>`

The first parent element with `position: relative` was the `<Card/>` component with the `card` class so the `loaded` component takes up the entire height and width of the card which is why clicking on the username takes the user to the tagged page.
![image](https://user-images.githubusercontent.com/69164301/217634402-8716ad96-22cf-467f-99c1-4aa846e8549d.png)


The fix was as simple as adding a `position : relative` to the anchor/link tag containing the image.