### PR TITLE
Fixed Organizations word mispelling

### DIFF
--- a/src/components/lco/PageBanner.tsx
+++ b/src/components/lco/PageBanner.tsx
@@ -67,7 +67,7 @@ export const PageBanner: React.FC<PageBannerProps> = ({ orgs }) => {
         {lcoList.length === 0
           ? (
             <p className='italic text-base-content/60'>
-              No organizationa found for this area
+              No organizations found for this area
             </p>
             )
           : (


### PR DESCRIPTION
### **Scope of change:** 
- Fixed the misspelling in the word Organizations.
### **Screenshots**
After the fix: 
<img width="572" alt="image" src="https://github.com/OpenBeta/open-tacos/assets/87971509/0c3155ab-d6dd-49bf-8dda-183c2200707b">
### **Notes**
This fixes #831 