### PR TITLE
adding unit test to forOwnerOnly #794

### DIFF
--- a/src/js/__tests__/auth/forOwnerOnly.tsx
+++ b/src/js/__tests__/auth/forOwnerOnly.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+
+import { render } from '@testing-library/react'
+import forOwnerOnly from '../../auth/forOwnerOnly'
+import usePermissions from '../../hooks/auth/usePermissions'
+import { IUserProfile, WithOwnerProfile } from '../../types/User'
+
+// Mock the usePermissions hook
+jest.mock('../../hooks/auth/usePermissions')
+
+const dummyOwnerProfile: IUserProfile = {
+  uuid: '12345678-1234-1234-1234-123456789012',
+  roles: ['user'],
+  loginsCount: 1,
+  name: 'John Doe',
+  nick: 'johndoe',
+  bio: 'Climber and outdoor enthusiast',
+  website: 'https://johndoe.com',
+  ticksImported: true,
+  collections: {
+    climbCollections: {
+      'John\'s Climbs': ['climb1', 'climb2', 'climb3']
+    },
+    areaCollections: {
+      'John\'s Areas': ['area1', 'area2', 'area3']
+    }
+  },
+  email: 'john@example.com',
+  avatar: 'https://example.com/john/avatar.jpg',
+  authProviderId: 'auth0|123456789012345678901234'
+}
+// Create a mock component to be used with forOwnerOnly
+const MockComponent: React.FC<WithOwnerProfile> = () => <div>Mock Component</div>
+
+// Create a component wrapped with forOwnerOnly
+const WrappedComponent = forOwnerOnly(MockComponent)
+
+describe('forOwnerOnly', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render the component if isAuthorized is true', async () => {
+    (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: true })
+
+    const { container } = render(<WrappedComponent ownerProfile={dummyOwnerProfile} />)
+    expect(container).toHaveTextContent('Mock Component')
+  })
+
+  it('should not render the component if isAuthorized is false', () => {
+    (usePermissions as jest.Mock).mockReturnValue({ isAuthorized: false })
+
+    const { container } = render(<WrappedComponent ownerProfile={dummyOwnerProfile} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should not render the component if the WrappedComponent is null', () => {
+    type Fn<P> = (props: P) => JSX.Element | null
+
+    const NullWrappedComponent = forOwnerOnly(null as unknown as Fn<WithOwnerProfile>)
+    expect(NullWrappedComponent({ ownerProfile: dummyOwnerProfile })).toBeNull()
+  })
+})

--- a/src/js/auth/forOwnerOnly.ts
+++ b/src/js/auth/forOwnerOnly.ts
@@ -1,6 +1,5 @@
 
 import React from 'react'
-
 import { WithOwnerProfile } from '../types/User'
 import usePermissions from '../hooks/auth/usePermissions'
 

--- a/src/js/auth/forOwnerOnly.ts
+++ b/src/js/auth/forOwnerOnly.ts
@@ -4,7 +4,14 @@ import React from 'react'
 import { WithOwnerProfile } from '../types/User'
 import usePermissions from '../hooks/auth/usePermissions'
 
+/**
+ * A function type that takes a set of props of type P and returns a JSX element or null.
+ * @template P - The type of the props passed to the function.
+ * @param {P} props - The props passed to the function.
+ * @returns {JSX.Element | null} - The JSX element returned by the function, or null.
+ */
 type Fn<P> = (props: P) => JSX.Element | null
+
 /**
  * Higher-order function to conditionally render a UI component
  * if the user currently authenticated is the same as the component owner.


### PR DESCRIPTION
This pull request adds unit tests for the forOwnerOnly higher order function, which is used to restrict access to certain components or functions to a specific owner. The tests verify that the function behaves as expected and that it correctly restricts access to components based on if isAuthorized returns `true` from the mocked usePermission hook.