### PR TITLE
fix: use correct next-auth server-side api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,9 +6,9 @@
             "type": "node-terminal",
             "request": "launch",
             "command": "npm run dev",
-            "env": {
-                "NEXT_PUBLIC_API_SERVER": "http://localhost:4000"
-            },
+            // "env": {
+            //     "NEXT_PUBLIC_API_SERVER": "http://localhost:4000"
+            // },
         },
         {
             "name": "Next.js: debug client-side",

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,5 @@
 import NextAuth from 'next-auth'
+import type { NextAuthOptions } from 'next-auth'
 import Auth0Provider from 'next-auth/providers/auth0'
 
 import { AUTH_CONFIG_SERVER } from '../../../Config'
@@ -15,7 +16,7 @@ if (process.env.NODE_ENV === 'production' && clientSecret.length === 0) {
   throw new Error('AUTH0_CLIENT_SECRET is required in production')
 }
 
-export default NextAuth({
+export const authOptions: NextAuthOptions = {
   providers: [
     Auth0Provider({
       clientId,
@@ -69,4 +70,6 @@ export default NextAuth({
       return session
     }
   }
-})
+}
+
+export default NextAuth(authOptions)

--- a/src/pages/api/basecamp/migrate.ts
+++ b/src/pages/api/basecamp/migrate.ts
@@ -1,4 +1,6 @@
 import { NextApiHandler } from 'next'
+import { getServerSession } from 'next-auth'
+
 import withAuth from '../withAuth'
 import { CreateUserData } from 'auth0'
 import { customAlphabet } from 'nanoid'
@@ -6,7 +8,6 @@ import { nolookalikesSafe } from 'nanoid-dictionary'
 import { UserRole } from '../../../js/types'
 
 import { auth0ManagementClient } from '../../../js/auth/ManagementClient'
-import { getServerSession } from 'next-auth'
 import { authOptions } from '../auth/[...nextauth]'
 
 /**

--- a/src/pages/api/basecamp/migrate.ts
+++ b/src/pages/api/basecamp/migrate.ts
@@ -1,5 +1,4 @@
 import { NextApiHandler } from 'next'
-import { getSession } from 'next-auth/react'
 import withAuth from '../withAuth'
 import { CreateUserData } from 'auth0'
 import { customAlphabet } from 'nanoid'
@@ -7,10 +6,16 @@ import { nolookalikesSafe } from 'nanoid-dictionary'
 import { UserRole } from '../../../js/types'
 
 import { auth0ManagementClient } from '../../../js/auth/ManagementClient'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../auth/[...nextauth]'
 
+/**
+ * @deprecated This endpoint was created to migrate Auth0 passwordless accounts to
+ * email/password
+ */
 const handler: NextApiHandler<any> = async (req, res) => {
   try {
-    const session = await getSession({ req })
+    const session = await getServerSession(req, res, authOptions)
     if (session?.user.metadata?.roles?.includes(UserRole.USER_ADMIN) ?? false) {
       const userId = req.query?.id as string
       if (userId == null) throw new Error('Invalid user id')

--- a/src/pages/api/basecamp/user.ts
+++ b/src/pages/api/basecamp/user.ts
@@ -1,9 +1,11 @@
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
-import { getSession } from 'next-auth/react'
+import { getServerSession } from 'next-auth'
+
 import withAuth from '../withAuth'
 import { updateUser } from '../../../js/auth/ManagementClient'
 import { UserRole } from '../../../js/types'
 import { IUserMetadataOriginal } from '../../../js/types/User'
+import { authOptions } from '../auth/[...nextauth]'
 
 const handler: NextApiHandler<any> = async (req, res) => {
   try {
@@ -29,7 +31,7 @@ const handler: NextApiHandler<any> = async (req, res) => {
  * @returns
  */
 async function handlePostRequest (req: NextApiRequest, res: NextApiResponse): Promise<void> {
-  const session = await getSession({ req })
+  const session = await getServerSession(req, res, authOptions)
   if (session?.user.metadata?.roles?.includes(UserRole.USER_ADMIN) ?? false) {
     res.setHeader('Cache-Control', 'no-store')
     const userId = req.query?.userId

--- a/src/pages/api/basecamp/userRoles.ts
+++ b/src/pages/api/basecamp/userRoles.ts
@@ -1,12 +1,14 @@
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
-import { getSession } from 'next-auth/react'
+import { getServerSession } from 'next-auth'
+
 import withAuth from '../withAuth'
 import { getUserRoles, setUserRoles } from '../../../js/auth/ManagementClient'
 import { UserRole } from '../../../js/types'
+import { authOptions } from '../auth/[...nextauth]'
 
 const handler: NextApiHandler<any> = async (req, res) => {
   try {
-    const session = await getSession({ req })
+    const session = await getServerSession(req, res, authOptions)
     if (session?.user.metadata?.roles?.includes(UserRole.USER_ADMIN) ?? false) {
       res.setHeader('Cache-Control', 'no-store')
       const userId = req.query?.userId

--- a/src/pages/api/basecamp/users.ts
+++ b/src/pages/api/basecamp/users.ts
@@ -1,12 +1,14 @@
 import { NextApiHandler } from 'next'
-import { getSession } from 'next-auth/react'
+import { getServerSession } from 'next-auth'
+
 import withAuth from '../withAuth'
 import { getAllUsersMetadata } from '../../../js/auth/ManagementClient'
 import { UserRole } from '../../../js/types'
+import { authOptions } from '../auth/[...nextauth]'
 
 const handler: NextApiHandler<any> = async (req, res) => {
   try {
-    const session = await getSession({ req })
+    const session = await getServerSession(req, res, authOptions)
     if (session?.user.metadata?.roles?.includes(UserRole.USER_ADMIN) ?? false) {
       res.setHeader('Cache-Control', 'no-store')
       const page = req.query?.page ?? 1

--- a/src/pages/api/media/get-signed-url.ts
+++ b/src/pages/api/media/get-signed-url.ts
@@ -1,11 +1,12 @@
 import { NextApiHandler } from 'next'
-import { getSession } from 'next-auth/react'
 import { customAlphabet } from 'nanoid'
 import { nolookalikesSafe } from 'nanoid-dictionary'
 import { extname } from 'path'
+import { getServerSession } from 'next-auth'
 
 import withAuth from '../withAuth'
 import { s3Client, SIRV_CONFIG } from '../../../js/sirv/SirvClient'
+import { authOptions } from '../auth/[...nextauth]'
 
 export interface MediaPreSignedProps {
   url: string
@@ -25,7 +26,7 @@ const handler: NextApiHandler<MediaPreSignedProps> = async (req, res) => {
       if (Array.isArray(filename)) {
         throw new Error('Expect only 1 filename param')
       }
-      const session = await getSession({ req })
+      const session = await getServerSession(req, res, authOptions)
       if (session?.user?.metadata?.uuid == null) {
         throw new Error('Missing user metadata')
       }

--- a/src/pages/api/user/fav.ts
+++ b/src/pages/api/user/fav.ts
@@ -50,7 +50,7 @@ function backToJSONSafe (collections: ReifiedFavouriteCollections): APIFavourite
  */
 const handler: NextApiHandler<any> = async (req, res) => {
   try {
-    const metadataClient = await createMetadataClient(req)
+    const metadataClient = await createMetadataClient(req, res)
     if (metadataClient == null) throw new Error('Can\'t create ManagementAPI client')
 
     /**

--- a/src/pages/api/user/me.ts
+++ b/src/pages/api/user/me.ts
@@ -1,12 +1,12 @@
 import { NextApiHandler } from 'next'
-import { getSession } from 'next-auth/react'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../auth/[...nextauth]'
 
 import withAuth from '../withAuth'
 import useUserProfileCmd from '../../../js/hooks/useUserProfileCmd'
 
 const handler: NextApiHandler<any> = async (req, res) => {
-  const session = await getSession({ req })
-
+  const session = await getServerSession(req, res, authOptions)
   const uuid = session?.user.metadata.uuid
 
   if (uuid == null) {

--- a/src/pages/api/user/metadataClient.ts
+++ b/src/pages/api/user/metadataClient.ts
@@ -1,8 +1,9 @@
-import { NextApiRequest } from 'next'
-import { getSession } from 'next-auth/react'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth'
 
 import { reshapeAuth0UserToProfile, extractUpdatableMetadataFromProfile, auth0ManagementClient } from '../../../js/auth/ManagementClient'
 import { IUserProfile } from '../../../js/types/User'
+import { authOptions } from '../auth/[...nextauth]'
 
 const allowedFields = ['name', 'nick', 'bio', 'website', 'ticksImported', 'collections'] as const
 type AllowedField = typeof allowedFields[number]
@@ -67,9 +68,10 @@ interface MetadataClient {
 }
 
 const createMetadataClient = async (
-  req: NextApiRequest
+  req: NextApiRequest,
+  res: NextApiResponse
 ): Promise<MetadataClient|null> => {
-  const session = await getSession({ req })
+  const session = await getServerSession(req, res, authOptions)
   if (session == null) return null
   const { id, accessToken } = session as unknown as {id: string, accessToken: string}
 

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -8,7 +8,7 @@ import { checkUsername, checkWebsiteUrl } from '../../../js/utils'
 type Handler = NextApiHandler<Auth0UserMetadata | { message: string }>
 
 const getProfile: Handler = async (req, res) => {
-  const metadataClient = await createMetadataClient(req)
+  const metadataClient = await createMetadataClient(req, res)
   if (metadataClient == null) {
     return res.status(401).end()
   }
@@ -24,7 +24,7 @@ const getProfile: Handler = async (req, res) => {
 }
 
 const updateMyProfile: Handler = async (req, res) => {
-  const metadataClient = await createMetadataClient(req)
+  const metadataClient = await createMetadataClient(req, res)
   if (metadataClient == null) {
     return res.status(401).end()
   }

--- a/src/pages/api/user/ticks.ts
+++ b/src/pages/api/user/ticks.ts
@@ -64,7 +64,7 @@ async function getMPTicks (uid: string): Promise<MPTick[]> {
 
 const handler: NextApiHandler<any> = async (req, res) => {
   try {
-    const metadataClient = await createMetadataClient(req)
+    const metadataClient = await createMetadataClient(req, res)
     if (metadataClient == null) throw new Error('Can\'t create ManagementAPI client')
     const meta = await metadataClient.getUserMetadata()
     if (req.method === 'GET') {

--- a/src/pages/api/withAuth.ts
+++ b/src/pages/api/withAuth.ts
@@ -2,12 +2,15 @@
 * Wrap an API Route to check that the user has a valid session.
 * If the user is not logged in the handler will return a 401 Unauthorized.
 */
-import { getSession } from 'next-auth/react'
 import { NextApiHandler } from 'next'
+import { getServerSession } from 'next-auth'
+import { authOptions } from './auth/[...nextauth]'
 
 const withAuth = (handler: NextApiHandler): NextApiHandler => {
   return async (req, res) => {
-    const session = await getSession({ req })
+    const session = await getServerSession(req, res, authOptions)
+
+    console.log('#withAuth', session)
     if (session != null) {
       await handler(req, res)
     } else {


### PR DESCRIPTION
Fix #876 

I [upgraded next-auth ](https://github.com/OpenBeta/open-tacos/commit/61b6c1ac310a060409969ba4deeeda6e7a4f3a73)which seems to introduce a breaking change in `getSession()`.  

According Next-auth docs we should use `getServerSession()`
https://next-auth.js.org/configuration/nextjs#getserversession


Screenshot: I was able to import my ticks in staging

---

<img width="510" alt="Screenshot 2023-06-23 at 10 26 32 AM" src="https://github.com/OpenBeta/open-tacos/assets/3805254/592ba96f-c929-4b34-9ec6-49856150e8f7">
