### PR TITLE
fix: match search result area badge to climb result

### DIFF
--- a/src/components/search/templates/ClimbResultXSearch.tsx
+++ b/src/components/search/templates/ClimbResultXSearch.tsx
@@ -51,16 +51,16 @@ interface AreaItemProps {
 export const AreaItem = ({ item }: AreaItemProps): JSX.Element => {
   const { pathTokens, highlightIndices, name } = item
   return (
-    <div className='py-4 text-xs flex flex-col gap-2'>
+    <div className='py-4 text-xs flex flex-row justify-between gap-2'>
       {pathTokens.length === 1 &&
         <>
-          <div className='badge bg-area-cue bg-opacity-60 badge-sm'>country</div>
           <div className='badge badge-outline badge-lg'>{name} →</div>
+          <div className='rounded-lg p-1 px-3 bg-area-cue bg-opacity-40 text-xs mr-2 self-center h-fit'>country</div>
         </>}
       {pathTokens.length > 1 &&
         <>
-          <div className='badge bg-area-cue badge-sm'>area</div>
           <TextOnlyCrumbs pathTokens={pathTokens} highlightIndices={highlightIndices} />
+          <div className='rounded-lg p-1 px-3 bg-area-cue text-base-100 text-xs mr-2 self-center h-fit'>area</div>
         </>}
     </div>
   )


### PR DESCRIPTION
---
name: (fix: match search result area badge to climb result)
about: Styling of area badges in search results
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #1070


### What this PR achieves

This PR updates the search result area and country badge styles to bring them inline with that of the climb result badges.

Additionally it changes the text color of the area badge to make it readable and also lightens the background of the country badge to improve it's readability  


### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->
Before

![Screenshot 2024-01-11 121119](https://github.com/OpenBeta/open-tacos/assets/24865286/99390916-64f3-427a-bcc8-5d0d16293df8)

After

![Screenshot 2024-01-11 121224](https://github.com/OpenBeta/open-tacos/assets/24865286/e60ad683-8721-4d06-a8e7-e3151c592825)




### Notes
<!--Anything in particular you want the reviwer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




