### PR TITLE
fix: remove snapping on area page map

### DIFF
--- a/src/app/(default)/components/ui/AreaPageContainer.tsx
+++ b/src/app/(default)/components/ui/AreaPageContainer.tsx
@@ -26,7 +26,7 @@ export const AreaPageContainer: React.FC<{
         {breadcrumbs == null ? <BreadCrumbsSkeleton /> : breadcrumbs}
         {children == null ? <ContentSkeleton /> : children}
       </div>
-      <div id='map' className='w-full mt-16 relative h-[90vh] border-t snap-start snap-normal'>
+      <div id='map' className='w-full mt-16 relative h-[90vh] border-t'>
         {map != null && map}
       </div>
     </article>

--- a/src/app/(default)/layout.tsx
+++ b/src/app/(default)/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout ({
   children: React.ReactNode
 }): any {
   return (
-    <html lang='en' className='snap-proximity snap-y scroll-smooth'>
+    <html lang='en' className='scroll-smooth'>
       <body className='relative'>
         <NextAuthProvider>
           <Header />


### PR DESCRIPTION
---
name: remove snapping from map on area pages
about: 
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #1107 


### What this PR achieves

Removes snaping from the map element
<!---Briefly explains what this PR does.
-->


### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->




### Notes
<!--Anything in particular you want the reviwer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




