### PR TITLE
fix(#1100): Gracefully handle runtime error for getArea query

### DIFF
--- a/src/app/(default)/area/[[...slug]]/page.tsx
+++ b/src/app/(default)/area/[[...slug]]/page.tsx
@@ -37,7 +37,7 @@ export interface PageWithCatchAllUuidProps {
 export default async function Page ({ params }: PageWithCatchAllUuidProps): Promise<any> {
   const areaUuid = parseUuidAsFirstParam({ params })
   const pageData = await getArea(areaUuid)
-  if (pageData == null) {
+  if (pageData == null || pageData.area == null) {
     notFound()
   }
 
@@ -188,8 +188,13 @@ export function generateStaticParams (): PageSlugType[] {
 // Page metadata
 export async function generateMetadata ({ params }: PageWithCatchAllUuidProps): Promise<Metadata> {
   const areaUuid = parseUuidAsFirstParam({ params })
+  const area = await getArea(areaUuid, 'cache-first')
 
-  const { area: { uuid, areaName, pathTokens, media } } = await getArea(areaUuid, 'cache-first')
+  if (area == null || area.area == null) {
+    return {}
+  }
+
+  const { area: { uuid, areaName, pathTokens, media } } = area
 
   let wall = ''
   if (pathTokens.length >= 2) {

--- a/src/app/(default)/editArea/[slug]/general/page.tsx
+++ b/src/app/(default)/editArea/[slug]/general/page.tsx
@@ -19,7 +19,12 @@ export const fetchCache = 'force-no-store' // opt out of Nextjs version of 'fetc
 
 // Page metadata
 export async function generateMetadata ({ params }: DashboardPageProps): Promise<Metadata> {
-  const { area: { areaName } } = await getPageDataForEdit(params.slug, 'cache-first')
+  const pageDataForEdit = await getPageDataForEdit(params.slug, 'cache-first')
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    return {}
+  }
+
+  const { area: { areaName } } = pageDataForEdit
   return {
     title: `Editing area ${areaName}`
   }
@@ -32,7 +37,12 @@ export interface DashboardPageProps {
 }
 
 export default async function AreaEditPage ({ params }: DashboardPageProps): Promise<any> {
-  const { area } = await getPageDataForEdit(params.slug)
+  const pageDataForEdit = await getPageDataForEdit(params.slug)
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    notFound()
+  }
+
+  const { area } = pageDataForEdit
   const {
     areaName, uuid, ancestors, pathTokens, children,
     content: { description },
@@ -100,7 +110,7 @@ export const getPageDataForEdit = async (pageSlug: string, fetchPolicy?: FetchPo
   }
 
   const pageData = await getArea(pageSlug, fetchPolicy)
-  if (pageData == null) {
+  if (pageData == null || pageData.area == null) {
     notFound()
   }
   return pageData

--- a/src/app/(default)/editArea/[slug]/layout.tsx
+++ b/src/app/(default)/editArea/[slug]/layout.tsx
@@ -16,7 +16,11 @@ export default async function EditAreaDashboardLayout ({
   children: React.ReactNode
   params: { slug: string }
 }): Promise<any> {
-  const { area: { uuid, pathTokens, ancestors, areaName, children: subAreas, climbs, metadata: { leaf, isBoulder } } } = await getPageDataForEdit(params.slug)
+  const pageDataForEdit = await getPageDataForEdit(params.slug)
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    return <div />
+  }
+  const { area: { uuid, pathTokens, ancestors, areaName, children: subAreas, climbs, metadata: { leaf, isBoulder } } } = pageDataForEdit
   return (
     <div className='relative w-full h-full'>
       <div className='px-12 pt-8 pb-4'>

--- a/src/app/(default)/editArea/[slug]/manageAreas/page.tsx
+++ b/src/app/(default)/editArea/[slug]/manageAreas/page.tsx
@@ -9,14 +9,24 @@ export const fetchCache = 'force-no-store' // opt out of Nextjs version of 'fetc
 
 // Page metadata
 export async function generateMetadata ({ params }: DashboardPageProps): Promise<Metadata> {
-  const { area: { areaName } } = await getPageDataForEdit(params.slug, 'cache-first')
+  const pageDataForEdit = await getPageDataForEdit(params.slug, 'cache-first')
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    return {}
+  }
+
+  const { area: { areaName } } = pageDataForEdit
   return {
     title: `Manage child areas in ${areaName}`
   }
 }
 
 export default async function AddClimbsPage ({ params: { slug } }: DashboardPageProps): Promise<any> {
-  const { area } = await getPageDataForEdit(slug)
+  const pageDataForEdit = await getPageDataForEdit(slug)
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    return {}
+  }
+
+  const { area } = pageDataForEdit
   const { uuid, children } = area
   const canEditLeaves = !area.metadata.leaf
   return (

--- a/src/app/(default)/editArea/[slug]/manageClimbs/page.tsx
+++ b/src/app/(default)/editArea/[slug]/manageClimbs/page.tsx
@@ -11,14 +11,24 @@ export const fetchCache = 'force-no-store' // opt out of Nextjs version of 'fetc
 
 // Page metadata
 export async function generateMetadata ({ params }: DashboardPageProps): Promise<Metadata> {
-  const { area: { areaName } } = await getPageDataForEdit(params.slug, 'cache-first')
+  const pageDataForEdit = await getPageDataForEdit(params.slug, 'cache-first')
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    return {}
+  }
+
+  const { area: { areaName } } = pageDataForEdit
   return {
     title: `Manage climbs in area ${areaName}`
   }
 }
 
 export default async function AddClimbsPage ({ params: { slug } }: DashboardPageProps): Promise<any> {
-  const { area } = await getPageDataForEdit(slug)
+  const pageDataForEdit = await getPageDataForEdit(slug)
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    return {}
+  }
+
+  const { area } = pageDataForEdit
   const { areaName, uuid, gradeContext, metadata } = area
   const { leaf, isBoulder } = metadata
   return (

--- a/src/app/(default)/editArea/[slug]/manageTopos/page.tsx
+++ b/src/app/(default)/editArea/[slug]/manageTopos/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { DashboardPageProps, getPageDataForEdit } from '../general/page'
 import { TopoEditor } from './components/TopoEditor'
 import { PageContainer } from '../components/EditAreaContainers'
+import { notFound } from 'next/navigation'
 
 // Opt out of caching for all data requests in the route segment
 export const dynamic = 'force-dynamic'
@@ -9,14 +10,24 @@ export const fetchCache = 'force-no-store' // opt out of Nextjs version of 'fetc
 
 // Page metadata
 export async function generateMetadata ({ params }: DashboardPageProps): Promise<Metadata> {
-  const { area: { areaName } } = await getPageDataForEdit(params.slug, 'cache-first')
+  const pageDataForEdit = await getPageDataForEdit(params.slug, 'cache-first')
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    return {}
+  }
+
+  const { area: { areaName } } = pageDataForEdit
   return {
     title: `Manage topos in area ${areaName}`
   }
 }
 
 export default async function EditToposPage ({ params: { slug } }: DashboardPageProps): Promise<any> {
-  const { area } = await getPageDataForEdit(slug)
+  const pageDataForEdit = await getPageDataForEdit(slug)
+  if (pageDataForEdit == null || pageDataForEdit.area == null) {
+    notFound()
+  }
+
+  const { area } = pageDataForEdit
 
   return (
     <PageContainer>

--- a/src/js/graphql/getArea.ts
+++ b/src/js/graphql/getArea.ts
@@ -6,7 +6,7 @@ import { graphqlClient } from './Client'
 import { AreaType, ChangesetType } from '../types'
 
 export interface AreaPageDataProps {
-  area: AreaType
+  area: AreaType | null
   getAreaHistory: ChangesetType[]
 }
 
@@ -15,14 +15,19 @@ export interface AreaPageDataProps {
  * @param uuid area uuid
  */
 export const getArea = async (uuid: string, fetchPolicy: FetchPolicy = 'no-cache'): Promise<AreaPageDataProps> => {
-  const rs = await graphqlClient.query<AreaPageDataProps>({
-    query: QUERY_AREA_BY_ID,
-    variables: {
-      uuid
-    },
-    fetchPolicy
-  })
-  return rs.data
+  try {
+    const rs = await graphqlClient.query<AreaPageDataProps>({
+      query: QUERY_AREA_BY_ID,
+      variables: {
+        uuid
+      },
+      fetchPolicy
+    })
+    return rs.data
+  } catch (error) {
+    console.error(error)
+    return { area: null, getAreaHistory: [] }
+  }
 }
 
 /**

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -389,6 +389,13 @@ export const getStaticProps: GetStaticProps<ClimbPageProps, { id: string }> = as
   }
 
   const parentAreaData = await getArea(climb.ancestors[climb.ancestors.length - 1], 'cache-first')
+
+  if (parentAreaData == null || parentAreaData.area == null) {
+    return {
+      notFound: true
+    }
+  }
+
   let leftClimb: ClimbType | null = null
   let rightClimb: ClimbType | null = null
 


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

Currently, if you go to an area whose uuid doesn't exist in the database, it'll throw a server error (ex: https://openbeta.io/area/f92d68ca-1b6f-5bc7-8d1f-16b3961b3cce):

![image](https://github.com/OpenBeta/open-tacos/assets/3220734/8cb85b4e-a4bb-4eea-a28f-d4a013f7bf94)

And if you go to an area with an invalid uuid, it'll throw a 404 (ex: https://openbeta.io/area/asdfasdf):

![image](https://github.com/OpenBeta/open-tacos/assets/3220734/340528c4-1d87-4add-8c20-5252bb50b726)

I believe this is occurring because of the way Apollo Server handles validation errors (like invalid uuids) vs resolver errors (area uuid doesn't exist in database).

### What this PR achieves

This PR remediates this issue by wrapping the graphql query made in `getArea` in a try/catch. If the query errors out, return a null area. And when rendering the area page, return `notFound()` for a null area.

![Screenshot 2024-03-19 at 9 08 20 PM](https://github.com/OpenBeta/open-tacos/assets/3220734/c1e9328e-c528-42e1-91cd-0158cf1d89f5)

Since the `AreaPageDataProps` interface was changed to accommodate for the area being nullable, I had to update a number of other places in the code that use this:

```
export interface AreaPageDataProps {
  area: AreaType | null
  getAreaHistory: ChangesetType[]
}
```

### Related Issues

Issue #1100


### Notes
- When querying area metadata, I chose to return an empty object for non-existent areas. Let me know if that shouldn't be the case!
- In [src/app/(default)/editArea/[slug]/layout.tsx](https://github.com/OpenBeta/open-tacos/compare/develop...melissapthai:open-tacos:issue-1100-fix-areas-graphql?expand=1#diff-9aba223ef777afe6f017b25f2d77cbd4c964a1994c898cea36bd98d78ee6ffd7), I'm not super confident that it should returning an empty div for a null area.



