### PR TITLE
fix: Allow spaces in coordinates

### DIFF
--- a/src/components/edit/EditAreaForm.tsx
+++ b/src/components/edit/EditAreaForm.tsx
@@ -9,7 +9,7 @@ import { AreaType, AreaUpdatableFieldsType, RulesType } from '../../js/types'
 import { areaDesignationToForm, areaDesignationToDb, AreaTypeFormProp, AreaDesignationRadioGroup } from './form/AreaDesignationRadioGroup'
 import useUpdateAreasCmd from '../../js/hooks/useUpdateAreasCmd'
 
-export const LATLNG_PATTERN = /(?<lat>^[-+]?(?:[1-8]?\d(?:\.\d+)?|90(?:\.0+)?)),(?<lng>[-+]?(?:180(?:\.0+)?|(?:1[0-7]\d|[1-9]?\d)(?:\.\d+)?))$/
+export const LATLNG_PATTERN = /^\s*(?<lat>[-+]?(?:[1-8]?\d(?:\.\d+)?|90(?:\.0+)?))\s*,\s*(?<lng>[-+]?(?:180(?:\.0+)?|(?:1[0-7]\d|[1-9]?\d)(?:\.\d+)?))\s*$/
 
 export const AREA_NAME_FORM_VALIDATION_RULES: RulesType = {
   required: 'A name is required.',


### PR DESCRIPTION
The editor checks user-provided latitude and longitude string string for two numbers separated by a comma.  This excludes common but unambiguous ways of formatting such strings with additional spaces.

Update `LATLNG_PATTERN` to allow for spaces on either side of either number.

Fixes #730