### PR TITLE
Fix getChangeHistory

### DIFF
--- a/src/components/edit/RecentChangeHistory.tsx
+++ b/src/components/edit/RecentChangeHistory.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { PlusIcon, UserCircleIcon, MinusIcon, PencilIcon, PencilSquareIcon, MinusCircleIcon, PlusCircleIcon } from '@heroicons/react/24/outline'
 import { formatDistanceToNow } from 'date-fns'
 
-import { ChangesetType, ChangeType, AreaType, ClimbType } from '../../js/types'
+import { ChangesetType, ChangeType, AreaType, ClimbType, OrganizationType, DocumentTypeName } from '../../js/types'
 
 export interface RecentChangeHistoryProps {
   history: ChangesetType[]
@@ -43,6 +43,7 @@ const ChangesetRow = ({ changeset }: ChangsetRowProps): JSX.Element => {
             <React.Fragment key={change.changeId}>
               <AreaChange {...change} />
               <ClimbChange {...change} />
+              <OrganizationChange {...change} />
             </React.Fragment>))}
         </div>
       </div>
@@ -51,7 +52,7 @@ const ChangesetRow = ({ changeset }: ChangsetRowProps): JSX.Element => {
 }
 
 const ClimbChange = ({ changeId, fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
-  if ((fullDocument as ClimbType)?.name == null) {
+  if (fullDocument.__typeName !== DocumentTypeName.Climb) {
     return null
   }
   const { name, id } = fullDocument as ClimbType
@@ -76,9 +77,7 @@ const ClimbChange = ({ changeId, fullDocument, updateDescription, dbOp }: Change
 }
 
 const AreaChange = ({ changeId, fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
-  // @ts-expect-error
-  // eslint-disable-next-line
-  if (fullDocument?.areaName == null) {
+  if (fullDocument.__typeName !== DocumentTypeName.Area) {
     return null
   }
   const { areaName, uuid } = fullDocument as AreaType
@@ -94,6 +93,28 @@ const AreaChange = ({ changeId, fullDocument, updateDescription, dbOp }: ChangeT
           {dbOp === 'delete'
             ? <span>{areaName}</span>
             : (<Link href={url}><a className='link link-hover'>{areaName}</a></Link>)}
+        </div>
+        <div className='text-xs text-base-300'>
+          <UpdatedFields fields={updateDescription?.updatedFields} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const OrganizationChange = ({ changeId, fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
+  if (fullDocument.__typeName !== DocumentTypeName.Organization) {
+    return null
+  }
+  const { displayName } = fullDocument as OrganizationType
+
+  return (
+    <div className='ml-2 flex gap-x-2'>
+      <div className='flex gap-2'>{dbOpIcon[dbOp]} <span className='badge badge-sm badge-warning'>Organization</span></div>
+
+      <div className=''>
+        <div className=''>
+          <span>{displayName}</span>
         </div>
         <div className='text-xs text-base-300'>
           <UpdatedFields fields={updateDescription?.updatedFields} />

--- a/src/js/graphql/gql/contribs.ts
+++ b/src/js/graphql/gql/contribs.ts
@@ -99,6 +99,7 @@ export const FRAGMENT_CHANGE_HISTORY = gql`
         updatedFields
       }
       fullDocument {
+        __typename
         ... on Area {
           areaName
           uuid
@@ -111,6 +112,9 @@ export const FRAGMENT_CHANGE_HISTORY = gql`
           id
           name
           uuid
+        }
+        ... on Organization {
+          displayName
         }
       }
     }

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -27,6 +27,10 @@ export enum SafetyType {
   X = 'X',
 }
 
+export enum OrgType {
+  LOCAL_CLIMBING_ORGANIZATION = 'LOCAL_CLIMBING_ORGANIZATION',
+}
+
 export interface ClimbMetadataType {
   lat: number
   lng: number
@@ -110,6 +114,22 @@ export interface EditMetadataType {
   updatedBy?: string
   createdAt?: number
   createdBy?: string
+}
+
+export type OrganizationType = EditMetadataType & {
+  orgId: string
+  orgType: OrgType
+  associatedAreaIds: string[]
+  excludedAreaIds: string[]
+  displayName: string
+  content: {
+    facebookLink: string
+    instagramLink: string
+    donationLink: string
+    description: string
+    website: string
+    email: string
+  }
 }
 
 export type AreaType = EditMetadataType & {
@@ -282,10 +302,20 @@ export interface UpdateDescriptionType {
   truncatedArrays?: any[]
 }
 
+export enum DocumentTypeName {
+  Area = 'Area',
+  Climb = 'Climb',
+  Organization = 'Organization',
+}
+
+export interface WithDocumentTypeName {
+  __typeName: DocumentTypeName
+}
+
 export interface ChangeType {
   dbOp: string
   changeId: string
-  fullDocument: AreaType | ClimbType
+  fullDocument: (AreaType | ClimbType | OrganizationType) & WithDocumentTypeName
   updateDescription: UpdateDescriptionType
 }
 


### PR DESCRIPTION
In response to breakage reported here: https://github.com/OpenBeta/open-tacos/pull/782.

In working on this, I considered whether we should be showing Organizations history in the general changelog. I feel it could go either way:
-  If we think of the changelog as helping folks keep tabs on user-executed changes so that we can fix them if there is abuse, then Organization changes shouldn't be there because these are done by LCO admins whom we trust more and are less at risk of abuse.
- If we think of the changelog as showing folks what's going on the site that might be of public interest, then since organizations are highly visible, it makes sense to show changes to them.

In the end, I figured we can just expand functionality to show a change (including those for organizations) if it exists. If we want to remove organization changes, the best place is probably at the GraphQL query layer, by adding a filter. 

The current filter doesn't support `kind`. The problem is that a changelog of a certain kind can involve documents of multiple kinds. Eg. add climb (changelog `kind` == 'climbs') involves inserting a climb (document `kind` == 'climbs') and updating the parent area (document `kind` = 'areas'). It's not clear whether we should include the parent area document change when filtering for climbing changelogs. So there's some nuance here to think about.

For context, `kind` is stabilized on the backend in this https://github.com/OpenBeta/openbeta-graphql/pull/277.
