### PR TITLE
feat: update map and share button labels and icons (#1079)

### DIFF
--- a/src/app/(default)/components/AreaPageActions.tsx
+++ b/src/app/(default)/components/AreaPageActions.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { PencilSimple, ArrowElbowLeftDown } from '@phosphor-icons/react/dist/ssr'
+import { PencilSimple, MapTrifold } from '@phosphor-icons/react/dist/ssr'
 import { ShareAreaLinkButton } from '@/app/(default)/components/ShareAreaLinkButton'
 import { UploadPhotoButton } from '@/components/media/PhotoUploadButtons'
 
@@ -15,7 +15,7 @@ export const AreaPageActions: React.FC<{ uuid: string, areaName: string } > = ({
     <UploadPhotoButton />
 
     <Link href='#map' className='btn'>
-      <ArrowElbowLeftDown size={20} className='hidden md:inline' /> Map
+      <MapTrifold size={20} className='hidden md:inline' /> Map
     </Link>
     <ShareAreaLinkButton uuid={uuid} areaName={areaName} />
   </ul>

--- a/src/app/(default)/components/ShareAreaLinkButton.tsx
+++ b/src/app/(default)/components/ShareAreaLinkButton.tsx
@@ -30,7 +30,7 @@ export const ShareAreaLinkButton: React.FC<{ uuid: string, areaName: string }> =
           setClicked(true)
         }}
       >
-        <LinkSimple size={20} /><span className='hidden md:inline'>Share</span>
+        <LinkSimple size={20} /><span className='hidden md:inline'>Copy Link</span>
       </button>
     </ControlledTooltip>
   )


### PR DESCRIPTION
## Description
- Update the map button icon to 'MapTrifold'
- Correctly label the 'share' button as 'Copy Link'

### Related Issues

Issue #1079 

### Screenshots, recordings
![Screenshot 2024-02-11 160612](https://github.com/OpenBeta/open-tacos/assets/21102277/d9da2460-0152-49ff-b5a2-7781376e1ccc)


