### PR TITLE
fix: adjust most recent tags filter to pick up more

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -199,7 +199,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     }
   })
 
-  const recentTagsByUsers = await getMediaForFeed(10, 3)
+  const recentTagsByUsers = await getMediaForFeed(20, 3)
 
   const recentTags = recentTagsByUsers.flatMap(entry => entry.mediaWithTags)
 


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description

### Related Issues

Issue https://github.com/OpenBeta/openbeta-graphql/issues/341


### What this PR achieves




### Screenshots, recordings
Adjust api filter to pick up more users.  The backend change still returns much older tags but at least the list is now doesn't seem random.



