### PR TITLE
Firing a toast when importing ticks is successful

### DIFF
--- a/src/components/users/ImportFromMtnProj.tsx
+++ b/src/components/users/ImportFromMtnProj.tsx
@@ -3,6 +3,7 @@ import { Transition } from '@headlessui/react'
 import { FolderArrowDownIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { useMutation } from '@apollo/client'
 import { useSession } from 'next-auth/react'
+import { toast } from 'react-toastify'
 import { graphqlClient } from '../../js/graphql/Client'
 import { Button, ButtonVariant } from '../ui/BaseButton'
 import { MUTATION_IMPORT_TICKS } from '../../js/graphql/gql/fragments'
@@ -71,6 +72,7 @@ export function ImportFromMtnProj ({ isButton }: Props): JSX.Element {
             input: ticks
           }
         })
+        toast.info('Your ticks have been imported!')
       } else {
         setErrors(['Sorry, something went wrong. Please try again later'])
       }

--- a/src/components/users/ImportFromMtnProj.tsx
+++ b/src/components/users/ImportFromMtnProj.tsx
@@ -73,7 +73,7 @@ export function ImportFromMtnProj ({ isButton }: Props): JSX.Element {
           }
         })
 
-        const ticksCount = ticks?.length ?? 0;
+        const ticksCount: number = ticks?.length ?? 0
         toast.info(`${ticksCount} ticks have been imported!`)
       } else {
         setErrors(['Sorry, something went wrong. Please try again later'])

--- a/src/components/users/ImportFromMtnProj.tsx
+++ b/src/components/users/ImportFromMtnProj.tsx
@@ -72,7 +72,9 @@ export function ImportFromMtnProj ({ isButton }: Props): JSX.Element {
             input: ticks
           }
         })
-        toast.info('Your ticks have been imported!')
+
+        const ticksCount = ticks?.length ?? 0;
+        toast.info(`${ticksCount} ticks have been imported!`)
       } else {
         setErrors(['Sorry, something went wrong. Please try again later'])
       }


### PR DESCRIPTION
# Firing a toast when importing ticks is successful

## Description
Related to issue https://github.com/OpenBeta/open-tacos/issues/733

Importing ticks used to give no feedback besides adding the ticks themselves. When trying the feature without ticks in my Mountain Project profile, I thought something went wrong and tried again.

This PR fixes the issue by adding a toast message of type info saying "<number> ticks have been imported!".

## Screenshot
<img width="1124" alt="image" src="https://user-images.githubusercontent.com/508428/226114039-a20309c8-6493-4d11-9542-85936a373396.png">
