### PR TITLE
fix: can't tag photos due to stale (empty) user session data

### DIFF
--- a/src/components/media/RemoveImage.tsx
+++ b/src/components/media/RemoveImage.tsx
@@ -2,19 +2,21 @@ import { MediaWithTags } from '../../js/types'
 import AlertDialogue from '../ui/micro/AlertDialogue'
 import { DefaultLoader } from '../../js/sirv/util'
 import useMediaCmd from '../../js/hooks/useMediaCmd'
+import { useSession } from 'next-auth/react'
 
 interface RemoveImageProps {
   imageInfo: MediaWithTags
 }
 
 export default function RemoveImage ({ imageInfo }: RemoveImageProps): JSX.Element | null {
+  const session = useSession()
   const { deleteOneMediaObjectCmd } = useMediaCmd()
 
   const { entityTags } = imageInfo
   if (entityTags.length > 0) return null
 
   const remove = async (): Promise<void> => {
-    await deleteOneMediaObjectCmd(imageInfo.id, imageInfo.mediaUrl)
+    await deleteOneMediaObjectCmd(imageInfo.id, imageInfo.mediaUrl, session.data?.accessToken)
   }
 
   return (

--- a/src/components/media/RemoveImage.tsx
+++ b/src/components/media/RemoveImage.tsx
@@ -1,8 +1,9 @@
+import { useSession } from 'next-auth/react'
+
 import { MediaWithTags } from '../../js/types'
 import AlertDialogue from '../ui/micro/AlertDialogue'
 import { DefaultLoader } from '../../js/sirv/util'
 import useMediaCmd from '../../js/hooks/useMediaCmd'
-import { useSession } from 'next-auth/react'
 
 interface RemoveImageProps {
   imageInfo: MediaWithTags

--- a/src/components/media/TagList.tsx
+++ b/src/components/media/TagList.tsx
@@ -2,7 +2,7 @@ import { useState, MouseEventHandler } from 'react'
 import classNames from 'classnames'
 import { TagIcon, PlusIcon } from '@heroicons/react/24/outline'
 import { DropdownMenuItem as PrimitiveDropdownMenuItem } from '@radix-ui/react-dropdown-menu'
-import { signIn } from 'next-auth/react'
+import { signIn, useSession } from 'next-auth/react'
 
 import AddTag from './AddTag'
 import { DropdownMenu, DropdownContent, DropdownTrigger, DropdownItem, DropdownSeparator } from '../ui/DropdownMenu'
@@ -29,17 +29,18 @@ interface TagsProps {
  */
 export default function TagList ({ mediaWithTags, isAuthorized = false, isAuthenticated = false, showDelete = false, showActions = true, className = '' }: TagsProps): JSX.Element | null {
   const { addEntityTagCmd, removeEntityTagCmd } = useMediaCmd()
+  const session = useSession()
 
   if (mediaWithTags == null) {
     return null
   }
 
   const onAddHandler: OnAddCallback = async (args) => {
-    await addEntityTagCmd(args)
+    await addEntityTagCmd(args, session.data?.accessToken)
   }
 
   const onDeleteHandler: OnDeleteCallback = async (args) => {
-    await removeEntityTagCmd(args)
+    await removeEntityTagCmd(args, , session.data?.accessToken)
   }
 
   const { entityTags, id } = mediaWithTags
@@ -83,15 +84,16 @@ export interface TagListProps {
  * Mobile tag list wrapped in a popup menu
  */
 export const MobilePopupTagList: React.FC<TagListProps> = ({ mediaWithTags, isAuthorized = false }) => {
+  const session = useSession()
   const { addEntityTagCmd, removeEntityTagCmd } = useMediaCmd()
   const [openSearch, setOpenSearch] = useState(false)
 
   const onAddHandler: OnAddCallback = async (args) => {
-    await addEntityTagCmd(args)
+    await addEntityTagCmd(args, session.data?.accessToken)
   }
 
   const onDeleteHandler: OnDeleteCallback = async (args) => {
-    await removeEntityTagCmd(args)
+    await removeEntityTagCmd(args, session.data?.accessToken)
   }
   const { id, entityTags } = mediaWithTags
   return (

--- a/src/components/media/TagList.tsx
+++ b/src/components/media/TagList.tsx
@@ -40,7 +40,7 @@ export default function TagList ({ mediaWithTags, isAuthorized = false, isAuthen
   }
 
   const onDeleteHandler: OnDeleteCallback = async (args) => {
-    await removeEntityTagCmd(args, , session.data?.accessToken)
+    await removeEntityTagCmd(args, session.data?.accessToken)
   }
 
   const { entityTags, id } = mediaWithTags

--- a/src/components/media/__tests__/MobilePopupTagMenu.tsx
+++ b/src/components/media/__tests__/MobilePopupTagMenu.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { MediaWithTags } from '../../../js/types'
+import { MediaFormat, MediaWithTags } from '../../../js/types'
 import { TagListProps } from '../TagList'
 
 const TAG_DATA: MediaWithTags = {
@@ -11,7 +11,7 @@ const TAG_DATA: MediaWithTags = {
   mediaUrl: 'https://example.com/1.jpg',
   width: 1200,
   height: 960,
-  format: 'jpeg',
+  format: MediaFormat.jpg,
   size: 30000,
   uploadTime: new Date(),
   entityTags: [{
@@ -50,12 +50,11 @@ describe('MobilePopupTagMenu', () => {
 
   test('Tag with permission to delete', async () => {
     const user = userEvent.setup()
-    const callback = jest.fn()
+    // const callback = jest.fn()
     render(
       <PopupTagList
         mediaWithTags={TAG_DATA}
         isAuthorized // Make sure we check that AddTag component is also rendered.
-        onChange={callback}
       />
     )
 

--- a/src/js/hooks/useMediaCmd.tsx
+++ b/src/js/hooks/useMediaCmd.tsx
@@ -1,4 +1,3 @@
-import { useSession } from 'next-auth/react'
 import { DefaultContext, useLazyQuery, useMutation } from '@apollo/client'
 import { toast } from 'react-toastify'
 import { useRouter } from 'next/router'
@@ -33,8 +32,8 @@ type FetchMoreMediaForwardCmd = (args: FetchMoreMediaForwardProps) => Promise<Me
 type AddEntityTagCmd = (props: AddEntityTagProps, jwtToken?: string) => Promise<[EntityTag | null, MediaWithTags | null]>
 type RemoveEntityTagCmd = (args: RemoveEntityTagProps, jwtToken?: string) => Promise<[boolean, MediaWithTags | null]>
 type GetMediaByIdCmd = (id: string) => Promise<MediaWithTags | null>
-type AddMediaObjectsCmd = (mediaList: NewMediaObjectInput[]) => Promise<MediaWithTags[] | null>
-type DeleteOneMediaObjectCmd = (mediaId: string, mediaUrl: string) => Promise<boolean>
+type AddMediaObjectsCmd = (mediaList: NewMediaObjectInput[], jwtToken?: string) => Promise<MediaWithTags[] | null>
+type DeleteOneMediaObjectCmd = (mediaId: string, mediaUrl: string, jwtToken?: string) => Promise<boolean>
 
 /**
  * A React hook for handling media tagging operations.
@@ -45,7 +44,6 @@ type DeleteOneMediaObjectCmd = (mediaId: string, mediaUrl: string) => Promise<bo
  * Apollo cache: https://www.apollographql.com/docs/react/caching/overview
  */
 export default function useMediaCmd (): UseMediaCmdReturn {
-  const session = useSession()
   const router = useRouter()
 
   const addNewMediaToUserGallery = useUserGalleryStore(set => set.addToFront)
@@ -128,12 +126,12 @@ export default function useMediaCmd (): UseMediaCmdReturn {
     }
   )
 
-  const addMediaObjectsCmd: AddMediaObjectsCmd = async (mediaList) => {
+  const addMediaObjectsCmd: AddMediaObjectsCmd = async (mediaList, jwtToken) => {
     const res = await addMediaObjects({
       variables: {
         mediaList
       },
-      context: apolloClientContext(session.data?.accessToken)
+      context: apolloClientContext(jwtToken)
     })
     return res.data?.addMediaObjects ?? null
   }
@@ -146,17 +144,17 @@ export default function useMediaCmd (): UseMediaCmdReturn {
     })
 
   /**
-     * Delete media object from the backend and media storage
-     * @param mediaId
-     * @param mediaUrl
-     */
-  const deleteOneMediaObjectCmd: DeleteOneMediaObjectCmd = async (mediaId, mediaUrl) => {
+    * Delete media object from the backend and media storage
+    * @param mediaId
+    * @param mediaUrl
+    */
+  const deleteOneMediaObjectCmd: DeleteOneMediaObjectCmd = async (mediaId, mediaUrl, jwtToken) => {
     try {
       const res = await deleteOneMediaObject({
         variables: {
           mediaId
         },
-        context: apolloClientContext(session.data?.accessToken)
+        context: apolloClientContext(jwtToken)
       })
       if (res.errors != null) {
         throw new Error('Unexpected API error.')

--- a/src/js/hooks/usePhotoUploader.tsx
+++ b/src/js/hooks/usePhotoUploader.tsx
@@ -76,7 +76,7 @@ export default function usePhotoUploader (): PhotoUploaderReturnType {
         height,
         size,
         ...entityTag != null && { entityTag }
-      }])
+      }], sessionData?.accessToken)
 
       // if upload is successful but we can't update the database,
       // then delete the upload

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,6 @@ import 'react-toastify/dist/ReactToastify.min.css'
 
 import '../styles/global.css'
 import '../../public/fonts/fonts.css'
-import useResponsive from '../js/hooks/useResponsive'
 import useUsernameCheck from '../js/hooks/useUsernameCheck'
 import { useUserGalleryStore } from '../js/stores/useUserGalleryStore'
 import { BlockingAlert } from '../components/ui/micro/AlertDialogue'

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,9 +26,7 @@ interface AppPropsWithAuth extends AppProps<{ session: any }> {
 }
 
 export default function MyApp ({ Component, pageProps: { session, ...pageProps } }: AppPropsWithAuth): JSX.Element {
-  const { isMobile } = useResponsive()
   const uploading = useUserGalleryStore(store => store.uploading)
-
   return (
     <>
       <SessionProvider session={session}>
@@ -48,7 +46,7 @@ export default function MyApp ({ Component, pageProps: { session, ...pageProps }
         <NewUserCheck />
       </SessionProvider>
       <ToastContainer
-        position={isMobile ? 'top-right' : 'bottom-right'}
+        position='bottom-right'
         autoClose={6000}
         hideProgressBar
         newestOnTop


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
On mobile devices `useMediaCmd` hook may bind xxxCmd functions with stale session data/empty JWT token.  Calling add/remove tag APIs will fail at the permission layer check.

### Related Issues

Issue #910 


### What this PR achieves

Delay passing session JWT token to xxxCmds until onClick events. 


### Screenshots, recordings

https://github.com/OpenBeta/open-tacos/assets/3805254/4766c1ef-0355-4c63-a6ce-9fb3c33dd92b






