### PR TITLE
Fix `updateMyProfile` bug that is blocking users from updating profiles without specifying a website

### DIFF
--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -26,12 +26,12 @@ interface PercentAndColor {
  * @returns {percents: [], colors:[]}
  */
 export const computeClimbingPercentsAndColors = (climbs: ClimbType[]): PercentAndColor => {
-  const typeToCount: {[key: string]: number} = {}
+  const typeToCount: { [key: string]: number } = {}
   climbs.forEach((climb) => {
     const { type } = climb
 
     Object.entries(type).reduce<Record<string, number>>(
-      (acc: {[key: string]: number}, [key, discipline]: [string, boolean]) => {
+      (acc: { [key: string]: number }, [key, discipline]: [string, boolean]) => {
         if (!discipline) return acc
         if (acc[key] !== undefined) {
           acc[key] = acc[key] + 1
@@ -105,7 +105,7 @@ export const sanitizeName = (s: string): string =>
  * @example {sport: true, boulder: false, trad: false} => {sport: true}
  * @param  type Climb type key-value dictionary
  */
-export const simplifyClimbTypeJson = (type?: ClimbDisciplineRecord): {[key: string]: boolean} => {
+export const simplifyClimbTypeJson = (type?: ClimbDisciplineRecord): { [key: string]: boolean } => {
   if (type === undefined) return {}
   for (const key in type) {
     if (type[key] === false) {
@@ -162,17 +162,18 @@ const regUsernameKeywords = /openbeta|0penbeta|admin/i
  */
 export const checkUsername = (uid: string): boolean => {
   return uid != null && uid.length <= 30 &&
-  !regUsernameKeywords.test(uid) &&
-  regUsername.test(uid)
+    !regUsernameKeywords.test(uid) &&
+    regUsername.test(uid)
 }
 
 /**
- * Website URL validation.
- * If no protocol is specified, it will default to https,
- * if it is specified, it must be https.
+ * Website URL validation and correction.
+ * Websites are validated with the URL function.
+ * Upon the first failure, a prefix of https:// will be added and the function will be called again.
+ * On the second failure null is returned.
  *
  * @param url
- * @returns true if valid website URL
+ * @returns a potentially altered valid url if immediately possible, null otherwise
  */
 export const checkWebsiteUrl = (url: string | null | undefined, allowRetest?: boolean): string | null => {
   if (typeof url !== 'string') return null
@@ -220,7 +221,7 @@ export const getUploadDateSummary = (dateUploaded: Date): string => {
  * @param dest
  * @returns url for the given destination type (area or climb) and destination uid
  */
-export const urlResolver = (type: number, dest: string|null): string | null => {
+export const urlResolver = (type: number, dest: string | null): string | null => {
   if (dest == null) return null
   switch (type) {
     case 0:
@@ -237,7 +238,7 @@ export const urlResolver = (type: number, dest: string|null): string | null => {
 /**
  * Create a Google Maps link from latitude and longitude
  */
-export const getMapHref = ({ lat, lng }: { lat: number, lng: number}): string => {
+export const getMapHref = ({ lat, lng }: { lat: number, lng: number }): string => {
   return `https://www.google.com/maps/place/${lat},${lng}`
 }
 

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -26,12 +26,12 @@ interface PercentAndColor {
  * @returns {percents: [], colors:[]}
  */
 export const computeClimbingPercentsAndColors = (climbs: ClimbType[]): PercentAndColor => {
-  const typeToCount: { [key: string]: number } = {}
+  const typeToCount: {[key: string]: number} = {}
   climbs.forEach((climb) => {
     const { type } = climb
 
     Object.entries(type).reduce<Record<string, number>>(
-      (acc: { [key: string]: number }, [key, discipline]: [string, boolean]) => {
+      (acc: {[key: string]: number}, [key, discipline]: [string, boolean]) => {
         if (!discipline) return acc
         if (acc[key] !== undefined) {
           acc[key] = acc[key] + 1
@@ -105,7 +105,7 @@ export const sanitizeName = (s: string): string =>
  * @example {sport: true, boulder: false, trad: false} => {sport: true}
  * @param  type Climb type key-value dictionary
  */
-export const simplifyClimbTypeJson = (type?: ClimbDisciplineRecord): { [key: string]: boolean } => {
+export const simplifyClimbTypeJson = (type?: ClimbDisciplineRecord): {[key: string]: boolean} => {
   if (type === undefined) return {}
   for (const key in type) {
     if (type[key] === false) {
@@ -162,8 +162,8 @@ const regUsernameKeywords = /openbeta|0penbeta|admin/i
  */
 export const checkUsername = (uid: string): boolean => {
   return uid != null && uid.length <= 30 &&
-    !regUsernameKeywords.test(uid) &&
-    regUsername.test(uid)
+  !regUsernameKeywords.test(uid) &&
+  regUsername.test(uid)
 }
 
 /**
@@ -221,7 +221,7 @@ export const getUploadDateSummary = (dateUploaded: Date): string => {
  * @param dest
  * @returns url for the given destination type (area or climb) and destination uid
  */
-export const urlResolver = (type: number, dest: string | null): string | null => {
+export const urlResolver = (type: number, dest: string|null): string | null => {
   if (dest == null) return null
   switch (type) {
     case 0:
@@ -238,7 +238,7 @@ export const urlResolver = (type: number, dest: string | null): string | null =>
 /**
  * Create a Google Maps link from latitude and longitude
  */
-export const getMapHref = ({ lat, lng }: { lat: number, lng: number }): string => {
+export const getMapHref = ({ lat, lng }: { lat: number, lng: number}): string => {
   return `https://www.google.com/maps/place/${lat},${lng}`
 }
 

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -37,7 +37,7 @@ const updateMyProfile: Handler = async (req, res) => {
 
     // validate that URL is properly formatted if one is provided
     let website = req.body?.website
-    if (website !== null && website !== "") {
+    if (website != null && website !== '') {
       website = checkWebsiteUrl(req.body?.website)
       if (website == null) {
         throw new Error('Bad website URL')

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -34,9 +34,16 @@ const updateMyProfile: Handler = async (req, res) => {
     if (!checkUsername(req.body?.nick)) {
       throw new Error('Bad username')
     }
-    // validate that URL is properly formatted
-    const website = checkWebsiteUrl(req.body?.website)
-    if (website == null) { throw new Error('Bad website URL') }
+
+    // validate that URL is properly formatted if one is provided
+    let website = req.body?.website
+    if (website !== null) {
+      website = checkWebsiteUrl(req.body?.website)
+      if (website == null) {
+        throw new Error('Bad website URL')
+      }
+    }
+
     if (req.body?.name?.length > 150 || req.body?.bio?.length > 150 || req?.body?.uuid == null) {
       throw new Error('Bad profile data')
     }

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -37,7 +37,7 @@ const updateMyProfile: Handler = async (req, res) => {
 
     // validate that URL is properly formatted if one is provided
     let website = req.body?.website
-    if (website !== null) {
+    if (website !== null && website !== "") {
       website = checkWebsiteUrl(req.body?.website)
       if (website == null) {
         throw new Error('Bad website URL')


### PR DESCRIPTION
If a user does not enter a website (for example, if they are a new user attempting to simply edit their username) they will get an error.

I think this utility function is confusing and should either be renamed to betray the fact that it is not just a check, or it should be changed to a simple check with the correction logic being moved elsewhere. 

I also think the unnecessary recursion should be removed.

These are out of scope though. This PR simply fixes the bug that is affecting users without altering the `checkWebsiteUrl` function at all.

A secondary issue is that these specific error messages are not being propagated to the front end. That would have made debugging easier, and would have given me a bit more feedback as a normal user as to what was going on. 