### PR TITLE
feat: add list of area's routes to route page

### DIFF
--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -297,7 +297,7 @@ const Body = ({ climb, leftClimb, rightClimb, parentArea }: ClimbPageProps): JSX
               </div>
             </div>
 
-            <div className='area-climb-page-summary-right lg:h-0 lg:min-h-full'>
+            <div className='area-climb-page-summary-right col-start-2 col-end-4 row-start-1 row-end-3'>
               <div className='mb-3 flex justify-between items-center'>
                 <h3>Description</h3>
               </div>
@@ -346,7 +346,7 @@ const Body = ({ climb, leftClimb, rightClimb, parentArea }: ClimbPageProps): JSX
                 {FormAction}
               </div>
             </div>
-            <div>
+            <div className='col-start-1 col-end-2'>
               <h4>Routes in {parentArea.areaName.includes(', The') ? 'The '.concat(parentArea.areaName.slice(0, -5)) : parentArea.areaName}</h4>
               <hr className='mt-2 mb-2 border-1 border-base-content' />
               {!editMode && <ClimbList gradeContext={parentArea.gradeContext} climbs={parentArea.climbs} areaMetadata={parentArea.metadata} editMode={editMode} routePageId={climbId} />}

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -385,7 +385,7 @@ export const getStaticProps: GetStaticProps<ClimbPageProps, { id: string }> = as
     }
   }
 
-  const parentAreaData = await getArea(climb.ancestors[climb.ancestors.length - 1])
+  const parentAreaData = await getArea(climb.ancestors[climb.ancestors.length - 1], 'cache-first')
   let leftClimb: ClimbType | null = null
   let rightClimb: ClimbType | null = null
 

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { GetStaticProps, NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { gql } from '@apollo/client'
 import { useForm, FormProvider } from 'react-hook-form'
 import { useSession } from 'next-auth/react'
 import dynamic from 'next/dynamic'
@@ -11,7 +10,6 @@ import { useSwipeable } from 'react-swipeable'
 import { toast } from 'react-toastify'
 import ArrowVertical from '../../assets/icons/arrow-vertical.svg'
 
-import { graphqlClient } from '../../js/graphql/Client'
 import Layout from '../../components/layout'
 import { AreaType, ClimbDisciplineRecord, ClimbType, RulesType } from '../../js/types'
 import SeoTags from '../../components/SeoTags'
@@ -33,6 +31,9 @@ import { TotalLengthInput } from '../../components/edit/form/TotalLengthInput'
 import { LegacyFAInput } from '../../components/edit/form/LegacyFAInput'
 import { getClimbById } from '../../js/graphql/api'
 import { GraphQLError } from 'graphql/error/GraphQLError'
+import { ClimbList } from '@/app/editArea/[slug]/general/components/climb/ClimbListForm'
+import { getArea } from '@/js/graphql/getArea'
+import { climbLeftRightIndexComparator } from '@/js/utils'
 
 export const CLIMB_DESCRIPTION_FORM_VALIDATION_RULES: RulesType = {
   maxLength: {
@@ -59,6 +60,7 @@ interface ClimbPageProps {
   leftClimb: ClimbType | null
   rightClimb: ClimbType | null
   showSkeleton?: boolean
+  parentArea: AreaType
 }
 
 const ClimbPage: NextPage<ClimbPageProps> = (props: ClimbPageProps) => {
@@ -102,7 +104,7 @@ export interface ClimbEditFormProps {
   length?: number
 }
 
-const Body = ({ climb, leftClimb, rightClimb }: ClimbPageProps): JSX.Element => {
+const Body = ({ climb, leftClimb, rightClimb, parentArea }: ClimbPageProps): JSX.Element => {
   const {
     id, name, fa: legacyFA, length, yds, grades, type, content, safety, metadata, ancestors, pathTokens, authorMetadata,
     parent
@@ -295,7 +297,7 @@ const Body = ({ climb, leftClimb, rightClimb }: ClimbPageProps): JSX.Element => 
               </div>
             </div>
 
-            <div className='area-climb-page-summary-right'>
+            <div className='area-climb-page-summary-right lg:h-0 lg:min-h-full'>
               <div className='mb-3 flex justify-between items-center'>
                 <h3>Description</h3>
               </div>
@@ -344,6 +346,11 @@ const Body = ({ climb, leftClimb, rightClimb }: ClimbPageProps): JSX.Element => 
                 {FormAction}
               </div>
             </div>
+            <div>
+              <h4>Routes in {parentArea.areaName.includes(', The') ? 'The '.concat(parentArea.areaName.slice(0, -5)) : parentArea.areaName}</h4>
+              <hr className='mt-2 mb-2 border-1 border-base-content' />
+              {!editMode && <ClimbList gradeContext={parentArea.gradeContext} climbs={parentArea.climbs} areaMetadata={parentArea.metadata} editMode={editMode} routePageId={climbId} />}
+            </div>
           </div>
         </form>
       </FormProvider>
@@ -378,14 +385,18 @@ export const getStaticProps: GetStaticProps<ClimbPageProps, { id: string }> = as
     }
   }
 
-  const sortedClimbsInArea = await fetchSortedClimbsInArea(climb.ancestors[climb.ancestors.length - 1])
+  const parentAreaData = await getArea(climb.ancestors[climb.ancestors.length - 1])
   let leftClimb: ClimbType | null = null
   let rightClimb: ClimbType | null = null
 
-  for (const [index, climb] of sortedClimbsInArea.entries()) {
+  const parentArea = parentAreaData.area
+
+  const sortedClimbs = [...parentArea.climbs].sort(climbLeftRightIndexComparator)
+
+  for (const [index, climb] of sortedClimbs.entries()) {
     if (climb.id === params.id) {
-      leftClimb = (sortedClimbsInArea[index - 1] != null) ? sortedClimbsInArea[index - 1] : null
-      rightClimb = sortedClimbsInArea[index + 1] != null ? sortedClimbsInArea[index + 1] : null
+      leftClimb = (sortedClimbs[index - 1] != null) ? sortedClimbs[index - 1] : null
+      rightClimb = sortedClimbs[index + 1] != null ? sortedClimbs[index + 1] : null
     }
   }
 
@@ -395,49 +406,11 @@ export const getStaticProps: GetStaticProps<ClimbPageProps, { id: string }> = as
       key: climb.id,
       climb,
       leftClimb,
-      rightClimb
+      rightClimb,
+      parentArea
     },
     revalidate: 30
   }
-}
-
-/**
- * Fetch and sort the climbs in the area from left to right
- */
-const fetchSortedClimbsInArea = async (uuid: string): Promise<ClimbType[]> => {
-  const query = gql`query SortedNearbyClimbsByAreaUUID($uuid: ID) {
-    area(uuid: $uuid) {
-      uuid,
-      climbs {
-        uuid,
-        id,
-        metadata {
-          climbId,
-          left_right_index
-        }
-      }
-    }
-  }`
-
-  const rs = await graphqlClient.query<{ area: AreaType }>({
-    query,
-    variables: {
-      uuid
-    }
-  })
-
-  if (rs.data == null || rs.data.area == null) {
-    return []
-  }
-
-  // Copy readonly array so we can sort
-  const routes = [...rs.data.area.climbs]
-
-  return routes.sort(
-    (a, b) =>
-      parseInt(a.metadata.left_right_index, 10) -
-      parseInt(b.metadata.left_right_index, 10)
-  )
 }
 
 const trimLegacyFA = (s: string): string => {

--- a/src/styles/defaults.css
+++ b/src/styles/defaults.css
@@ -41,7 +41,7 @@ a:active, a:focus {
 }
 
 .area-climb-page-summary-right {
-  @apply mt-6 lg:mt-0 lg:col-span-2 lg:pl-16 w-full;
+  @apply mt-6 lg:mt-0 lg:pl-16 w-full;
 }
 
 /**


### PR DESCRIPTION
---
name: (feat: add list of area's routes to route page)
about: Route list on route page
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #881 


### What this PR achieves

This PR adds a list of the areas routes to individual route pages 

### Screenshots, recordings

![Screenshot 2024-01-06 at 21-46-57 Coyote Ugly · 5 10 · Sport](https://github.com/OpenBeta/open-tacos/assets/24865286/7e943f3d-f214-456e-83a9-06ad3de4b1c3)


### Notes
<!--Anything in particular you want the reviwer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




