### PR TITLE
fix: Searches for climbs should consider parent areas

### DIFF
--- a/src/js/typesense/TypesenseClient.ts
+++ b/src/js/typesense/TypesenseClient.ts
@@ -68,7 +68,7 @@ export async function multiSearch (query: string): Promise<MultisearchReturnType
     searches: [
       {
         q: query,
-        query_by: 'climbName, climbDesc',
+        query_by: 'climbName, areaNames',
         collection: 'climbs',
         exclude_fields: 'climbDesc',
         page: 1,


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description


When searching for a climb, it is useful to be able to narrow the number of results by including the parent areas' names.  open-tacos does not include parent area names as a field when querying, so this did not work.

The data already exists in  typsense, so just tell open-tacos to use it.

### Related Issues

Fixes https://github.com/OpenBeta/open-tacos/issues/907


### What this PR achieves


Before:  the only result for query "robbers lynn woods" was "Home / USA / Colorado / Telluride / Norwood area / Ophir / Ophir Wall/Mirror Wall / Ophir Broke".  Presumably this was due to partial matches in the description: 
> **Lynn** and I went to Telluride to try and start a guide service for Royal **Robbins**,

![image](https://github.com/OpenBeta/open-tacos/assets/16665084/9e57d379-8b73-4aa9-97a3-5fffd5f5bccc)



After: exactly what I expected, although maybe not the optimal order.

![image](https://github.com/OpenBeta/open-tacos/assets/16665084/756436fa-b7ef-4b0b-9b85-edfc3200b3db)



### Notes

I haven't added any tests.




