### PR TITLE
feat: users can set area type when creating a new area

### DIFF
--- a/src/components/crag/cragSummary.tsx
+++ b/src/components/crag/cragSummary.tsx
@@ -119,6 +119,10 @@ export default function CragSummary ({ area, history }: CragSummaryProps): JSX.E
    */
   const [childAreasCache, setChildAreasCache] = useState(sortByLeftRightIndex(childAreas))
 
+  useEffect(() => {
+    setChildAreasCache(sortByLeftRightIndex(childAreas))
+  }, [childAreas])
+
   /**
    * Hold the form base states aka default values.  Since we use Next SSG,
    * this component props become stale the moment a user submits a change.

--- a/src/components/edit/AddChildAreaForm.tsx
+++ b/src/components/edit/AddChildAreaForm.tsx
@@ -9,6 +9,7 @@ import { AddAreaReturnType } from '../../js/graphql/gql/contribs'
 import { SuccessAlert, AlertAction, ErrorAlert } from './alerts/Alerts'
 import Input from '../ui/form/Input'
 import useUpdateAreasCmd from '../../js/hooks/useUpdateAreasCmd'
+import { AreaDesignationRadioGroup, areaDesignationToDb, AreaTypeFormProp } from './form/AreaDesignationRadioGroup'
 
 export interface AddAreaFormProps {
   parentUuid: string
@@ -70,6 +71,7 @@ export interface ChildAreaBaseProps {
 interface NewAreaFormProps extends ChildAreaBaseProps {
   newAreaName: string
   shortCode: string
+  areaType: AreaTypeFormProp
 }
 
 /**
@@ -92,10 +94,11 @@ const Step1 = (props: ChildAreaBaseProps): JSX.Element => {
     defaultValues: { newAreaName: '', shortCode: '', parentName: parentName }
   })
 
-  const { handleSubmit, formState: { isSubmitting }, setFocus } = form
+  const { handleSubmit, formState: { isSubmitting, isSubmitSuccessful }, setFocus } = form
 
-  const submitHandler = async ({ newAreaName }: NewAreaFormProps): Promise<void> => {
-    await addOneAreaCmd({ name: newAreaName, parentUuid })
+  const submitHandler = async ({ newAreaName, areaType }: NewAreaFormProps): Promise<void> => {
+    const { isBoulder, isLeaf } = areaDesignationToDb(areaType)
+    await addOneAreaCmd({ name: newAreaName, parentUuid, isBoulder, isLeaf })
   }
 
   useEffect(() => {
@@ -128,10 +131,14 @@ const Step1 = (props: ChildAreaBaseProps): JSX.Element => {
             }
           }}
         />
+
+        <AreaDesignationRadioGroup disabled={false} />
+
         <button
+          disabled={isSubmitSuccessful || isSubmitting}
           className={
-            clx('mt-4 btn btn-primary w-full',
-              isSubmitting ? 'loading btn-disabled' : ''
+            clx('mt-12 btn btn-primary w-full',
+              isSubmitting ? 'btn-disabled' : ''
             )
           }
           type='submit'

--- a/src/components/edit/Triggers.tsx
+++ b/src/components/edit/Triggers.tsx
@@ -78,7 +78,8 @@ export const DeleteAreaTriggerButtonSm = ({ disabled }: TriggerButtonProps): JSX
       </Tooltip>)
     : (
       <DialogTrigger
-        className='btn btn-ghost btn-circle btn-primary'
+        data-no-dnd='true'
+        className='z-50 btn btn-ghost btn-circle btn-accent'
         disabled={disabled}
         type='button'
       >
@@ -130,13 +131,13 @@ const AddAreaTriggerButtonCTA = (): JSX.Element => (
 )
 
 export const AddAreaTriggerButtonMd = (): JSX.Element => (
-  <DialogTrigger className='btn btn-sm w-full md:btn-wide btn-solid btn-secondary border-dashed border-2 gap-2'>
-    <PlusIcon className='stroke-2 w-5 h-5' /> New Area
+  <DialogTrigger data-no-dnd='true' className='btn btn-sm w-full md:btn-wide btn-solid btn-secondary border-dashed border-2 gap-2'>
+    <PlusIcon className='stroke-2 w-5 h-5' data-no-dnd='true' /> New Area
   </DialogTrigger>
 )
 
 export const AddAreaTriggerButtonSm = (): JSX.Element => (
-  <DialogTrigger className='btn btn-square btn-secondary btn-sm btn-ghost border-dashed border-2'>
-    <PlusCircleIcon className='w-6 h-6 text-secondary' />
+  <DialogTrigger className='btn btn-square btn-sm btn-ghost'>
+    <PlusCircleIcon className='w-6 h-6 text-base-content/80' />
   </DialogTrigger>
 )

--- a/src/components/edit/form/AreaDesignationRadioGroup.tsx
+++ b/src/components/edit/form/AreaDesignationRadioGroup.tsx
@@ -26,6 +26,7 @@ export const AreaDesignationRadioGroup = ({ name = 'areaType', disabled = false 
       'Boulder']}
     values={['area', 'crag', 'boulder']}
     labelTips={['Group other areas.', 'List rope climbing routes.', 'List boulder problems.']}
+    requiredErrorMessage='Please select an area type'
   />)
 
 export const ExplainAreaTypeLockTooltip = ({ canEdit }: { canEdit: boolean }): JSX.Element | null =>

--- a/src/components/ui/MobileDialog.tsx
+++ b/src/components/ui/MobileDialog.tsx
@@ -19,6 +19,7 @@ export const DialogContent = React.forwardRef<any, Props>(
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className='z-40 fixed inset-0 bg-black/60' />
         <DialogPrimitive.Content
+          data-no-dnd='true'
           className={clx(fullScreen ? 'dialog-wide' : 'dialog-default')} {...props} ref={forwardedRef}
         >
           <DialogPrimitive.Title className='dialog-title'>

--- a/src/components/ui/form/RadioGroup.tsx
+++ b/src/components/ui/form/RadioGroup.tsx
@@ -8,16 +8,24 @@ interface RadioGroupProps {
   values: string[]
   labelTips?: string[]
   disabled?: boolean
+  requiredErrorMessage: string
 }
 
 /**
- * A radio button group
+ * A radio button group.  An option must be selected.
  */
-export default function RadioGroup ({ groupLabel, groupLabelAlt, name, labels, values, labelTips = [], disabled = false }: RadioGroupProps): JSX.Element | null {
+export default function RadioGroup ({ groupLabel, groupLabelAlt, name, labels, values, labelTips = [], requiredErrorMessage, disabled = false }: RadioGroupProps): JSX.Element | null {
   if (labels.length !== values.length) return null // Mismatched labels and values
 
-  const { field } = useController({ name })
+  const { field, formState: { errors } } = useController({
+    name,
+    rules: {
+      required: requiredErrorMessage
+    }
+  })
   const { value } = field
+
+  const error = errors?.[name]
 
   return (
     <div className='form-control'>
@@ -46,7 +54,10 @@ export default function RadioGroup ({ groupLabel, groupLabelAlt, name, labels, v
           </label>
         ))}
       </div>
-      {/* <label className='label label-text-alt'>{labelTips[selectedIndex]}</label> */}
+      <label className='label h-12' id={`${name}-helper`} htmlFor={name}>
+        {error?.message != null &&
+           (<span className='label-text-alt text-error'>{error?.message as string}</span>)}
+      </label>
     </div>
   )
 }

--- a/src/js/graphql/gql/areaById.ts
+++ b/src/js/graphql/gql/areaById.ts
@@ -119,18 +119,17 @@ export const QUERY_AREA_BY_ID = gql`
  * Why having 2 nearly identical queries?
  * TODO:  Combine this one and the main one above
  */
-export const QUERY_AREA_FOR_EDIT = gql`query AreaByID($uuid: ID) {
-  ${FRAGMENT_CLIMB_DISCIPLINES}
+export const QUERY_AREA_FOR_EDIT = gql`
+${FRAGMENT_CLIMB_DISCIPLINES}
+${FRAGMENT_MEDIA_WITH_TAGS}
+query AreaByID($uuid: ID) {
   area(uuid: $uuid) {
     id
     uuid
     areaName
     gradeContext
     media {
-      username
-      mediaUrl
-      destination
-      destType
+      ... MediaWithTagsFields
     }
     metadata {
       areaId

--- a/src/js/graphql/gql/contribs.ts
+++ b/src/js/graphql/gql/contribs.ts
@@ -15,8 +15,8 @@ mutation ($isoCode: String!) {
 }`
 
 export const MUTATION_ADD_AREA = gql`
-mutation ($name: String!, $parentUuid: ID, $countryCode: String) {
-    addArea(input: { name: $name, parentUuid: $parentUuid, countryCode: $countryCode } ) {
+mutation ($name: String!, $parentUuid: ID, $countryCode: String, $isBoulder: Boolean, $isLeaf: Boolean) {
+    addArea(input: { name: $name, parentUuid: $parentUuid, countryCode: $countryCode, isBoulder: $isBoulder, isLeaf: $isLeaf } ) {
       areaName
       uuid
     }
@@ -152,6 +152,8 @@ export interface AddAreaProps {
   name: string
   parentUuid?: string
   countryCode?: string
+  isBoulder?: boolean
+  isLeaf?: boolean
 }
 
 export type AddAreaReturnType = Pick<AreaType, 'areaName'|'uuid'>

--- a/src/js/hooks/useUpdateAreasCmd.tsx
+++ b/src/js/hooks/useUpdateAreasCmd.tsx
@@ -118,14 +118,13 @@ export default function useUpdateAreasCmd ({ areaId, accessToken = '', ...props 
     MUTATION_ADD_AREA, {
       client: graphqlClient,
       onCompleted: async (data) => {
+        if (onAddCompleted != null) {
+          onAddCompleted(data)
+        }
         toast.info('Area added 🔥')
 
         await refreshPage(`/api/revalidate?s=${data.addArea.uuid}`) // build new area page
         await refreshPage(`/api/revalidate?s=${areaId}`) // rebuild parent page
-
-        if (onAddCompleted != null) {
-          onAddCompleted(data)
-        }
       },
       onError: (error) => {
         toast.error(`Unexpected error: ${error.message}`)
@@ -136,11 +135,13 @@ export default function useUpdateAreasCmd ({ areaId, accessToken = '', ...props 
     }
   )
 
-  const addOneAreaCmd: AddOneAreCmdType = async ({ name, parentUuid }: AddAreaProps) => {
+  const addOneAreaCmd: AddOneAreCmdType = async ({ name, parentUuid, isBoulder, isLeaf }: AddAreaProps) => {
     await addArea({
       variables: {
         name,
-        parentUuid: parentUuid
+        parentUuid: parentUuid,
+        ...isBoulder != null && { isBoulder },
+        ...isLeaf != null && { isLeaf }
       },
       context: {
         headers: {

--- a/src/pages/edit/addArea.tsx
+++ b/src/pages/edit/addArea.tsx
@@ -206,6 +206,7 @@ const Step2b = (): JSX.Element => {
       name='locationRefType'
       labels={['Near by', 'Add as nested area']}
       values={['near', 'child']}
+      requiredErrorMessage='Please select a type'
     />
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
   ],
 
   // https://github.com/tailwindlabs/tailwindcss-forms
-  plugins: [require('daisyui'), require('@tailwindcss/typography'), require('tailwindcss-radix')()],
+  plugins: [require('@tailwindcss/typography'), require('daisyui'), require('tailwindcss-radix')()],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
- [x] feat: users can select area type when creating a new area
- [x] feat: users don't need to be in edit mode to add an area
- [x] fix: prevent drag-n-drop component from capturing click events

---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #709 


### What this PR achieves




### Screenshots, recordings
New area type selection
<img width="500" alt="Screenshot 2023-07-24 at 9 08 46 AM" src="https://github.com/OpenBeta/open-tacos/assets/3805254/958ed52b-d5f1-44ab-958c-872b12631458">

Add button accessible without requiring users to be in Edit mode
<img width="900" alt="Screenshot 2023-07-24 at 9 06 41 AM" src="https://github.com/OpenBeta/open-tacos/assets/3805254/02f92e30-273d-4115-b7c6-789c4882e995">




