### PR TITLE
Basecamp organization page displayname filter

### DIFF
--- a/src/js/graphql/gql/organization.ts
+++ b/src/js/graphql/gql/organization.ts
@@ -56,3 +56,33 @@ export interface AddOrganizationProps extends OrganizationEditableFieldsType {
 export interface UpdateOrganizationProps extends OrganizationEditableFieldsType {
   orgId: string
 }
+
+export interface OrgInput {
+  filter?: OrgFilter
+  sort?: OrgSort
+  limit?: number
+}
+
+interface OrgSort {
+  displayName?: number
+  updatedAt?: number
+}
+
+interface OrgFilter {
+  displayName?: DisplayNameFilter
+  associatedAreaIds?: AssociatedAreaIdsFilter
+  excludedAreaIds?: ExcludedAreaIdsFilter
+}
+
+interface DisplayNameFilter {
+  match: string
+  exactMatch: boolean
+}
+
+interface AssociatedAreaIdsFilter {
+  includes: string[]
+}
+
+interface ExcludedAreaIdsFilter {
+  excludes: string[]
+}


### PR DESCRIPTION
We were trying to examine the BCC organization to find out why it doesn't show on the BCC page. However, the page currently only shows the 20 most recently updated orgs and BCC was not one of them. So we had no way to access BCC since we don't have pagination either.

Rather than implement pagination, I decided a filter would be quicker and solve the retrieval problem more directly.

When filter finds something
<img width="1180" alt="image" src="https://github.com/OpenBeta/open-tacos/assets/3641356/9724ce42-81db-4504-a5ae-aad9f42f6c4f">


When filter does not find something
<img width="1418" alt="image" src="https://github.com/OpenBeta/open-tacos/assets/3641356/26a12b63-deca-48ba-a37d-b39311c73716">
