### PR TITLE
History cards #751

### DIFF
--- a/src/components/edit/RecentChangeHistory.tsx
+++ b/src/components/edit/RecentChangeHistory.tsx
@@ -58,7 +58,6 @@ const ClimbChange = ({ changeId, fullDocument, updateDescription, dbOp }: Change
   if (fullDocument.__typename !== DocumentTypeName.Climb) {
     return null
   }
-  const doc = fullDocument as ClimbType
   // @ts-expect-error
   const icon = dbOpIcon[dbOp]
   return (
@@ -68,11 +67,11 @@ const ClimbChange = ({ changeId, fullDocument, updateDescription, dbOp }: Change
       <div className=''>
         <div className=''>
           {dbOp === 'delete'
-            ? <span>{doc.name}</span>
-            : (<Link href={`/climbs/${doc.id}`}><a className='link link-hover'>{doc.name}</a></Link>)}
+            ? <span>{(fullDocument as ClimbType).name}</span>
+            : (<Link href={`/climbs/${(fullDocument as ClimbType).id}`}><a className='link link-hover'>{(fullDocument as ClimbType).name}</a></Link>)}
         </div>
         <div className='text-xs text-base-300'>
-          <UpdatedFields fields={updateDescription?.updatedFields} doc={doc} />
+          <UpdatedFields fields={updateDescription?.updatedFields} doc={fullDocument as ClimbType} />
         </div>
       </div>
       {/* <div className='row-span-2 col-span-2'>{JSON.stringify(updateDescription?.updatedFields)}</div> */}

--- a/src/components/edit/RecentChangeHistory.tsx
+++ b/src/components/edit/RecentChangeHistory.tsx
@@ -4,7 +4,6 @@ import { PlusIcon, UserCircleIcon, MinusIcon, PencilIcon, PencilSquareIcon, Minu
 import { formatDistanceToNow } from 'date-fns'
 
 import { ChangesetType, ChangeType, AreaType, ClimbType, OrganizationType, DocumentTypeName } from '../../js/types'
-import { constant } from 'underscore'
 
 export interface RecentChangeHistoryProps {
   history: ChangesetType[]
@@ -22,7 +21,7 @@ interface ChangsetRowProps {
 }
 
 const ChangesetRow = ({ changeset }: ChangsetRowProps): JSX.Element => {
-  const { id, createdAt, editedByUser, operation, changes } = changeset
+  const { createdAt, editedByUser, operation, changes } = changeset
 
   // @ts-expect-error
   const op = operationLabelMap[operation]
@@ -130,7 +129,7 @@ const OrganizationChange = ({ changeId, fullDocument, updateDescription, dbOp }:
 
 interface UpdatedFieldsProps {
   fields: string[] | undefined
-  doc: ClimbType | AreaType | OrganizationType
+  doc: any
 }
 const UpdatedFields = ({ fields, doc }: UpdatedFieldsProps): JSX.Element | null => {
   if (fields == null) return null
@@ -144,17 +143,17 @@ const UpdatedFields = ({ fields, doc }: UpdatedFieldsProps): JSX.Element | null 
 
       // single access - doc[attr]
       if (field in doc) {
-        // @ts-expect-error
         const value = JSON.stringify(doc[field])
         return (<div key={field}>{field} -&gt; {value}{field.includes('length') ? 'm' : ''}</div>)
       }
 
       // double access - doc[parent][child]
       if (field.includes('.')) {
-        const [parent, child] = field.split('.')
-        // @ts-expect-error
+        var [parent, child] = field.split('.')
+        if (parent === 'content' && doc.__typename === DocumentTypeName.Area) {
+          parent = 'areaContent' // I had to alias this in the query bc of the overlap with ClimbType
+        }
         if (parent in doc && child in doc[parent]) {
-          // @ts-expect-error
           const value = JSON.stringify(doc[parent][child])
           return (<div key={field}>{child} -&gt; {value}</div>)
         }

--- a/src/js/graphql/gql/contribs.ts
+++ b/src/js/graphql/gql/contribs.ts
@@ -114,15 +114,53 @@ export const FRAGMENT_CHANGE_HISTORY = gql`
         ... on Area {
           areaName
           uuid
+          areaContent: content {
+            description
+          }
           metadata {
             leaf
             areaId
+            isDestination
+            leaf
+            isBoulder
+            lat
+            lng
+            leftRightIndex
           }
+          shortCode
         }
         ... on Climb {
           id
           name
           uuid
+          content {
+            description
+            location
+            protection
+          }
+          grades {
+            vscale
+            yds
+            ewbank
+            french
+            font
+            uiaa
+          }
+          type {
+            aid
+            alpine
+            bouldering
+            deepwatersolo
+            ice
+            mixed
+            snow
+            sport
+            tr
+            trad
+          }
+          boltsCount
+          fa
+          length
         }
         ... on Organization {
           displayName


### PR DESCRIPTION
name: Recent history cards #751 
---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
 I updated the cards on the edit page to display more info - just the name of the changed attribute and the new value. This required making the 'FRAGMENT_CHANGE_HISTORY' query in contribs.ts larger. I also updated the margins on the cards themselves because they were inconsistent/nonexistent.
### Related Issues

Issue #751 


### What this PR achieves
Makes the cards on the /edit page look better, and they provide some info, rather than just the name of the fields. Hide the unnecessary (weird metadata) or inaccessible (i.e. 'children', which is an array of AreaType that I didn't include in the query).

### Screenshots, recordings
<img width="548" alt="Screen Shot 2023-08-02 at 2 08 19 PM" src="https://github.com/OpenBeta/open-tacos/assets/74275670/58f41c4b-06fd-4490-b68f-7c9493f8a68e">



### Notes
I had some issues with types and accessing objects - currently I don't have a type for the doc that's passed in. I first typed it as (ClimbType | AreaType | OrgType) but I needed the type name that it initially comes with (in types.ts it includes '... & DocumentTypeName') and couldn't work that out without removing the typing.

I'm open to any advice or changes.