### PR TITLE
feat: add Brazilian grades to frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@hookform/resolvers": "^3.1.1",
     "@lexical/react": "^0.7.5",
     "@math.gl/web-mercator": "3.6.2",
-    "@openbeta/sandbag": "^0.0.48",
+    "@openbeta/sandbag": "^0.0.51",
     "@radix-ui/react-alert-dialog": "^1.0.0",
     "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-dropdown-menu": "^2.0.1",

--- a/src/js/grades/Grade.ts
+++ b/src/js/grades/Grade.ts
@@ -47,6 +47,18 @@ const gradeContextToGradeScales = {
     aid: GradeScales.FRENCH,
     snow: GradeScales.FRENCH, // is this the same as alpine?
     ice: GradeScales.FRENCH // is this the same as alpine?
+  },
+  BR: {
+    trad: GradeScales.BRAZILIAN_CRUX,
+    sport: GradeScales.BRAZILIAN_CRUX,
+    bouldering: GradeScales.VSCALE,
+    tr: GradeScales.BRAZILIAN_CRUX,
+    deepwatersolo: GradeScales.BRAZILIAN_CRUX,
+    alpine: GradeScales.BRAZILIAN_CRUX,
+    mixed: GradeScales.BRAZILIAN_CRUX,
+    aid: GradeScales.AID,
+    ice: GradeScales.WI,
+    snow: GradeScales.WI
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,10 +1805,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openbeta/sandbag@^0.0.48":
-  version "0.0.48"
-  resolved "https://registry.yarnpkg.com/@openbeta/sandbag/-/sandbag-0.0.48.tgz#d876ae47634c287be1f71858576a9f826f8ee270"
-  integrity sha512-QyTGG9Y+c+2TY+EbdUByAAr1u7qyqZ4H1ZM0TztetJU/a7TLjdMoR32yaRY8uSFvm3f1sP0zn0ffhlLiICDdlg==
+"@openbeta/sandbag@^0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@openbeta/sandbag/-/sandbag-0.0.51.tgz#21ce618d2414dc0b8d4f31ef260ac2ebad5a43c8"
+  integrity sha512-qMVohgqRdFjXH8a3aSEZa6zemwSpak/HMttR/pqvclDIXqgPKzWvjFRA3o/YDGieI/19P4dtizLo91TKx0smGQ==
 
 "@panva/hkdf@^1.0.2":
   version "1.1.1"


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
Adds `BR` the `gradeContextToGradeScales`
### Related Issues

Issue #1022


### What this PR achieves
This PR maps Brazil (BR) to its designated climbing grade scales.

### Notes
~I was not able to test this because it's under login wall and passing that seems cumbersome right now~ I realized I have no idea how to test this or if it's even possible to add climbs :)

