### PR TITLE
fix: area page erroneously requires users to login

### DIFF
--- a/src/js/hooks/usePhotoUploader.tsx
+++ b/src/js/hooks/usePhotoUploader.tsx
@@ -37,7 +37,7 @@ export default function usePhotoUploader (): PhotoUploaderReturnType {
 
   const setUploading = useUserGalleryStore(store => store.setUploading)
   const isUploading = useUserGalleryStore(store => store.uploading)
-  const { data: sessionData } = useSession({ required: true })
+  const { data: sessionData } = useSession()
   const { addMediaObjectsCmd } = useMediaCmd()
 
   /** When a file is loaded by the browser (as in, loaded from the local filesystem,
@@ -76,7 +76,7 @@ export default function usePhotoUploader (): PhotoUploaderReturnType {
       }
     } catch (e) {
       toast.error('Uploading error.  Please try again.')
-      console.error('Meida upload error.', e)
+      console.error('Media upload error.', e)
     }
   }
 


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
When viewing an area page without photo, users are prompted to log in because the photo upload component requires a login session.  This PR makes sure the login session is optional.

### Related Issues

Issue #894
