### PR TITLE
Removed community link from CONTRIBUTING.md (fixed)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ The following is a set of guidelines for contributing to Open-Tacos and related 
 [I don't want to read this whole thing, I just have a question!!!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
 
 [How Can I Contribute?](#how-can-i-contribute)
-  * [Reporting Bugs](#reporting-bugs)
-  * [Suggesting Enhancements](#suggesting-enhancements)
 
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Enhancements](#suggesting-enhancements)
 
 ## Code of Conduct
 
@@ -23,19 +23,15 @@ This project and everyone participating in it is governed by the [OpenBeta of Co
 
 > **Note:** Please don't file an issue to ask a question. You'll get faster results by using the resources below.
 
-We have an official message board where the community chimes in with helpful advice if you have questions.
+We have a Discord chat server where the community chimes in with helpful advice if you have questions.
 
-* [**Community**](https://community.openbeta.io) &mdash; the official OpenBeta community message board
-
-If chat is more your speed, you can join the Discord chat server:
-
-* [Join the Discord chat server](https://discord.gg/ptpnWWNkJx)
-    * Even though Discord is a chat service, sometimes it takes several hours for community members to respond &mdash; please be patient!
-    * Assign yourself role(s) according the type of climbing often do, eg: bouldering, sport, etc.
-    * Under **OpenBeta category**, use the `#general` channel  for general questions or discussion about contributing to the project.
-    * Use the `#openbeta-dev` channel for technical discussion about our on-going projects.
-    * Under **Community category**, use the `#general` channel for discussion with other community members.
-    * There are many other channels available, check the channel list
+- [Join the Discord chat server](https://discord.gg/ptpnWWNkJx)
+  - Even though Discord is a chat service, sometimes it takes several hours for community members to respond &mdash; please be patient!
+  - Assign yourself role(s) according the type of climbing often do, eg: bouldering, sport, etc.
+  - Under **OpenBeta category**, use the `#general` channel for general questions or discussion about contributing to the project.
+  - Use the `#openbeta-dev` channel for technical discussion about our on-going projects.
+  - Under **Community category**, use the `#general` channel for discussion with other community members.
+  - There are many other channels available, check the channel list
 
 ## How Can I Contribute?
 
@@ -45,17 +41,17 @@ If chat is more your speed, you can join the Discord chat server:
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
-* **Use a clear and descriptive title** for the issue to identify the problem.
-* **Describe the exact steps which reproduce the problem** in as many details as possible. 
-* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets.
+- **Use a clear and descriptive title** for the issue to identify the problem.
+- **Describe the exact steps which reproduce the problem** in as many details as possible.
+- **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
 ### Suggesting Enhancements
 
-* **Use a clear and descriptive title** for the issue to identify the suggestion.
-* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
-* **Explain why this enhancement would be useful** to most OpenBeta users.
+- **Use a clear and descriptive title** for the issue to identify the suggestion.
+- **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+- **Explain why this enhancement would be useful** to most OpenBeta users.
 
 This guide was adapted from project [Atom's](https://github.com/atom/atom)
 


### PR DESCRIPTION
Per issue [#821](https://github.com/OpenBeta/open-tacos/issues/821). Only the Discord link is there now

Redo of [this pull request](https://github.com/OpenBeta/open-tacos/pull/850) using a different branch. Old commits are no longer included