### PR TITLE
Update users from Basecamp page

### DIFF
--- a/src/components/basecamp/OrganizationForm.tsx
+++ b/src/components/basecamp/OrganizationForm.tsx
@@ -13,19 +13,13 @@ import {
   UpdateOrganizationProps
 } from '../../js/graphql/gql/organization'
 import { toast } from 'react-toastify'
-import { validate as uuidValidate } from 'uuid'
+import { MUUID_VALIDATION, conjoinedStringToArray } from './utils'
 
 const DISPLAY_NAME_FORM_VALIDATION_RULES: RulesType = {
   required: 'A display name is required.',
   minLength: {
     value: 2,
     message: 'Minimum 2 characters.'
-  }
-}
-
-const MUUID_VALIDATION = {
-  validate: (value: string) => {
-    return conjoinedStringToArray(value).every(uuidValidate) || 'Expected comma-separated MUUID hex strings eg. 49017dad-7baf-5fde-8078-f3a4b1230bbb, 88352d11-eb85-5fde-8078-889bb1230b11...'
   }
 }
 
@@ -251,12 +245,4 @@ export default function OrganizationForm ({ existingOrg, onClose }: Organization
       </div>
     </div>
   )
-}
-
-/**
- * Convert comma-separated string to array.
- * Notably, '' and ',' return [].
- */
-function conjoinedStringToArray (conjoined: string): string[] {
-  return conjoined.split(',').map(s => s.trim()).filter(s => s !== '')
 }

--- a/src/components/basecamp/UserForm.tsx
+++ b/src/components/basecamp/UserForm.tsx
@@ -1,0 +1,135 @@
+import type { User } from 'auth0'
+import clx from 'classnames'
+import { TextArea } from '../ui/form'
+import { useForm, FormProvider } from 'react-hook-form'
+import { MUUID_VALIDATION, conjoinedStringToArray } from './utils'
+import axios from 'axios'
+import useSWR from 'swr'
+import { Role } from 'auth0'
+import { UserRole } from '../../js/types'
+import MultiSelect from '../ui/form/MultiSelect'
+import { useEffect } from 'react'
+
+interface UserFormProps {
+  user: User
+  onClose: () => void
+}
+
+interface HtmlFormProps {
+  roles: string[]
+  conjoinedOrgAdminOrgIds: string // Form will return one large conjoined string
+}
+
+const fetcher = async (url: string): Promise<any> => (await axios.get(url)).data
+
+/*
+ * Form for updating users.
+*/
+export default function UserForm ({ user, onClose }: UserFormProps): JSX.Element {
+  const userId = user.user_id
+  if (userId == null) {
+    return <div>Can't load user. Missing user_id.</div>
+  }
+  const { data: roles, error, mutate } = useSWR<Role[]>(`/api/basecamp/userRoles?userId=${userId}`, fetcher)
+  if (error != null) {
+    return <div>{error}</div>
+  }
+  const defaultValues = {
+    roles: roles?.map(r => r.name),
+    conjoinedOrgAdminOrgIds: user.user_metadata?.orgAdminOrgIds?.join(', ') ?? ''
+  }
+
+  // React-hook-form declaration
+  const form = useForm<HtmlFormProps>({
+    mode: 'onBlur',
+    defaultValues
+  })
+  const { handleSubmit, reset, watch, formState: { isSubmitting, dirtyFields } } = form
+
+  useEffect(() => {
+    /* Without this, even after useSWR's refetch produces new data, defaultValues.roles remains
+     * undefined and falls back to the component's default (which for roles is []).
+     */
+    if (roles != null) {
+      reset(
+        defaultValues,
+        { keepErrors: true, keepDirty: true }
+      )
+    }
+  }, [roles, user.user_metadata?.orgAdminOrgIds]) // Dependencies of defaultValues
+
+  /**
+   * Call various Auth0 APIs to update new user data.
+   * @param formProps Data populated by the user in the form
+   * @returns
+   */
+  const submitHandler = async ({
+    conjoinedOrgAdminOrgIds,
+    roles
+  }: HtmlFormProps): Promise<void> => {
+    if ((dirtyFields?.roles as boolean | undefined) === true) {
+      await axios.post(`/api/basecamp/userRoles?userId=${userId}${roles.map(r => `&roles=${r}`).join('')}`)
+    }
+    if (dirtyFields?.conjoinedOrgAdminOrgIds === true) {
+      const orgAdminOrgIds = conjoinedStringToArray(conjoinedOrgAdminOrgIds)
+
+      // Ideally we'd also validate that these orgIds match actual organizations.
+      await axios.post(`/api/basecamp/user?userId=${userId}${orgAdminOrgIds.map(o => `&orgAdminOrgIds=${o}`).join('')}`)
+    }
+    void mutate() // Have SWR refetch data. Auth0 role endpoints don't return the latest state, so we can't set manually.
+    onClose()
+  }
+  return (
+
+    <div className='px-8 pt-12 pb-4 flex flex-row flex-wrap'>
+      <div className='basis-1/3 shink-0 grow min-w-[10em] pr-4'>
+        <h2>User Editor</h2>
+        <div className='mt-4'>
+          <div className='mt-4 break-words'>
+            <h4>userId</h4>
+            <p className='text-xs'>{userId}</p>
+          </div>
+          <div className='mt-4'>
+            <h4>nick</h4>
+            <p className='text-xs'>{user.user_metadata?.nick}</p>
+          </div>
+          <div className='mt-4'>
+            <h4>email</h4>
+            <p className='text-xs'>{user.email}</p>
+          </div>
+        </div>
+      </div>
+      <div className='basis-2/3 grow'>
+        <FormProvider {...form}>
+          <form onSubmit={handleSubmit(submitHandler)} className='min-w-[16em]'>
+            <MultiSelect
+              label='Roles:'
+              name='roles'
+              options={[UserRole.EDITOR, UserRole.ORG_ADMIN, UserRole.USER_ADMIN]}
+              disabledOptions={[UserRole.USER_ADMIN] /* User will lose access to page if they toggle this off */}
+              defaultOptions={[]}
+            />
+            <TextArea
+              label='Organizations to administer:'
+              labelAlt={!watch('roles')?.includes(UserRole.ORG_ADMIN) ? 'Requires org_admin role' : ''}
+              name='conjoinedOrgAdminOrgIds'
+              placeholder='49017dad-7baf-5fde-8078-f3a4b1230bbb, 59e17fad-6bb8-de47-aa80-bba4b1a29be1'
+              disabled={!watch('roles')?.includes(UserRole.ORG_ADMIN)}
+              registerOptions={MUUID_VALIDATION}
+              className=''
+            />
+            <button
+              className={
+                clx('mt-4 btn btn-primary w-full',
+                  isSubmitting ? 'loading btn-disabled' : ''
+                )
+              }
+              type='submit'
+            >Save
+            </button>
+          </form>
+        </FormProvider>
+      </div>
+    </div>
+  )
+}

--- a/src/components/basecamp/utils.tsx
+++ b/src/components/basecamp/utils.tsx
@@ -1,0 +1,15 @@
+import { validate as uuidValidate } from 'uuid'
+
+export const MUUID_VALIDATION = {
+  validate: (value: string) => {
+    return conjoinedStringToArray(value).every(uuidValidate) || 'Expected comma-separated MUUID hex strings eg. 49017dad-7baf-5fde-8078-f3a4b1230bbb, 88352d11-eb85-5fde-8078-889bb1230b11...'
+  }
+}
+
+/**
+ * Convert comma-separated string to array.
+ * Notably, '' and ',' return [].
+ */
+export function conjoinedStringToArray (conjoined: string): string[] {
+  return conjoined.split(',').map(s => s.trim()).filter(s => s !== '')
+}

--- a/src/components/ui/ComboBox.tsx
+++ b/src/components/ui/ComboBox.tsx
@@ -6,29 +6,43 @@ function classNames (...classes): string {
   return classes.filter(Boolean).join(' ')
 }
 
-interface ValueObj{
+export interface ValueObj{
   id: number
   name: string
+  disabled?: boolean
 }
 
-interface ComboBoxProps{
+interface ComboBoxSingleProps {
   options: ValueObj[]
   value: ValueObj
   onChange: (value: ValueObj) => void
   label: string
+  selectClassName?: string
 }
-export default function ComboBox ({ options, value, onChange, label }: ComboBoxProps): JSX.Element {
+interface ComboBoxMultiProps {
+  options: ValueObj[]
+  value: ValueObj[]
+  onChange: (value: ValueObj[]) => void
+  label: string
+  multiple: true
+  selectClassName?: string
+}
+type ComboBoxProps = ComboBoxSingleProps | ComboBoxMultiProps
+
+export default function ComboBox (props: ComboBoxProps): JSX.Element {
+  const { options, value, onChange, label, selectClassName = '' } = props
   return (
-    <Listbox value={value} onChange={onChange}>
+    <Listbox value={value} onChange={onChange} multiple={'multiple' in props ? props.multiple : false}>
       {({ open }) => (
         <>
-          <Listbox.Label className='block text-sm font-medium text-gray-700 mt-2'>{label}</Listbox.Label>
+          {label !== '' && <Listbox.Label className='block text-sm font-medium text-gray-700 mt-2'>{label}</Listbox.Label>}
           <div className='mt-1 relative'>
-            <Listbox.Button className='relative w-full bg-white border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm'>
-              <span className='block truncate'>{value.name}</span>
-              <span className='absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none'>
-                <ChevronUpDownIcon className='h-5 w-5 text-gray-400' aria-hidden='true' />
-              </span>
+            <Listbox.Button className={selectClassName !== '' ? selectClassName : SELECT_DEFAULT_CSS}>
+              <span className='block truncate'>{Array.isArray(value) ? value.map(valueObj => valueObj.name).join(', ') : value.name}</span>
+              {selectClassName === '' && // Set icon by className
+                <span className='absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none'>
+                  <ChevronUpDownIcon className='h-5 w-5 text-gray-400' aria-hidden='true' />
+                </span>}
             </Listbox.Button>
 
             <Transition
@@ -48,6 +62,7 @@ export default function ComboBox ({ options, value, onChange, label }: ComboBoxP
                         'cursor-default select-none relative py-2 pl-8 pr-4'
                       )}
                     value={type}
+                    disabled={type.disabled}
                   >
                     {({ selected, active }) => (
                       <>
@@ -79,3 +94,5 @@ export default function ComboBox ({ options, value, onChange, label }: ComboBoxP
     </Listbox>
   )
 }
+
+const SELECT_DEFAULT_CSS = 'relative w-full bg-white border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm'

--- a/src/components/ui/form/Input.tsx
+++ b/src/components/ui/form/Input.tsx
@@ -2,7 +2,7 @@ import { RegisterOptions, useFormContext, UseFormReturn } from 'react-hook-form'
 import clx from 'classnames'
 
 interface InputProps {
-  label: string
+  label?: string
   labelAlt?: string | JSX.Element
   unitLabel?: string
   name: string
@@ -50,7 +50,7 @@ export default function Input ({ label, labelAlt, unitLabel, name, registerOptio
   return (
     <div className='form-control'>
       <label className='label' htmlFor={name}>
-        <span className='label-text font-semibold'>{label}</span>
+        {label != null && <span className='label-text font-semibold'>{label}</span>}
         {labelAlt != null && <span className='label-text-alt'>{labelAlt}</span>}
       </label>
       {unitLabel == null

--- a/src/components/ui/form/MultiSelect.tsx
+++ b/src/components/ui/form/MultiSelect.tsx
@@ -1,0 +1,105 @@
+import { Controller, useFormContext, UseFormReturn } from 'react-hook-form'
+import ComboBox, { ValueObj } from '../ComboBox'
+
+interface MultiSelectProps {
+  label: string
+  labelAlt?: string | JSX.Element
+  name: string
+  options: string[]
+  defaultOptions?: string[]
+  disabledOptions?: string[]
+  helper?: string | JSX.Element
+}
+
+interface BaseMultiSelectProps {
+  name: string
+  formContext: UseFormReturn
+  options: string[]
+  defaultOptions?: string[]
+  disabledOptions?: string[]
+}
+
+/**
+ * Wraps our custom ComboBox multi-selector in react-hook-form's Controller
+ * so that it can be used within a FormProvider.
+ * @param param0
+ * @returns
+ */
+export const BaseMultiSelect: React.FC<BaseMultiSelectProps> = ({
+  name, formContext, options, defaultOptions, disabledOptions
+}) => {
+  const { control } = formContext
+
+  // ComboBox uses ValueObjs, need to convert the strings into them.
+  const valueObjOptions = options.map((option, idx) => {
+    return {
+      id: idx,
+      name: option,
+      disabled: disabledOptions?.includes(option) ?? false
+    }
+  })
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      defaultValue={defaultOptions}
+      render={({
+        field: { onChange, value }
+      }) => {
+        // Map value (array of strings) to their corresponding valueObjs.
+        if (value == null) return <div>Loading ... </div>
+        const valueObj = value.map(v => valueObjOptions.find(voo => voo.name === v))
+        if (valueObj == null) throw new Error('value does not match any of the options supplied')
+
+        // Expects arrays since ComboBox set to `multiple`.
+        const valueObjAcceptingOnChange = (valueObjs: ValueObj[]): void => {
+          onChange(valueObjs.map(valueObj => valueObj.name))
+        }
+        return (
+          <ComboBox
+            label=''
+            options={valueObjOptions}
+            onChange={valueObjAcceptingOnChange}
+            value={valueObj}
+            selectClassName={SELECT_DEFAULT_CSS}
+            multiple
+          />
+        )
+      }}
+    />
+  )
+}
+
+/**
+ * A reusable react-hook-form multi-select field.
+ */
+export default function MultiSelect ({
+  label, labelAlt, name, options, defaultOptions, disabledOptions, helper
+}: MultiSelectProps): JSX.Element {
+  const formContext = useFormContext()
+  const { formState: { errors } } = formContext
+  const error = errors?.[name]
+  return (
+    <div className='form-control'>
+      <label className='label' htmlFor={name}>
+        <span className='label-text font-semibold'>{label}</span>
+        {labelAlt != null && <span className='label-text-alt'>{labelAlt}</span>}
+      </label>
+      <BaseMultiSelect
+        name={name}
+        formContext={formContext}
+        options={options}
+        defaultOptions={defaultOptions}
+        disabledOptions={disabledOptions}
+      />
+      <label className='label' id={`${name}-helper`} htmlFor={name}>
+        {error?.message != null &&
+           (<span className='label-text-alt text-error'>{error?.message as string}</span>)}
+        {(error == null) && helper}
+      </label>
+    </div>
+  )
+}
+
+const SELECT_DEFAULT_CSS = 'select select-md input-primary font-normal w-full items-center'

--- a/src/components/ui/form/TextArea.tsx
+++ b/src/components/ui/form/TextArea.tsx
@@ -3,6 +3,7 @@ import clx from 'classnames'
 
 interface InputProps {
   label: string
+  labelAlt?: string
   name: string
   placeholder?: string
   registerOptions?: RegisterOptions
@@ -15,7 +16,7 @@ interface InputProps {
   rows?: number
 }
 
-export default function TextArea ({ label, name, rows = 5, registerOptions, placeholder = '', className = '', classDefault = INPUT_DEFAULT_CSS, helper, formContext, disabled = false, readOnly = false }: InputProps): JSX.Element {
+export default function TextArea ({ label, labelAlt, name, rows = 5, registerOptions, placeholder = '', className = '', classDefault = INPUT_DEFAULT_CSS, helper, formContext, disabled = false, readOnly = false }: InputProps): JSX.Element {
   const context = formContext == null ? useFormContext() : formContext
   const { register, formState: { errors } } = context
   const inputProps = register(name, registerOptions)
@@ -24,6 +25,7 @@ export default function TextArea ({ label, name, rows = 5, registerOptions, plac
     <div className='form-control'>
       <label className='label' htmlFor={name}>
         <span className='label-text font-semibold'>{label}</span>
+        {labelAlt != null && <span className='label-text-alt'>{labelAlt}</span>}
       </label>
       <textarea
         id={name}

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -3,9 +3,10 @@ import { ViewState } from 'react-map-gl'
 import { BaseItem } from '@algolia/autocomplete-core'
 import { RegisterOptions } from 'react-hook-form'
 import { GradeScalesTypes } from '@openbeta/sandbag'
-import { IUserProfile } from './types/User'
+import { IUserProfile, UserRole } from './types/User'
 
 export type { IUserProfile }
+export { UserRole }
 export interface AreaMetadataType {
   leaf: boolean
   isDestination: boolean

--- a/src/js/types/User.ts
+++ b/src/js/types/User.ts
@@ -1,7 +1,17 @@
+export enum UserRole { // These need to match https://manage.auth0.com/dashboard/us/dev-fmjy7n5n/roles.
+  EDITOR = 'editor',
+  ORG_ADMIN = 'org_admin',
+  USER_ADMIN = 'user_admin',
+}
+
+// Read-only to the user; potentially writable by admins in Basecamp.
 export interface IReadOnlyUserMetadata {
   uuid: string
-  roles: string[]
   loginsCount: number
+  /* Denotes the organizations that users that have the 'org_admin' role
+   * are administering. Those without the role will have this as undefined.
+   */
+  orgAdminOrgIds?: string[]
 }
 
 export interface IWritableUserMetadata {
@@ -28,7 +38,18 @@ export interface IWritableUserMetadata {
   }
 }
 
-export type IUserMetadata = IWritableUserMetadata & IReadOnlyUserMetadata
+/**
+ * `user_metadata` as seen in the Auth0 datastore,
+ * before we add fields during post-login actions.
+ */
+export type IUserMetadataOriginal = IWritableUserMetadata & IReadOnlyUserMetadata
+
+/* `roles` are added by a post-login action and are not in
+ * the user's `user_metadata` object in Auth0.
+ */
+export type IUserMetadata = IUserMetadataOriginal & {
+  roles: UserRole[]
+}
 
 export interface IUserProfile extends IUserMetadata {
   email?: string

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -2,7 +2,7 @@ import NextAuth from 'next-auth'
 import Auth0Provider from 'next-auth/providers/auth0'
 
 import { AUTH_CONFIG_SERVER } from '../../../Config'
-import { IUserMetadata } from '../../../js/types/User'
+import { IUserMetadata, UserRole } from '../../../js/types/User'
 
 const CustomClaimsNS = 'https://tacos.openbeta.io/'
 const CustomClaimUserMetadata = CustomClaimsNS + 'user_metadata'
@@ -51,7 +51,8 @@ export default NextAuth({
       if (profile?.[CustomClaimUserMetadata] != null) {
         // null guard needed because profile object is only available once
         token.userMetadata = (profile?.[CustomClaimUserMetadata] as IUserMetadata)
-        token.userMetadata.roles = profile?.[CustomClaimRoles] as string[] ?? []
+        const customClaimRoles = profile?.[CustomClaimRoles] as string[] ?? []
+        token.userMetadata.roles = customClaimRoles.map((r: string) => UserRole[r])
       }
 
       return token

--- a/src/pages/api/basecamp/migrate.ts
+++ b/src/pages/api/basecamp/migrate.ts
@@ -4,13 +4,14 @@ import withAuth from '../withAuth'
 import { CreateUserData } from 'auth0'
 import { customAlphabet } from 'nanoid'
 import { nolookalikesSafe } from 'nanoid-dictionary'
+import { UserRole } from '../../../js/types'
 
 import { auth0ManagementClient } from '../../../js/auth/ManagementClient'
 
 const handler: NextApiHandler<any> = async (req, res) => {
   try {
     const session = await getSession({ req })
-    if (session?.user.metadata?.roles?.includes('user_admin') ?? false) {
+    if (session?.user.metadata?.roles?.includes(UserRole.USER_ADMIN) ?? false) {
       const userId = req.query?.id as string
       if (userId == null) throw new Error('Invalid user id')
 

--- a/src/pages/api/basecamp/user.ts
+++ b/src/pages/api/basecamp/user.ts
@@ -1,0 +1,65 @@
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
+import { getSession } from 'next-auth/react'
+import withAuth from '../withAuth'
+import { updateUser } from '../../../js/auth/ManagementClient'
+import { UserRole } from '../../../js/types'
+import { IUserMetadataOriginal } from '../../../js/types/User'
+
+const handler: NextApiHandler<any> = async (req, res) => {
+  try {
+    switch (req.method) {
+      case 'POST':
+        await handlePostRequest(req, res)
+        break
+      default:
+        res.status(405).json({ error: 'Unexpected HTTP method for /api/basecamp/user' })
+        break
+    }
+  } catch (e) {
+    console.log('/api/basecamp/user', e)
+    res.status(200).redirect(401, '/')
+  }
+}
+
+/**
+ * For admins to update user data from Basecamp. Does not support
+ * creation of new users (hence userId required).
+ * @param req
+ * @param res
+ * @returns
+ */
+async function handlePostRequest (req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  const session = await getSession({ req })
+  if (session?.user.metadata?.roles?.includes(UserRole.USER_ADMIN) ?? false) {
+    res.setHeader('Cache-Control', 'no-store')
+    const userId = req.query?.userId
+    if (userId == null) {
+      res.status(400).json({ error: 'Missing \'userId\' in query string' })
+      return
+    }
+    if (Array.isArray(userId)) {
+      res.status(400).json({ error: '\'userId\' should only be supplied once in query string' })
+      return
+    }
+
+    const payload: Partial<IUserMetadataOriginal> = {}
+    const orgAdminOrgIds = req.query?.orgAdminOrgIds
+    if (typeof orgAdminOrgIds === 'string') {
+      payload.orgAdminOrgIds = [orgAdminOrgIds]
+    } else if (Array.isArray(orgAdminOrgIds)) {
+      payload.orgAdminOrgIds = orgAdminOrgIds
+    } else {
+      // orgAdminOrgIds undefined, likely because not supplied in req.
+    }
+
+    if (Object.keys(payload).length === 0) {
+      res.status(400).json({ error: 'No data to update' })
+    }
+    const user = await updateUser(userId, payload)
+    res.json(user)
+  } else {
+    res.status(401).end()
+  }
+}
+
+export default withAuth(handler)

--- a/src/pages/api/basecamp/userRoles.ts
+++ b/src/pages/api/basecamp/userRoles.ts
@@ -1,0 +1,59 @@
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
+import { getSession } from 'next-auth/react'
+import withAuth from '../withAuth'
+import { getUserRoles, setUserRoles } from '../../../js/auth/ManagementClient'
+import { UserRole } from '../../../js/types'
+
+const handler: NextApiHandler<any> = async (req, res) => {
+  try {
+    const session = await getSession({ req })
+    if (session?.user.metadata?.roles?.includes(UserRole.USER_ADMIN) ?? false) {
+      res.setHeader('Cache-Control', 'no-store')
+      const userId = req.query?.userId
+      if (userId == null) {
+        res.status(400).json({ error: 'Missing \'userId\' in query string' })
+        return
+      }
+      if (Array.isArray(userId)) {
+        res.status(400).json({ error: '\'userId\' should only be supplied once in query string' })
+        return
+      }
+      switch (req.method) {
+        case 'GET':
+          await handleGetRequest(req, res)
+          break
+        case 'POST':
+          await handlePostRequest(req, res)
+          break
+        default:
+          res.status(405).json({ error: 'Unexpected HTTP method for /api/basecamp/user' })
+          break
+      }
+    } else {
+      res.status(401).end()
+    }
+  } catch (e) {
+    console.log('/api/basecamp/userRoles', e)
+    res.status(200).redirect(401, '/')
+  }
+}
+
+async function handleGetRequest (req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  const rolesResp = await getUserRoles(req.query.userId as string)
+  res.json(rolesResp)
+}
+
+async function handlePostRequest (req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  let roles = req.query?.roles
+  if (roles == null) {
+    res.status(400).json({ error: 'Missing \'roles\' in query string' })
+    return
+  }
+  if (!Array.isArray(roles)) {
+    roles = [roles]
+  }
+  await setUserRoles(req.query.userId as string, roles)
+  res.status(200).end()
+}
+
+export default withAuth(handler)

--- a/src/pages/api/basecamp/users.ts
+++ b/src/pages/api/basecamp/users.ts
@@ -2,17 +2,20 @@ import { NextApiHandler } from 'next'
 import { getSession } from 'next-auth/react'
 import withAuth from '../withAuth'
 import { getAllUsersMetadata } from '../../../js/auth/ManagementClient'
+import { UserRole } from '../../../js/types'
 
 const handler: NextApiHandler<any> = async (req, res) => {
   try {
     const session = await getSession({ req })
-    if (session?.user.metadata?.roles?.includes('user_admin') ?? false) {
+    if (session?.user.metadata?.roles?.includes(UserRole.USER_ADMIN) ?? false) {
       res.setHeader('Cache-Control', 'no-store')
       const page = req.query?.page ?? 1
       const type = req.query?.type ?? 'auth0'
+      const email = Array.isArray(req.query?.email) ? req.query.email[0] : req.query?.email
       const params = {
         page: parseInt(page as string),
-        connectionType: type as ('auth0' | 'email')
+        connectionType: type as ('auth0' | 'email'),
+        email
       }
       const users = await getAllUsersMetadata(params)
       res.json(users)

--- a/src/pages/basecamp/organizations.tsx
+++ b/src/pages/basecamp/organizations.tsx
@@ -22,7 +22,7 @@ const Organizations: NextPage<OrganizationHomeProps> = () => {
         contentContainerClass='content-default with-standard-y-margin'
         showFilterBar={false}
       >
-        <div className='max-w-screen-2xl mx-auto flex flex-col items-center 2xl:px-8'>
+        <div className='max-w-screen-2xl mx-auto px-4 flex flex-col items-center 2xl:px-8'>
           <div className='flex flex-row w-full'>
             <LinkButton
               href='/basecamp/users'

--- a/src/pages/basecamp/users.tsx
+++ b/src/pages/basecamp/users.tsx
@@ -22,7 +22,7 @@ const Users: NextPage<UserHomeProps> = () => {
         contentContainerClass='content-default with-standard-y-margin'
         showFilterBar={false}
       >
-        <div className='max-w-screen-2xl mx-auto flex flex-col items-center 2xl:px-8'>
+        <div className='max-w-screen-2xl mx-auto px-4 flex flex-col items-center 2xl:px-8'>
           <div className='flex flex-row w-full'>
             <LinkButton
               href='/basecamp/users'


### PR DESCRIPTION
Aim of this PR is to allow admins to go to Basecamp, designate some users as LCO admins and tag them with the LCOs they are admins of.

I redesigned `/basecamp/users` as well.
- Use `<table>` instead of `<div className='grid>`. Rationale is that grids lack row/column structure -- they work well for dynamically arranged cards and such. But in this case, I wanted to do row-level formatting which is v messy with grids. Let me know if I missed something, and if grids are actually the way to go here!
- I added email address search functionality so that we can find the accounts we want to grant LCO admin status to. Otherwise it's just one big list and we would have to page through it to find the desired ones. In theory we could search according to other identifiers, but I'm guessing most admins will have their organization's email domains which will make searching easy.

Before:
![image](https://user-images.githubusercontent.com/3641356/235598303-20d4dfa9-da21-4163-86d6-a4a1046ccbbb.png)

After:
![image](https://user-images.githubusercontent.com/3641356/235598663-2dbf1ade-756c-4935-83ba-08a0ae7d62ad.png)

User editor modal:
![image](https://user-images.githubusercontent.com/3641356/235833646-03eb01d9-d7a6-440b-9ec1-7357223b9087.png)

Form blocks adding organization if user is not `org_admin`:
![image](https://user-images.githubusercontent.com/3641356/235833558-16feaf0e-a7a3-458e-a1b0-fb31c9e7a7f4.png)

Also updated the Organization page to match the updated design:
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/3641356/236066719-8263e1ad-6d9e-45e4-85ba-6f32497f9fbf.png">


## Deployment
NOTE: Before deploying this to prod, we need to update Auth0 so that the prod client has the newly request scope: `read: roles`. Failure to do this will break prod because the Auth0ManagementClient will start failing from requesting a scope that was not granted to it.
