### PR TITLE
feat: Get grade context from sandbag

### DIFF
--- a/src/js/grades/Grade.ts
+++ b/src/js/grades/Grade.ts
@@ -1,43 +1,6 @@
-import { GradeScales, getScale } from '@openbeta/sandbag'
+import { gradeContextToGradeScales, getScale } from '@openbeta/sandbag'
 import { RulesType, GradeContextType, GradeValuesType, ClimbDisciplineRecord } from '../types'
 import { EditableClimbType } from '../../components/crag/cragSummary'
-
-const gradeContextToGradeScales = {
-  US: {
-    trad: GradeScales.YDS,
-    sport: GradeScales.YDS,
-    bouldering: GradeScales.VSCALE,
-    tr: GradeScales.YDS,
-    alpine: GradeScales.YDS,
-    mixed: GradeScales.YDS,
-    aid: GradeScales.YDS,
-    snow: GradeScales.YDS, // is this the same as alpine?
-    ice: GradeScales.YDS // is this the same as alpine?
-  },
-  FR: {
-    trad: GradeScales.FRENCH,
-    sport: GradeScales.FRENCH,
-    bouldering: GradeScales.FONT,
-    tr: GradeScales.FRENCH,
-    alpine: GradeScales.FRENCH,
-    mixed: GradeScales.FRENCH,
-    aid: GradeScales.FRENCH,
-    snow: GradeScales.FRENCH, // is this the same as alpine?
-    ice: GradeScales.FRENCH // is this the same as alpine?
-  },
-  AU: {
-    trad: GradeScales.EWBANK,
-    sport: GradeScales.EWBANK,
-    bouldering: GradeScales.VSCALE,
-    tr: GradeScales.EWBANK,
-    deepwatersolo: GradeScales.EWBANK,
-    alpine: GradeScales.YDS,
-    mixed: GradeScales.YDS,
-    aid: GradeScales.AID,
-    snow: GradeScales.YDS, // is this the same as alpine?
-    ice: GradeScales.WI
-  }
-}
 
 export default class Grade {
   context: GradeContextType


### PR DESCRIPTION
## What type of PR is this?

- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

sandbag now has grade contexts that previously were part of openbeta-graphql. Use them instead of maintaining a parallel implementation in open-tacos.


### Related Issues

- https://github.com/OpenBeta/open-tacos/issues/853
- https://github.com/OpenBeta/open-tacos/issues/797


### What this PR achieves

<!---Briefly explains what this PR does.
-->

This will enable adding climbs in a wider variety of locations.

Test UIAA context area on staging: https://stg.openbeta.io/crag/0ce6b0ec-de9b-5062-bcab-0c976f2b8df0

### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->

a sport and a trad route in Germany - this requires UIAA context https://stg.openbeta.io/crag/94404bb7-847d-5bb1-ab4c-82e9dd1913c4
![image](https://github.com/OpenBeta/open-tacos/assets/16665084/b79decd2-256f-4eed-8f04-86ca7ee14295)

test boulder problem in UIAA context https://stg.openbeta.io/crag/7fd87bcd-4f38-5a96-8c54-2453a6d494cd
![image](https://github.com/OpenBeta/open-tacos/assets/16665084/60f571be-41b2-403c-a0b1-fcf61d88a393)

test sport/trad in South Africa context
![image](https://github.com/OpenBeta/open-tacos/assets/16665084/d849c946-053a-48fc-b494-0dcac557f133)


test boulder in South Africa context
![image](https://github.com/OpenBeta/open-tacos/assets/16665084/332cf22d-e8fd-49c9-90cf-c9fa6f43cea5)



### Notes

todo:

- [ ] tests
- [ ] merge https://github.com/OpenBeta/sandbag/pull/134 and release new version
- [ ] bump required sandbag version here



