### PR TITLE
fix: some photos are shown in distorted ration 

### DIFF
--- a/src/components/home/RecentMediaCard.tsx
+++ b/src/components/home/RecentMediaCard.tsx
@@ -41,6 +41,7 @@ export const RecentImageCard = ({
               width={MOBILE_IMAGE_MAX_WIDITH}
               height={MOBILE_IMAGE_MAX_WIDITH / imageRatio}
               sizes='100vw'
+              objectFit='cover'
               onLoad={() => setLoaded(true)}
             />
             <div


### PR DESCRIPTION
Add `objectFit='cover'` to Next `Image` component
to fix issue #847


