### PR TITLE
chore: #749 add application level error handling to log graphQL errors

### DIFF
--- a/src/js/graphql/Client.ts
+++ b/src/js/graphql/Client.ts
@@ -8,18 +8,20 @@ const httpLinkPro = new HttpLink({
 const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors !== null && graphQLErrors !== undefined) {
     graphQLErrors.forEach(({ message, locations, path }) => {
-      console.error('GraphQL error',  
-      { message: message , locations: locations, path:path })
+      console.error('GraphQL error', {
+        message: message,
+        locations: locations,
+        path: path
+      })
     })
   }
 
   if (networkError !== null && networkError !== undefined) {
-    console.error('Network error',
-    {
-      name:networkError.name,
-      statusCode:networkError.statusCode,
-      erros:JSON.stringify(networkError.result),
-      extentions:JSON.stringify(networkError.extensions),
+    console.error('Network error', {
+      name: networkError.name,
+      statusCode: networkError.statusCode,
+      erros: JSON.stringify(networkError.result),
+      extentions: JSON.stringify(networkError.extensions)
     })
   }
 })

--- a/src/js/graphql/Client.ts
+++ b/src/js/graphql/Client.ts
@@ -6,8 +6,8 @@ const httpLinkPro = new HttpLink({
   uri: uri
 })
 const errorLink = onError(({ graphQLErrors, networkError }) => {
-  if (graphQLErrors !== null && graphQLErrors !== undefined) {
-    graphQLErrors.forEach(({ message, locations, path }) => {
+  if (graphQLErrors != null) {
+    graphQLErrors?.forEach(({ message, locations, path }) => {
       console.error('GraphQL error', {
         message: message,
         locations: locations,
@@ -16,12 +16,10 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
     })
   }
 
-  if (networkError !== null && networkError !== undefined) {
+  if (networkError != null) {
     console.error('Network error', {
       name: networkError.name,
-      statusCode: networkError.statusCode,
-      erros: JSON.stringify(networkError.result),
-      extentions: JSON.stringify(networkError.extensions)
+      detail: JSON.stringify(networkError)
     })
   }
 })

--- a/src/js/graphql/Client.ts
+++ b/src/js/graphql/Client.ts
@@ -8,16 +8,19 @@ const httpLinkPro = new HttpLink({
 const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors !== null && graphQLErrors !== undefined) {
     graphQLErrors.forEach(({ message, locations, path }) => {
-      console.log(
-        `[GraphQL error]: Message: ${message}, Location: ${JSON.stringify(
-          locations ?? []
-        )}, Path: ${JSON.stringify(path ?? [])}`
-      )
+      console.error('GraphQL error',  
+      { message: message , locations: locations, path:path })
     })
   }
 
   if (networkError !== null && networkError !== undefined) {
-    console.log(`[Network error]: ${JSON.stringify(networkError)}`)
+    console.error('Network error',
+    {
+      name:networkError.name,
+      statusCode:networkError.statusCode,
+      erros:JSON.stringify(networkError.result),
+      extentions:JSON.stringify(networkError.extensions),
+    })
   }
 })
 


### PR DESCRIPTION
#749 

Hi there,

I used `onError` link to log `graphQL` errors. and added this to both staging and production clients. 
Questions: 

1. I wasn't sure which `client` I should add it to. 
2. `concole.log()` vs. `console.error() ` the latter logs messages in red, and there are a few other differences. What is your preference? 
3. How should I test the change? 

Let me know what you think! 