### PR TITLE
Fix/ticklist revalidation

### DIFF
--- a/src/js/graphql/api.ts
+++ b/src/js/graphql/api.ts
@@ -159,7 +159,8 @@ export const getTicksByUserAndClimb = async (climbId: string, userId: string): P
       variables: {
         climbId,
         userId
-      }
+      },
+      fetchPolicy: 'no-cache'
     })
 
     if (Array.isArray(res.data?.userTicksByClimbId)) {
@@ -177,7 +178,8 @@ export const getTicksByUser = async (userId: string): Promise<TickType[]> => {
       query: QUERY_TICKS_BY_USER,
       variables: {
         userId
-      }
+      },
+      fetchPolicy: 'no-cache'
     })
 
     if (Array.isArray(res.data?.userTicks)) {

--- a/src/pages/u2/[...slug].tsx
+++ b/src/pages/u2/[...slug].tsx
@@ -70,7 +70,8 @@ export const getStaticProps: GetStaticProps<TicksIndexPageProps, {slug: string[]
     const { uuid } = userProfile
     const ticks = await getTicksByUser(uuid)
     return {
-      props: { uid, ticks }
+      props: { uid, ticks },
+      revalidate: 10
     }
   } catch (e) {
     return { notFound: true }


### PR DESCRIPTION
_Ready to go now_

I have added revalidation of tick lists after 10 seconds.  I can see in the log that the appropriate call to `getSaticProps` does happen once every 10 seconds when I continuously refresh the page.

However, this isn't yet sufficient to fix #727: the tick list doesn't change after adding ticks.  The data logged inside `getSaticProps` does not change either.


The data returned by querying the API directly through [hasura](https://cloud.hasura.io/public/graphiql?endpoint=https%3A%2F%2Fstg-api.openbeta.io%2F+&query=query+MyQuery+%7B%0A++userTicks%28userId%3A+%22c26b3c91-bb05-42a9-8f8c-b2209c55781b%22%29+%7B%0A++++_id%0A++++climbId%0A++++userId%0A++++name%0A++%7D%0A%7D%0A) does reflect ticks being added/removed.

Is there another layer of caching I'm missing?