### PR TITLE
refactor: use dedicate query (less data) for crumbs

### DIFF
--- a/src/js/graphql/getArea.ts
+++ b/src/js/graphql/getArea.ts
@@ -1,7 +1,9 @@
+import { FetchPolicy } from '@apollo/client'
+
 import { QUERY_AREA_BY_ID } from './gql/areaById'
+import { QUERY_CHILD_AREAS_FOR_BREADCRUMBS, ChildAreasQueryReturn, AreaWithChildren } from './gql/breadcrumbs'
 import { graphqlClient } from './Client'
 import { AreaType, ChangesetType } from '../types'
-import { FetchPolicy } from '@apollo/client'
 
 export interface AreaPageDataProps {
   area: AreaType
@@ -21,4 +23,20 @@ export const getArea = async (uuid: string, fetchPolicy: FetchPolicy = 'no-cache
     fetchPolicy
   })
   return rs.data
+}
+
+/**
+ * Get child areas for breadcrumbs.
+ * @param uuid parent area uuid
+ * @param fetchPolicy
+ */
+export const getChildAreasForBreadcrumbs = async (uuid: string, fetchPolicy: FetchPolicy = 'no-cache'): Promise<AreaWithChildren> => {
+  const rs = await graphqlClient.query<ChildAreasQueryReturn>({
+    query: QUERY_CHILD_AREAS_FOR_BREADCRUMBS,
+    variables: {
+      uuid
+    },
+    fetchPolicy
+  })
+  return rs.data.area
 }

--- a/src/js/graphql/gql/breadcrumbs.ts
+++ b/src/js/graphql/gql/breadcrumbs.ts
@@ -1,0 +1,32 @@
+import { gql } from '@apollo/client'
+import { AreaType } from '@/js/types'
+import { SortableAreaType } from '@/js/utils'
+
+type SelectedFields = Pick<AreaType, 'uuid' | 'areaName'> & SortableAreaType
+
+export type SiblingArea = SelectedFields
+
+export interface AreaWithChildren extends SelectedFields {
+  children: SiblingArea[]
+}
+
+export interface ChildAreasQueryReturn {
+  area: AreaWithChildren
+}
+
+export const QUERY_CHILD_AREAS_FOR_BREADCRUMBS = gql`
+  query ($uuid: ID) {
+    area(uuid: $uuid) {
+      uuid
+      areaName
+      children {
+        uuid
+        areaName
+        metadata {
+          areaId
+          leftRightIndex
+        }
+      }
+    }
+  }
+  `

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -3,7 +3,7 @@ import slugify from 'slugify'
 import { ClimbTypeToColor } from './constants'
 import { formatDistanceToNowStrict, differenceInYears, format } from 'date-fns'
 
-import { AreaType, ClimbType, ClimbDisciplineRecord, ClimbDiscipline, MediaWithTags, MediaConnection } from './types'
+import { AreaType, ClimbType, ClimbDisciplineRecord, ClimbDiscipline, MediaWithTags, MediaConnection, AreaMetadataType } from './types'
 
 /**
  * Given a path or parent id and the type of the page generate the GitHub URL
@@ -308,7 +308,9 @@ export const climbLeftRightIndexComparator = (a: ClimbType, b: ClimbType): numbe
   return 0
 }
 
-export const areaLeftRightIndexComparator = (a: AreaType, b: AreaType): number => {
+export interface SortableAreaType { metadata: Pick<AreaMetadataType, 'leftRightIndex' | 'areaId'> }
+
+export const areaLeftRightIndexComparator = (a: SortableAreaType, b: SortableAreaType): number => {
   const aIndex = a.metadata.leftRightIndex ?? -1
   const bIndex = b.metadata.leftRightIndex ?? -1
   if (aIndex < bIndex) return -1


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #1065 


### What this PR achieves
Follow up optimization. Since the query to get sibling areas is executed client-side we can should fetch less fields.