### PR TITLE
Temporarily disable tick functionality

### DIFF
--- a/src/components/users/ImportFromMtnProj.tsx
+++ b/src/components/users/ImportFromMtnProj.tsx
@@ -109,7 +109,7 @@ export function ImportFromMtnProj ({ isButton }: Props): JSX.Element {
   // if the isButton prop is passed to this component as true, the component will be rendered as a button, otherwise it will be a modal
   return (
     <>
-      {isButton && <Button onClick={straightToInput} label='Import Ticks' variant={ButtonVariant.OUTLINED_DEFAULT} size='sm' />}
+      {isButton && <Button onClick={straightToInput} label='Import Ticks' variant={ButtonVariant.OUTLINED_DEFAULT} size='sm' disabled />}
       <div
         aria-live='assertive'
         className='fixed inset-0 z-10 flex items-end px-4 py-6 mt-24 pointer-events-none sm:p-6 sm:items-start'

--- a/src/components/users/TickButton.tsx
+++ b/src/components/users/TickButton.tsx
@@ -66,7 +66,7 @@ export default function TickButton ({ climbId, areaId, name, grade }: Props): JS
       {!isTicked &&
         <button
           type='button'
-          disabled={loading}
+          disabled // Temporarily disable while we deploy and migrate https://github.com/OpenBeta/openbeta-graphql/pull/301
           onClick={() => setOpen(true)}
           className='btn btn-primary btn-sm'
         >

--- a/src/components/users/TickForm.tsx
+++ b/src/components/users/TickForm.tsx
@@ -23,7 +23,7 @@ const TickSchema = Yup.object().shape({
     .required('Please choose an ascent style'),
   attemptType: Yup.string()
     .required('Please choose an ascent type'),
-  dateClimbed: Yup.string()
+  dateClimbed: Yup.date()
     .required('Please include a date'),
   grade: Yup.string()
     .required('Something went wrong fetching the climbs grade, please try again')
@@ -61,7 +61,7 @@ interface Props{
 export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, climbId, name, grade }: Props): JSX.Element {
   const [style, setStyle] = useState(styles[1])
   const [attemptType, setAttemptType] = useState(attemptTypes[1])
-  const [dateClimbed, setDateClimbed] = useState<string>(new Date().toISOString().slice(0, 10)) // default is today for dateClimbed
+  const [dateClimbed, setDateClimbed] = useState<Date>(new Date()) // default is today for dateClimbed
   const [notes, setNotes] = useState<string>('')
   const [errors, setErrors] = useState<string[]>()
   const session = useSession()
@@ -76,7 +76,7 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
    *
    */
   function resetInputs (): void {
-    setDateClimbed(new Date().toISOString().slice(0, 10))
+    setDateClimbed(new Date())
     setAttemptType(attemptTypes[1])
     setNotes('')
     setStyle(styles[1])
@@ -163,8 +163,8 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
                     <input
                       type='date'
                       name='date'
-                      value={dateClimbed}
-                      onChange={(e) => setDateClimbed(e.target.value)}
+                      value={dateClimbed.toLocaleDateString()}
+                      onChange={(e) => setDateClimbed(new Date(e.target.value))}
                       id='date'
                       className='shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md'
                     />

--- a/src/pages/api/user/metadataClient.ts
+++ b/src/pages/api/user/metadataClient.ts
@@ -31,7 +31,7 @@ export interface Tick {
   userId: string | undefined
   style: string
   attemptType: string
-  dateClimbed: string
+  dateClimbed: Date
   grade: string
   source: string
 }

--- a/src/pages/api/user/ticks.ts
+++ b/src/pages/api/user/ticks.ts
@@ -65,7 +65,7 @@ const handler: NextApiHandler<any> = async (req, res) => {
             userId: meta.uuid,
             style: tick.Style === '' ? 'N/A' : tick.Style,
             attemptType: tick.Style === '' ? 'N/A' : tick.Style,
-            dateClimbed: tick.Date,
+            dateClimbed: new Date(tick.Date), // Assumes date is based on user's present timezone.
             grade: tick.Rating,
             source: 'MP'
           }


### PR DESCRIPTION
Enable the migration in https://github.com/OpenBeta/openbeta-graphql/pull/301/files to happen without new date coming in midway.

Confirmed that buttons are disabled:
<img width="371" alt="image" src="https://github.com/OpenBeta/open-tacos/assets/3641356/24da9c24-f86e-4775-a0d4-7ec30e6c213e">

<img width="270" alt="image" src="https://github.com/OpenBeta/open-tacos/assets/3641356/6b3a0f0c-5284-4f7e-a61a-652a82744e0b">
