### PR TITLE
Re-enable tick functionality

### DIFF
--- a/src/components/users/TickCard.tsx
+++ b/src/components/users/TickCard.tsx
@@ -8,7 +8,7 @@ interface Props{
   ticks: TickType[]
   setTicks: Function
   tickId: string
-  dateClimbed: string
+  dateClimbed: Date
   notes: string
   style: string
 }
@@ -33,7 +33,7 @@ export default function TickCard ({ tickId, ticks, setTicks, dateClimbed, notes,
   return (
     <div className='flex flex-row justify-between px-3 py-3 mb-3 border-2 rounded-lg border-slate-100' id={tickId}>
       <div className='flex flex-col'>
-        <p className='text-md text-left text-gray-500'>{dateClimbed}</p>
+        <p className='text-md text-left text-gray-500'>{dateClimbed.toLocaleDateString()}</p>
         <p className='text-sm text-gray-500 mb-0'>{notes}</p>
       </div>
       <div className='flex flex-row'>

--- a/src/components/users/TickForm.tsx
+++ b/src/components/users/TickForm.tsx
@@ -23,7 +23,7 @@ const TickSchema = Yup.object().shape({
     .required('Please choose an ascent style'),
   attemptType: Yup.string()
     .required('Please choose an ascent type'),
-  dateClimbed: Yup.string()
+  dateClimbed: Yup.date()
     .required('Please include a date'),
   grade: Yup.string()
     .required('Something went wrong fetching the climbs grade, please try again')
@@ -61,7 +61,7 @@ interface Props{
 export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, climbId, name, grade }: Props): JSX.Element {
   const [style, setStyle] = useState(styles[1])
   const [attemptType, setAttemptType] = useState(attemptTypes[1])
-  const [dateClimbed, setDateClimbed] = useState<string>(new Date().toISOString().slice(0, 10)) // default is today for dateClimbed
+  const [dateClimbed, setDateClimbed] = useState<Date>(new Date()) // default is today for dateClimbed
   const [notes, setNotes] = useState<string>('')
   const [errors, setErrors] = useState<string[]>()
   const session = useSession()
@@ -76,7 +76,7 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
    *
    */
   function resetInputs (): void {
-    setDateClimbed(new Date().toISOString().slice(0, 10))
+    setDateClimbed(new Date())
     setAttemptType(attemptTypes[1])
     setNotes('')
     setStyle(styles[1])
@@ -163,8 +163,8 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
                     <input
                       type='date'
                       name='date'
-                      value={dateClimbed}
-                      onChange={(e) => setDateClimbed(e.target.value)}
+                      value={dateClimbed.toLocaleDateString()}
+                      onChange={(e) => setDateClimbed(new Date(e.target.value))}
                       id='date'
                       className='shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md'
                     />

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -332,7 +332,7 @@ export interface TickType {
   climbId: string
   style: string
   attemptType: string
-  dateClimbed: string
+  dateClimbed: Date
   grade: string
   source: string
 }

--- a/src/pages/api/user/metadataClient.ts
+++ b/src/pages/api/user/metadataClient.ts
@@ -31,7 +31,7 @@ export interface Tick {
   userId: string | undefined
   style: string
   attemptType: string
-  dateClimbed: string
+  dateClimbed: Date
   grade: string
   source: string
 }

--- a/src/pages/u2/[...slug].tsx
+++ b/src/pages/u2/[...slug].tsx
@@ -40,7 +40,7 @@ const Tick = (tick: TickType): JSX.Element => {
           <a className='hover:underline'>{name}</a>
         </Link>
       </div>
-      <div className='text-base-300'>{dateClimbed}</div>
+      <div className='text-base-300'>{dateClimbed.toLocaleDateString()}</div>
     </div>
   )
 }


### PR DESCRIPTION
Undoes the temporary deactivation of tick functionality here: https://github.com/OpenBeta/open-tacos/pull/841 as part of a wider push to migrate ticks' `dateClimbed` field from `string` to `Date`. https://github.com/OpenBeta/openbeta-graphql/issues/175