### PR TITLE
fix: add appropiate top margin to climb page's area routes section

### DIFF
--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -349,7 +349,7 @@ const Body = ({ climb, leftClimb, rightClimb, parentArea }: ClimbPageProps): JSX
                 {FormAction}
               </div>
             </div>
-            <div className='col-start-1 col-end-2'>
+            <div className='col-start-1 col-end-2 mt-8'>
               <h4>Routes in {parentArea.areaName.includes(', The') ? 'The '.concat(parentArea.areaName.slice(0, -5)) : parentArea.areaName}</h4>
               <hr className='mt-2 mb-2 border-1 border-base-content' />
               {!editMode && <ClimbList gradeContext={parentArea.gradeContext} climbs={parentArea.climbs} areaMetadata={parentArea.metadata} editMode={editMode} routePageId={climbId} />}


### PR DESCRIPTION
---
name: Add appropriate top margin to climb page's area routes section
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #


### What this PR achieves

Adds missing margin between 'tick this climb' button and the 'Routes in the area' section on climb pages.


### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->
Before
![Screenshot 2024-01-13 143716](https://github.com/OpenBeta/open-tacos/assets/24865286/4777432d-71df-4a7b-8558-361e15b0e197)

After
![Screenshot 2024-01-13 143743](https://github.com/OpenBeta/open-tacos/assets/24865286/12eda9e5-9c7c-4c5d-aa80-898ae2c825e6)




### Notes
<!--Anything in particular you want the reviwer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




