### PR TITLE
fix: add full screen option in area map

### DIFF
--- a/src/components/area/areaMap.tsx
+++ b/src/components/area/areaMap.tsx
@@ -1,6 +1,6 @@
 'use client'
 import * as React from 'react'
-import { Map, Marker, ScaleControl, LngLatBoundsLike, MapboxMap } from 'react-map-gl'
+import { Map, Marker, ScaleControl, FullscreenControl, LngLatBoundsLike, MapboxMap } from 'react-map-gl'
 import dynamic from 'next/dynamic'
 import { AreaMetadataType, AreaType } from '../../js/types'
 import { MAP_STYLES } from '../maps/BaseMap'
@@ -108,6 +108,7 @@ export default function AreaMap (props: AreaMapProps): JSX.Element {
         </Marker>
 
         <ScaleControl />
+        <FullscreenControl />
       </Map>
     </div>
   )


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [x] other

### Related Issues

Issue #1039 


### What this PR achieves

Adds a button for entering full-screen mode in the area map.

### Screenshots, recordings
![image](https://github.com/OpenBeta/open-tacos/assets/19895420/d180c239-3ee5-41c8-8ab9-2e0276add862)


