### PR TITLE
fix: Implementing 404 page for unknown crags and climbs

### DIFF
--- a/src/js/graphql/api.ts
+++ b/src/js/graphql/api.ts
@@ -215,6 +215,6 @@ export const getClimbById = async (id: string): Promise<ClimbType> => {
       id
     },
     fetchPolicy: 'no-cache'
-  })
+  }).catch(e => { throw new Error(e) })
   return res.data.climb
 }

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -32,6 +32,7 @@ import { removeTypenameFromDisciplines } from '../../js/utils'
 import { TotalLengthInput } from '../../components/edit/form/TotalLengthInput'
 import { LegacyFAInput } from '../../components/edit/form/LegacyFAInput'
 import { getClimbById } from '../../js/graphql/api'
+import { GraphQLError } from 'graphql/error/GraphQLError'
 
 export const CLIMB_DESCRIPTION_FORM_VALIDATION_RULES: RulesType = {
   maxLength: {
@@ -360,6 +361,17 @@ export const getStaticProps: GetStaticProps<ClimbPageProps, { id: string }> = as
   }
 
   const climb = await getClimbById(params.id)
+    .catch((err: GraphQLError) => {
+      if (err.message === 'Invalid UUID.') {
+        return null
+      }
+    })
+
+  if (climb == null) {
+    return {
+      notFound: true
+    }
+  }
 
   const sortedClimbsInArea = await fetchSortedClimbsInArea(climb.ancestors[climb.ancestors.length - 1])
   let leftClimb: ClimbType | null = null

--- a/src/pages/crag/[id].tsx
+++ b/src/pages/crag/[id].tsx
@@ -11,6 +11,7 @@ import PhotoMontage from '../../components/media/PhotoMontage'
 import { UploadCTACragBanner } from '../../components/media/UploadCTA'
 import CragSummary, { Skeleton as AreaContentSkeleton } from '../../components/crag/cragSummary'
 import { QUERY_AREA_BY_ID } from '../../js/graphql/gql/areaById'
+import { GraphQLError } from 'graphql/error/GraphQLError'
 
 interface CragProps {
   area: AreaType
@@ -93,6 +94,10 @@ export const getStaticProps: GetStaticProps<CragProps, { id: string }> = async (
       uuid: params.id
     },
     fetchPolicy: 'no-cache'
+  }).catch((e: GraphQLError) => {
+    if (e.message === 'Invaild UUID') {
+      return null
+    }
   })
 
   if (rs?.data == null || rs?.data?.area == null) {


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: Implementing 404 page for unknown crags and climbs
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Addressing Issue #927

### What this PR achieves

As pointed out in the issue, if you go to https://openbeta.io/crag/79be0b8 or https://openbeta.io/climbs/428f9f46-7dab, you are taken to a page that looks like this:

![image](https://github.com/OpenBeta/open-tacos/assets/20007305/2c54be89-c931-4e03-947e-ad45d337cb11)

This is because we are trying to query the graphqlClient with an invalid UUID. This throws an unhandled GraphQLError error in getStaticProps functions of both the crag and climbs page. 

What this PR achieves is that it handles this error by returning { notFound: true } in getStaticProps, which consequently leads to the 404 page.

![image](https://github.com/OpenBeta/open-tacos/assets/20007305/cede5605-dc75-4b68-a1c2-5f10c9773751)


### Notes

 - I ensured that this error will only trigger when there is an invalid UUID. The idea being if there were other errors, there may be a different page. I wonder if this was the right approach or if a general catch-all would work.
 
- This is actually my first pull request, so I would appreciate some strict scrutiny of my code.

