### PR TITLE
Remove react-beautiful-dnd

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "raw-body": "^2.5.1",
     "rc-slider": "^10.0.0-alpha.5",
     "react": "^18.0.0",
-    "react-beautiful-dnd": "^13.1.0",
     "react-content-loader": "^6.2.0",
     "react-dom": "^18.0.0",
     "react-dropzone": "^14.2.1",

--- a/src/components/crag/cragTable.tsx
+++ b/src/components/crag/cragTable.tsx
@@ -6,7 +6,6 @@ import { getSetTypes } from '../ui/RouteTypeChips'
 import ButtonGroup from '../../components/ui/ButtonGroup'
 import { Button } from '../../components/ui/Button'
 import { summarize } from '../ui/Description'
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
 // import { APIFavouriteCollections } from '../../pages/api/user/fav'
 
 interface CragTableProps {
@@ -99,16 +98,6 @@ const climbSortByOptions: CragSortType[] = [
   { value: 'grade', text: 'Grade' }
 ]
 
-const reorderFromDrag = (
-  climbs: Climb[],
-  startIndex: number,
-  endIndex: number
-): Climb[] => {
-  const [removed] = climbs.splice(startIndex, 1)
-  climbs.splice(endIndex, 0, removed)
-  return climbs
-}
-
 export default function CragTable (props: CragTableProps): JSX.Element {
   // Index for one of climbSortByOptions
   const [selectedClimbSort, setSelectedClimbSort] = useState<number>(0)
@@ -199,51 +188,13 @@ export default function CragTable (props: CragTableProps): JSX.Element {
           </div>
         )}
       </div>
-
-      <DragDropContext
-        onDragEnd={(result) =>
-          setSortedRoutes(
-            reorderFromDrag(
-              sortedRoutes,
-              result.source.index,
-              result.destination?.index ?? 0
-            )
-          )}
-      >
-        <Droppable droppableId='cragTable'>
-          {(provided) => (
-            <div
-              {...provided.droppableProps}
-              ref={provided.innerRef}
-              className={`grid grid-cols-1 lg:gap-3 ${
-                isEditing ? '' : 'xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2'
-              }  fr-2`}
-            >
-              {sortedRoutes.map((i, idx) => (
-                <Draggable
-                  isDragDisabled={!isEditing}
-                  draggableId={i.id}
-                  index={idx}
-                  key={i.id}
-                >
-                  {(provided, snapshot) => (
-                    <div
-                      className={`m-1 ${
-                        snapshot.isDragging ? 'bg-purple-100' : 'bg-white'
-                      }`}
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                      {...provided.dragHandleProps}
-                    >
-                      <ClimbItem favs={favs} hideSummary={isEditing} key={i.id} climb={i} />
-                    </div>
-                  )}
-                </Draggable>
-              ))}
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>
+      <div className='grid grid-cols-1 lg:gap-3 xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 fr-2'>
+        {sortedRoutes.map((i, idx) => (
+          <div className='m-1 bg-white' key={i.id}>
+            <ClimbItem favs={favs} hideSummary={isEditing} key={i.id} climb={i} />
+          </div>
+        ))}
+      </div>
     </>
   )
 }


### PR DESCRIPTION
In response to https://github.com/OpenBeta/open-tacos/pull/696#discussion_r1199638229.

Took the more conservative approach of editing `CragTable` instead of deprecating. In the long run, `ClimbListPreview` should be able to replace it, but there are some vital differences that make it hard to just drop it in. Notably, `ClimbListPreview` receives data from react-hook-form context instead of from its props. 