### PR TITLE
Encourage first time users to change their username #750

### DIFF
--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -4,30 +4,36 @@ import { ReactNode } from 'react'
 interface Props {
   content: string | ReactNode
   enabled?: boolean
-  children: JSX.Element | JSX.Element [] | null
+  hover?: boolean
+  children: JSX.Element | JSX.Element[] | null
   className?: string
+  defaultOpen?: boolean
+  side?: 'top' | 'right' | 'bottom' | 'left'
 }
 
 /**
- * A Tooltip that activates on mouse click or touch.
- * @param enabled false to disable tooltip but still render the trigger element
+ * Tooltip component displays a tooltip with custom content and positioning.
+ * @param enabled `false` to disable tooltip but still render the trigger element
  * @param children Trigger element
+ * @param defaultOpen `true` to open tooltip by default
+ * @param side "top" | "right" | "bottom" | "left" - where to place the tooltip relative to the trigger element
  */
-export default function Tooltip ({ content, enabled = true, className = '', children }: Props): JSX.Element {
+export default function Tooltip ({ content, side = 'top', enabled = true, defaultOpen = false, className = '', children }: Props): JSX.Element {
   return (
-    <Popover.Root>
+    <Popover.Root defaultOpen={defaultOpen}>
       <Popover.Trigger className={className}>{children}</Popover.Trigger>
-      {enabled &&
+      {enabled && (
         <Popover.Content
           className='z-20 text-sm text-base-300 bg-tooltip rounded-md p-2 drop-shadow-lg border max-w-[300px] focus:outline-none'
-          side='top'
+          side={side}
           align='start'
           alignOffset={-40}
           collisionPadding={8}
         >
           {content}
           <Popover.Arrow className='stroke-tooltip fill-tooltip' />
-        </Popover.Content>}
+        </Popover.Content>
+      )}
     </Popover.Root>
   )
 }

--- a/src/components/users/EditProfileButton.tsx
+++ b/src/components/users/EditProfileButton.tsx
@@ -16,7 +16,7 @@ interface EditProfileButtonProps extends WithOwnerProfile {
 function EditProfileButton ({ loginsCount }: EditProfileButtonProps): JSX.Element {
   return (
     <>
-      {loginsCount === 2 // the loginsCount is 2 after the user creates their account
+      {loginsCount === 1
         ? (
           <Tooltip
             side='bottom'
@@ -32,7 +32,7 @@ function EditProfileButton ({ loginsCount }: EditProfileButtonProps): JSX.Elemen
             />
           </Tooltip>
           )
-        : loginsCount !== undefined && loginsCount > 0
+        : loginsCount !== undefined && loginsCount > 1
           ? (
             <Button
               href='/account/edit'

--- a/src/components/users/EditProfileButton.tsx
+++ b/src/components/users/EditProfileButton.tsx
@@ -16,7 +16,7 @@ interface EditProfileButtonProps extends WithOwnerProfile {
 function EditProfileButton ({ loginsCount }: EditProfileButtonProps): JSX.Element {
   return (
     <>
-      {loginsCount === 1
+      {loginsCount === 2 // the loginsCount is 2 after the user creates their account
         ? (
           <Tooltip
             side='bottom'

--- a/src/components/users/EditProfileButton.tsx
+++ b/src/components/users/EditProfileButton.tsx
@@ -1,14 +1,48 @@
+import React from 'react'
 import { Button, ButtonVariant } from '../ui/BaseButton'
-
 import forOwnerOnly from '../../js/auth/forOwnerOnly'
 import { WithOwnerProfile } from '../../js/types/User'
+import Tooltip from '../ui/Tooltip'
 
 interface EditProfileButtonProps extends WithOwnerProfile {
+  loginsCount?: number // Add loginsCount prop
 }
 
-function EditProfileButton (): JSX.Element {
+/**
+ * EditProfileButton component displays a "Edit" button with optional tooltip based on loginsCount prop.
+ * @param {EditProfileButtonProps} loginsCount - The number of times a user has logged in since account creation.
+ * @returns {JSX.Element} - JSX element representing the EditProfileButton component.
+ */
+function EditProfileButton ({ loginsCount }: EditProfileButtonProps): JSX.Element {
   return (
-    <Button href='/account/edit' label='Edit' variant={ButtonVariant.OUTLINED_DEFAULT} size='sm' />
+    <>
+      {loginsCount === 1
+        ? (
+          <Tooltip
+            side='bottom'
+            defaultOpen
+            enabled
+            content='It looks like this is your first time logging in, click here to change your username!'
+          >
+            <Button
+              href='/account/edit'
+              label='Edit'
+              variant={ButtonVariant.OUTLINED_DEFAULT}
+              size='sm'
+            />
+          </Tooltip>
+          )
+        : loginsCount !== undefined && loginsCount > 0
+          ? (
+            <Button
+              href='/account/edit'
+              label='Edit'
+              variant={ButtonVariant.OUTLINED_DEFAULT}
+              size='sm'
+            />
+            )
+          : null}
+    </>
   )
 }
 

--- a/src/components/users/PublicProfile.tsx
+++ b/src/components/users/PublicProfile.tsx
@@ -21,7 +21,7 @@ export default function PublicProfile ({ userProfile: initialUserProfile }: Publ
     setUserProfile(initialUserProfile)
   }, [initialUserProfile])
 
-  const { name, nick, avatar, bio, website } = userProfile ?? {}
+  const { name, nick, avatar, bio, website, loginsCount } = userProfile ?? {}
   let websiteWithScheme: string | null = null
   if (website != null) {
     websiteWithScheme = website.startsWith('http') ? website : `//${website}`
@@ -40,7 +40,7 @@ export default function PublicProfile ({ userProfile: initialUserProfile }: Publ
           <div className='text-2xl font-bold mr-4'>
             {nick}
           </div>
-          <EditProfileButton ownerProfile={initialUserProfile} />
+          <EditProfileButton ownerProfile={initialUserProfile} loginsCount={loginsCount} />
           {userProfile != null && isAuthorized && <ImportFromMtnProj isButton />}
           {userProfile != null && <APIKey ownerProfile={initialUserProfile} />}
         </div>

--- a/src/components/users/__tests__/EditProfileButton.tsx
+++ b/src/components/users/__tests__/EditProfileButton.tsx
@@ -1,11 +1,9 @@
 import '@testing-library/jest-dom/extend-expect'
 import { render, screen } from '@testing-library/react'
+import usePermissions from '../../../js/hooks/auth/usePermissions'
 
-const mockedUseSession = jest.fn()
-
-jest.mock('next-auth/react', () => ({
-  useSession: mockedUseSession
-}))
+// Mock the usePermissions hook
+jest.mock('../../../js/hooks/auth/usePermissions')
 
 jest.requireMock('next-auth/react')
 
@@ -17,19 +15,33 @@ beforeAll(async () => {
 })
 
 test('EditProfileButton renders when the user has logged in', async () => {
-  mockedUseSession
-    .mockClear()
-    .mockReturnValue({ status: 'authenticated' })
-  render(<EditProfileButton />)
-  expect(mockedUseSession).toBeCalledTimes(1)
+  (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: true })
+  render(<EditProfileButton loginsCount={5} />)
+  screen.debug()
   expect(screen.queryByRole('button')).toBeDefined()
 })
 
 test('EditProfileButton renders null when the user hasn\'t logged in', async () => {
-  mockedUseSession
-    .mockClear()
-    .mockReturnValue({ status: '' })
-  render(<EditProfileButton />)
-  expect(mockedUseSession).toBeCalledTimes(1)
+  (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: false })
+
+  render(<EditProfileButton loginsCount={0} />)
   expect(screen.queryByRole('button')).toBeNull()
+})
+
+test('EditProfileButton renders the tooltip when loginsCount is 1', async () => {
+  (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: true })
+  render(<EditProfileButton loginsCount={1} />)
+  const tooltip = screen.queryByText(
+    'It looks like this is your first time logging in, click here to change your username!'
+  )
+  expect(tooltip).toBeInTheDocument()
+})
+
+test('EditProfileButton does not render the tooltip when loginsCount is greater than 1', async () => {
+  (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: true })
+  render(<EditProfileButton loginsCount={5} />)
+  const tooltip = screen.queryByText(
+    'It looks like this is your first time logging in, click here to change your username!'
+  )
+  expect(tooltip).not.toBeInTheDocument()
 })

--- a/src/components/users/__tests__/EditProfileButton.tsx
+++ b/src/components/users/__tests__/EditProfileButton.tsx
@@ -28,9 +28,9 @@ test('EditProfileButton renders null when the user hasn\'t logged in', async () 
   expect(screen.queryByRole('button')).toBeNull()
 })
 
-test('EditProfileButton renders the tooltip when loginsCount is 2', async () => { // (the loginsCount is 2 after making the account and logging in)
+test('EditProfileButton renders the tooltip when loginsCount is 1', async () => { // (the loginsCount is 1 after making the account and logging in)
   (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: true })
-  render(<EditProfileButton loginsCount={2} />)
+  render(<EditProfileButton loginsCount={1} />)
   const tooltip = screen.queryByText(
     'It looks like this is your first time logging in, click here to change your username!'
   )

--- a/src/components/users/__tests__/EditProfileButton.tsx
+++ b/src/components/users/__tests__/EditProfileButton.tsx
@@ -28,9 +28,9 @@ test('EditProfileButton renders null when the user hasn\'t logged in', async () 
   expect(screen.queryByRole('button')).toBeNull()
 })
 
-test('EditProfileButton renders the tooltip when loginsCount is 1', async () => {
+test('EditProfileButton renders the tooltip when loginsCount is 2', async () => { // (the loginsCount is 2 after making the account and logging in)
   (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: true })
-  render(<EditProfileButton loginsCount={1} />)
+  render(<EditProfileButton loginsCount={2} />)
   const tooltip = screen.queryByText(
     'It looks like this is your first time logging in, click here to change your username!'
   )

--- a/src/js/__tests__/auth/forOwnerOnly.tsx
+++ b/src/js/__tests__/auth/forOwnerOnly.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+
+import { render } from '@testing-library/react'
+import forOwnerOnly from '../../auth/forOwnerOnly'
+import usePermissions from '../../hooks/auth/usePermissions'
+import { IUserProfile, WithOwnerProfile } from '../../types/User'
+
+// Mock the usePermissions hook
+jest.mock('../../hooks/auth/usePermissions')
+
+const dummyOwnerProfile: IUserProfile = {
+  uuid: '12345678-1234-1234-1234-123456789012',
+  roles: ['user'],
+  loginsCount: 1,
+  name: 'John Doe',
+  nick: 'johndoe',
+  bio: 'Climber and outdoor enthusiast',
+  website: 'https://johndoe.com',
+  ticksImported: true,
+  collections: {
+    climbCollections: {
+      'John\'s Climbs': ['climb1', 'climb2', 'climb3']
+    },
+    areaCollections: {
+      'John\'s Areas': ['area1', 'area2', 'area3']
+    }
+  },
+  email: 'john@example.com',
+  avatar: 'https://example.com/john/avatar.jpg',
+  authProviderId: 'auth0|123456789012345678901234'
+}
+// Create a mock component to be used with forOwnerOnly
+const MockComponent: React.FC<WithOwnerProfile> = () => <div>Mock Component</div>
+
+// Create a component wrapped with forOwnerOnly
+const WrappedComponent = forOwnerOnly(MockComponent)
+
+describe('forOwnerOnly', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render the component if isAuthorized is true', async () => {
+    (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: true })
+
+    const { container } = render(<WrappedComponent ownerProfile={dummyOwnerProfile} />)
+    expect(container).toHaveTextContent('Mock Component')
+  })
+
+  it('should not render the component if isAuthorized is false', () => {
+    (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: false })
+
+    const { container } = render(<WrappedComponent ownerProfile={dummyOwnerProfile} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should not render the component if the WrappedComponent is null', () => {
+    type Fn<P> = (props: P) => JSX.Element | null
+
+    const NullWrappedComponent = forOwnerOnly(null as unknown as Fn<WithOwnerProfile>)
+    expect(NullWrappedComponent({ ownerProfile: dummyOwnerProfile })).toBeNull()
+  })
+})


### PR DESCRIPTION
I added a check to see if it was the user's first login, and if it is, there will be a tooltip to prompt the user to change their username away from the autogenerated one.

I also added unit tests to EditProfileButton and forOwnerOnly to ensure those are working as expected. 

![image](https://user-images.githubusercontent.com/24685932/233762487-95495eda-66dd-4ce9-85ee-cbd420b45997.png)
