### PR TITLE
Set up an initial SA grade context, so that routes can be added in th…

### DIFF
--- a/src/js/grades/Grade.ts
+++ b/src/js/grades/Grade.ts
@@ -36,6 +36,17 @@ const gradeContextToGradeScales = {
     aid: GradeScales.AID,
     snow: GradeScales.YDS, // is this the same as alpine?
     ice: GradeScales.WI
+  },
+  SA: {
+    trad: GradeScales.FRENCH,
+    sport: GradeScales.FRENCH,
+    bouldering: GradeScales.FONT,
+    tr: GradeScales.FRENCH,
+    alpine: GradeScales.FRENCH,
+    mixed: GradeScales.FRENCH,
+    aid: GradeScales.FRENCH,
+    snow: GradeScales.FRENCH, // is this the same as alpine?
+    ice: GradeScales.FRENCH // is this the same as alpine?
   }
 }
 


### PR DESCRIPTION
…

This is not a strictly accurate context to give, as there are bespoke SA systems for trad and sport. Nevertheless, this should get us off the ground with pretty close conversions

---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [x] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description


### What this PR achieves

Not a permanent solution, but this will let me add South African routes in the interim. The provided context is not entirely accurate, and South Africa uses different grade contexts depending on the sub-area...


### Notes

This is not a scalable solution, a proper run at sandbag will need to be made at some point.

