### PR TITLE
feat: add gh action that posts a message to discord when pushing to develop

### DIFF
--- a/.github/workflows/discord-messages.yml
+++ b/.github/workflows/discord-messages.yml
@@ -1,0 +1,24 @@
+name: notify-discord
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Actions for Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
+        with:
+          args: ${{ env.DISCORD_MESSAGE }}
+
+      - name: Error Alert
+        if: failure()
+        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
+        with:
+          args: '🚨 An error occurred while running the workflow. test'


### PR DESCRIPTION
closes #895

---
name: Pull request
about: Create a pull request
title: 'add gh action that posts a message to discord when pushing to develop'
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

This is a github action that will post a message to the channel 'github-updates' when: a pull request is merged into develop, a push occurs directly to develop. 

### Related Issues

Issue #895 


### Screenshots, recordings
![image](https://github.com/OpenBeta/open-tacos/assets/24685932/0d5aeec6-139e-4300-ba4f-5475736df37c)

it also works when merging from a fork 
![image](https://github.com/OpenBeta/open-tacos/assets/24685932/c9cab1a9-8741-4c61-9cb3-de757f18fc46)





### Notes
discord channel: https://discord.com/channels/815145484003967026/1124217132071276604




