### PR TITLE
Updated public CDN to new media server [  #1013]

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ AUTH0_MGMT_CLIENT_SECRET=send request to hello at openbeta.io
 # Must prefix with NEXT_PUBLIC_in order to expose vars to the browser
 # See https://nextjs.org/docs/basic-features/environment-variables
 
-NEXT_PUBLIC_CDN_URL=https://storage.googleapis.com/openbeta-staging
+NEXT_PUBLIC_CDN_URL=https://stg-media.openbeta.io
 
 NEXT_PUBLIC_API_SERVER=https://stg-api.openbeta.io
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,20 +1,7 @@
 module.exports = {
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'openbeta.sirv.com'
-      },
-      {
-        protocol: 'https',
-        hostname: 'openbeta-dev.sirv.com',
-        pathname: '*'
-      },
-      {
-        protocol: 'https',
-        hostname: 'storage.googleapis.com'
-      }
-    ]
+    loader: 'custom',
+    loaderFile: './src/image-loader.js'
   },
   typescript: {
     ignoreBuildErrors: false

--- a/src/app/components/Volunteers.tsx
+++ b/src/app/components/Volunteers.tsx
@@ -56,7 +56,7 @@ const Profile: React.FC<GithubProfile> = ({
   >
     <div className='avatar'>
       <div className='w-8 rounded-box'>
-        <img src={avatar_url} alt={name} />
+        <img loading='lazy' src={avatar_url} alt={name} />
       </div>
     </div>
     <div className='text-sm uppercase text-base-content pr-4'>{name}</div>

--- a/src/components/home/RecentMediaCard.tsx
+++ b/src/components/home/RecentMediaCard.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image'
 import clx from 'classnames'
 import Card from '../ui/Card/Card'
 import TagList from '../media/TagList'
-import { MobileLoader } from '../../js/sirv/util'
 import { MediaWithTags } from '../../js/types'
 import { getUploadDateSummary } from '../../js/utils'
 import { PostHeader } from './Post'
@@ -38,10 +37,7 @@ export const RecentImageCard = ({
         <div className='relative block w-full h-full'>
           <ATagWrapper href={firstUrl}>
             <Image
-              src={MobileLoader({
-                src: mediaUrl,
-                width: MOBILE_IMAGE_MAX_WIDITH
-              })}
+              src={mediaUrl}
               width={MOBILE_IMAGE_MAX_WIDITH}
               height={MOBILE_IMAGE_MAX_WIDITH / imageRatio}
               sizes={`${MOBILE_IMAGE_MAX_WIDITH}px`}

--- a/src/components/ui/FeatureCard/FeatureCard.tsx
+++ b/src/components/ui/FeatureCard/FeatureCard.tsx
@@ -12,7 +12,7 @@ function FeatureCard ({ area }: { area: AreaType }): JSX.Element | null {
 
   if (media == null || media.length === 0) return null
 
-  const imageUrl = `${CLIENT_CONFIG.CDN_BASE_URL}${shuffle(media)[0].mediaUrl}?format=webp&h=300&q=90`
+  const imageUrl = `${CLIENT_CONFIG.CDN_BASE_URL}${shuffle(media)[0].mediaUrl}?h=300&q=90`
 
   const image = {
     url: imageUrl,

--- a/src/image-loader.js
+++ b/src/image-loader.js
@@ -3,8 +3,7 @@ const imageLoader = ({ src, width, quality }) => {
   if (src.includes(BASE_URL)) {
     return src
   }
-  // The case below does not seem to be handled by this image-loader, it's here just in case:
-  return `${process.env.NEXT_PUBLIC_CDN_URL}/${src}?w=${width}&q=${quality || 75}`
+  return `${process.env.NEXT_PUBLIC_CDN_URL}${src}?w=${width}&q=${quality || 75}`
 }
 
 export default imageLoader

--- a/src/image-loader.js
+++ b/src/image-loader.js
@@ -1,0 +1,10 @@
+const BASE_URL = process.env.NEXT_PUBLIC_CDN_URL
+const imageLoader = ({ src, width, quality }) => {
+  if (src.includes(BASE_URL)) {
+    return src
+  }
+  // The case below does not seem to be handled by this image-loader, it's here just in case:
+  return `${process.env.NEXT_PUBLIC_CDN_URL}/${src}?w=${width}&q=${quality || 75}`
+}
+
+export default imageLoader

--- a/src/js/sirv/util.ts
+++ b/src/js/sirv/util.ts
@@ -1,23 +1,24 @@
 import { ImageLoaderProps } from 'next/image'
 import { CLIENT_CONFIG } from '../configs/clientConfig'
 
+const DEFAULT_IMAGE_QUALITY = 90
 /**
  * Custom NextJS image loader
  */
 export const DefaultLoader = ({ src, width, quality }: ImageLoaderProps): string => {
-  return `${CLIENT_CONFIG.CDN_BASE_URL}${src}?format=webp&w=${width}&q=${quality ?? '90'}`
+  return `${CLIENT_CONFIG.CDN_BASE_URL}${src}?w=${width}&q=${quality ?? DEFAULT_IMAGE_QUALITY}`
 }
 
 /**
  * Desktop preview loader
  */
 export const DesktopPreviewLoader = ({ src, width, quality }: ImageLoaderProps): string => {
-  return `${CLIENT_CONFIG.CDN_BASE_URL}${src}?format=webp&thumbnail=300&q=${quality ?? '90'}`
+  return `${CLIENT_CONFIG.CDN_BASE_URL}${src}?thumbnail=300&q=${quality ?? DEFAULT_IMAGE_QUALITY}`
 }
 
 /**
  * Custom NextJS image loader for mobile
  */
 export const MobileLoader = ({ src, width = 650, quality }: ImageLoaderProps): string => {
-  return `${CLIENT_CONFIG.CDN_BASE_URL}${src}?format=webp&w=${width}&q=${quality ?? '90'}`
+  return `${CLIENT_CONFIG.CDN_BASE_URL}${src}?w=${width}&q=${quality ?? DEFAULT_IMAGE_QUALITY}`
 }


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [x] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description
This pr replaces next's  and google storage cdn with our own image server. 
It also makes small tweaks in images loading with `MobileLoader`. 
We also remove `format=webp` because this should not be "enforced", browsers will tell the new image-server what format they accept. We go with webp > avif > jpg.

### Related Issues
Issue #1013


### What this PR achieves
Takes control of how images are optimized, also allowing us better cost/scalability control.

### Notes
I could not really understand why we have that `MobileLoader` messing with all image widths, something seems wrong there so I just replaced it and let the image width come naturally - it was set to 600px before, something seems missing.



