### PR TITLE
chore: linting TypeScript in Visual Studio Code setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "git.ignoreLimitWarning": true,
+  "[typescriptreact]": {
+    "editor.formatOnType": true,
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "standard.vscode-standard"
+  },
+  "[typescript]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "standard.vscode-standard"
+  },
+  "standard.enable": true,
+  "standard.autoFixOnSave": true,
+  "standard.engine": "ts-standard",
+  "standard.treatErrorsAsWarnings": true,
+  "javascript.format.enable": false,
+  "javascript.format.semicolons": "remove",
+  "typescript.format.enable": false
+}

--- a/README.md
+++ b/README.md
@@ -122,11 +122,18 @@ By default, your local dev environment connects to our staging GraphQL API serve
 ```
 yarn dev-local
 ```
-### Build errors
-You might get build errors or be prompted to downgrade your version of TypeScript. This is due to the linter ```ts-standard``` using an older version fo TypeScript. To commit without pre-build tests because you're doing a simple/unrelated change then run: ```yarn lint``` and commit with the ```--no-verify``` flag.
+### Typescript version warning
+You might get build errors or be prompted to downgrade your version of TypeScript. This is due to the linter ```ts-standard``` using an older version of TypeScript.  You can ignore the warning message.
 
-### Linting erros
-You might get linting erros when run ```yarn lint```. To fix this, if you use VS Code,please make sure you have ```StandardJS``` extension installed and enabled.
+### Commit your work-in-progress
+To commit without passing pre-build tests because you're doing a simple/unrelated change or simply wish to save your work-in-progres, run commit with the `--no-verify` flag.  Example:
+
+```
+git commit --no-verify -am "saving my work before going climbing"
+```
+
+### Linting errors
+You might get linting errors when run ```yarn lint```. To fix this, if you use VS Code, please make sure you have ```StandardJS``` extension installed and enabled.
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ yarn dev-local
 ### Build errors
 You might get build errors or be prompted to downgrade your version of TypeScript. This is due to the linter ```ts-standard``` using an older version fo TypeScript. To commit without pre-build tests because you're doing a simple/unrelated change then run: ```yarn lint``` and commit with the ```--no-verify``` flag.
 
+### Linting erros
+You might get linting erros when run ```yarn lint```. To fix this, if you use VS Code,please make sure you have ```StandardJS``` extension installed and enabled.
+
 ## How to contribute
 
 See our general [How to contribute guide](https://docs.openbeta.io/how-to-contribute/overview) for more details.


### PR DESCRIPTION
Fix linting errors that devs might encounter. 