### PR TITLE
Connect lco be and fe

### DIFF
--- a/src/components/crag/cragSummary.tsx
+++ b/src/components/crag/cragSummary.tsx
@@ -72,6 +72,7 @@ export default function CragSummary ({ area, history }: CragSummaryProps): JSX.E
     metadata: areaMeta,
     climbs,
     ancestors,
+    organizations,
     pathTokens,
     children: childAreas,
     gradeContext,
@@ -484,7 +485,7 @@ export default function CragSummary ({ area, history }: CragSummaryProps): JSX.E
                 placeholder='Area description'
                 rules={AREA_DESCRIPTION_FORM_VALIDATION_RULES}
               />
-              {!editMode && <LCOBanner ancestors={ancestors} />}
+              {!editMode && <LCOBanner orgs={organizations} />}
             </div>
           </div>
 

--- a/src/components/lco/PageBanner.tsx
+++ b/src/components/lco/PageBanner.tsx
@@ -1,6 +1,5 @@
 // import * as HoverCard from '@radix-ui/react-hover-card'
-import { ClimbType } from '../../js/types'
-import { LCO_LIST } from './data'
+import { OrganizationType } from '../../js/types'
 import Tooltip from '../../components/ui/Tooltip'
 import { InformationCircleIcon } from '@heroicons/react/20/solid'
 import { UsersIcon } from '@heroicons/react/24/outline'
@@ -12,38 +11,45 @@ export interface LCOProfileType {
   areaIdList: string[]
   /** Official name */
   name: string
+  description: string
+  email?: string
+  facebook?: string
   /** IG Url */
-  instagram: string
+  instagram?: string
   /** Official website */
-  website: string
+  website?: string
   /** Bad hardware report form url */
   report?: string
   /** Donation url */
   donation?: string
 }
 
-const findLCOs = (
-  lcoList: LCOProfileType[],
-  currentPageAncestors: string[]
-): LCOProfileType[] => {
-  return lcoList.reduce<LCOProfileType[]>((acc, curr) => {
-    if (isMyCrag(currentPageAncestors, curr.areaIdList)) {
-      acc.push(curr)
-    }
-    return acc
-  }, [])
+interface PageBannerProps{orgs: OrganizationType[]}
+const getLcoList = (orgs): LCOProfileType[] => {
+  const lcoList: LCOProfileType[] = []
+
+  orgs.forEach(org => {
+    lcoList.push({
+      id: org.orgId,
+      areaIdList: org.associatedAreaIds ?? [],
+      name: org.displayName,
+      description: org.content?.description ?? '',
+      email: org.content?.email,
+      website: org.content?.website,
+      facebook: org.content?.facebookLink,
+      instagram: org.content?.instagramLink,
+      report: org.content?.hardwareReportLink,
+      donation: org.content?.donationLink
+    })
+  })
+  return lcoList
 }
-
-const isMyCrag = (ancestors: string[], myCrags: string[]): boolean =>
-  ancestors.some((path) => myCrags.some((myCragId) => myCragId === path))
-
-type PageBannerProps = Pick<ClimbType, 'ancestors'>
-
 /**
  * Display LCO banner if there is one.  An area may have multiple LCOs.
  */
-export const PageBanner: React.FC<PageBannerProps> = ({ ancestors }) => {
-  const orgs = findLCOs(LCO_LIST, ancestors)
+export const PageBanner: React.FC<PageBannerProps> = ({ orgs }) => {
+  const lcoList = getLcoList(orgs)
+
   return (
     <div className='grid pt-6 pb-4 lg:pb-16 lg:pt-16'>
       <div className='col-span-full flex justify-start items-center pb-6'>
@@ -60,14 +66,14 @@ export const PageBanner: React.FC<PageBannerProps> = ({ ancestors }) => {
         </Tooltip>
       </div>
       <div>
-        {orgs.length === 0
+        {lcoList.length === 0
           ? (
             <p className='italic text-base-content/60'>
               No organizationa found for this area
             </p>
             )
           : (
-              orgs.map((orgProfile) => (
+              lcoList.map((orgProfile) => (
                 <IndividualBanner key={orgProfile.id} profile={orgProfile} />
               ))
             )}

--- a/src/components/lco/PageBanner.tsx
+++ b/src/components/lco/PageBanner.tsx
@@ -25,11 +25,10 @@ export interface LCOProfileType {
 }
 
 interface PageBannerProps{orgs: OrganizationType[]}
-const getLcoList = (orgs): LCOProfileType[] => {
-  const lcoList: LCOProfileType[] = []
 
-  orgs.forEach(org => {
-    lcoList.push({
+const getLcoList = (orgs): LCOProfileType[] => {
+  return orgs.filter(org => org.orgType === 'LOCAL_CLIMBING_ORGANIZATION')
+    .map(org => ({
       id: org.orgId,
       areaIdList: org.associatedAreaIds ?? [],
       name: org.displayName,
@@ -40,9 +39,7 @@ const getLcoList = (orgs): LCOProfileType[] => {
       instagram: org.content?.instagramLink,
       report: org.content?.hardwareReportLink,
       donation: org.content?.donationLink
-    })
-  })
-  return lcoList
+    }))
 }
 /**
  * Display LCO banner if there is one.  An area may have multiple LCOs.

--- a/src/components/lco/data.tsx
+++ b/src/components/lco/data.tsx
@@ -1,10 +1,8 @@
-import { LCOProfileType } from './PageBanner'
-
 /**
  * A hand-coded list of LCOs.
  * Use https://www.uuidgenerator.net to generate a new `id`
  */
-export const LCO_LIST: LCOProfileType[] = [
+export const LCO_LIST = [
   {
     id: 'a791edd2-6a19-4f12-b69d-cbd499fed81f',
     areaIdList: [

--- a/src/js/graphql/gql/areaById.ts
+++ b/src/js/graphql/gql/areaById.ts
@@ -47,6 +47,20 @@ export const QUERY_AREA_BY_ID = gql`
       }
       pathTokens  
       ancestors
+      organizations{
+        orgId
+        associatedAreaIds
+        displayName
+        content{
+          description
+          donationLink
+          email
+          facebookLink
+          hardwareReportLink
+          instagramLink
+          website
+        }
+      }
       climbs {
         id
         name

--- a/src/js/graphql/gql/areaById.ts
+++ b/src/js/graphql/gql/areaById.ts
@@ -47,11 +47,12 @@ export const QUERY_AREA_BY_ID = gql`
       }
       pathTokens  
       ancestors
-      organizations{
+      organizations {
         orgId
+        orgType
         associatedAreaIds
         displayName
-        content{
+        content {
           description
           donationLink
           email

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -151,6 +151,7 @@ export interface AreaType {
   pathTokens: string[]
   metadata: AreaMetadataType
   ancestors: string[]
+  organizations: OrganizationType[]
   aggregate: AggregateType
   totalClimbs: number
   density: number


### PR DESCRIPTION
- Add organizations to area query
- Pass organization query result to page banner component
- parse organization data to lco profile list

Questions for @vnugent  @zichongkao 
- Which fields in lco profile are required, and which aren't? For optional fields, what is the fallback state? 
- Can hand coded `data.tsx` be removed? 

@zichongkao I think this PR will have merge conflicts with yours [#823](https://github.com/OpenBeta/open-tacos/pull/823) 