### PR TITLE
Map layers selector #1108

### DIFF
--- a/.env
+++ b/.env
@@ -32,6 +32,9 @@ NEXT_PUBLIC_TYPESENSE_API_KEY=nBvjNVojLn792SX9sOLhLlpQ7BQJo5ok
 # Mapbox Geocoder token
 NEXT_PUBLIC_MAPBOX_API_KEY=pk.eyJ1IjoibWFwcGFuZGFzIiwiYSI6ImNsZG1wcnBhZTA5eXozb3FnZTY1bHg4bHcifQ.7LJGRLFeLUbntAt5twiDiw
 
+# Maptiler API Key
+NEXT_PUBLIC_MAPTILER_API_KEY=ejjLkz58mUNz9TgNs0Ed
+
 # Discord invite
 NEXT_PUBLIC_DISCORD_INVITE=https://discord.gg/a6vuuTQxS8
 

--- a/src/app/(default)/components/recent/RecentContributionsMap.tsx
+++ b/src/app/(default)/components/recent/RecentContributionsMap.tsx
@@ -87,7 +87,7 @@ export const RecentContributionsMap: React.FC<{ history: ChangesetType[] }> = ({
     <div className='relative w-full h-full'>
       <Map
         reuseMaps
-        mapStyle={MAP_STYLES.minimal.style}
+        mapStyle={MAP_STYLES.standard.style}
         cooperativeGestures
         {...clickableLayer1 != null && clickableLayer2 != null &&
         { interactiveLayerIds: [clickableLayer2, clickableLayer1] }}

--- a/src/app/(default)/components/recent/RecentContributionsMap.tsx
+++ b/src/app/(default)/components/recent/RecentContributionsMap.tsx
@@ -87,7 +87,7 @@ export const RecentContributionsMap: React.FC<{ history: ChangesetType[] }> = ({
     <div className='relative w-full h-full'>
       <Map
         reuseMaps
-        mapStyle={MAP_STYLES.dataviz.style}
+        mapStyle={MAP_STYLES.minimal.style}
         cooperativeGestures
         {...clickableLayer1 != null && clickableLayer2 != null &&
         { interactiveLayerIds: [clickableLayer2, clickableLayer1] }}

--- a/src/app/(default)/components/recent/RecentContributionsMap.tsx
+++ b/src/app/(default)/components/recent/RecentContributionsMap.tsx
@@ -87,7 +87,7 @@ export const RecentContributionsMap: React.FC<{ history: ChangesetType[] }> = ({
     <div className='relative w-full h-full'>
       <Map
         reuseMaps
-        mapStyle={MAP_STYLES.dataviz}
+        mapStyle={MAP_STYLES.dataviz.style}
         cooperativeGestures
         {...clickableLayer1 != null && clickableLayer2 != null &&
         { interactiveLayerIds: [clickableLayer2, clickableLayer1] }}

--- a/src/components/maps/GlobalMap.tsx
+++ b/src/components/maps/GlobalMap.tsx
@@ -49,7 +49,7 @@ export const GlobalMap: React.FC<GlobalMapProps> = ({
   const [selected, setSelected] = useState<Point | Polygon | null>(null)
   const [mapInstance, setMapInstance] = useState<MapInstance | null>(null)
   const [cursor, setCursor] = useState<string>('default')
-  const [mapStyle, setMapStyle] = useState<string>(MAP_STYLES.minimal.style)
+  const [mapStyle, setMapStyle] = useState<string>(MAP_STYLES.standard.style)
 
   const onLoad = useCallback((e: MapLibreEvent) => {
     if (e.target == null) return

--- a/src/components/maps/GlobalMap.tsx
+++ b/src/components/maps/GlobalMap.tsx
@@ -49,7 +49,7 @@ export const GlobalMap: React.FC<GlobalMapProps> = ({
   const [selected, setSelected] = useState<Point | Polygon | null>(null)
   const [mapInstance, setMapInstance] = useState<MapInstance | null>(null)
   const [cursor, setCursor] = useState<string>('default')
-  const [mapStyle, setMapStyle] = useState<string>(MAP_STYLES.dataviz.style)
+  const [mapStyle, setMapStyle] = useState<string>(MAP_STYLES.minimal.style)
 
   const onLoad = useCallback((e: MapLibreEvent) => {
     if (e.target == null) return

--- a/src/components/maps/GlobalMap.tsx
+++ b/src/components/maps/GlobalMap.tsx
@@ -49,7 +49,7 @@ export const GlobalMap: React.FC<GlobalMapProps> = ({
   const [selected, setSelected] = useState<Point | Polygon | null>(null)
   const [mapInstance, setMapInstance] = useState<MapInstance | null>(null)
   const [cursor, setCursor] = useState<string>('default')
-  const [mapStyle, setMapStyle] = useState<string>(MAP_STYLES.dataviz)
+  const [mapStyle, setMapStyle] = useState<string>(MAP_STYLES.dataviz.style)
 
   const onLoad = useCallback((e: MapLibreEvent) => {
     if (e.target == null) return
@@ -110,7 +110,7 @@ export const GlobalMap: React.FC<GlobalMapProps> = ({
 
   const updateMapLayer = (key: keyof MapStyles): void => {
     const style = MAP_STYLES[key]
-    setMapStyle(style)
+    setMapStyle(style.style)
   }
 
   return (

--- a/src/components/maps/GlobalMap.tsx
+++ b/src/components/maps/GlobalMap.tsx
@@ -5,13 +5,14 @@ import maplibregl, { MapLibreEvent } from 'maplibre-gl'
 import { Point, Polygon } from '@turf/helpers'
 import dynamic from 'next/dynamic'
 
-import { MAP_STYLES } from './MapSelector'
+import { MAP_STYLES, type MapStyles } from './MapSelector'
 import { AreaInfoDrawer } from './AreaInfoDrawer'
 import { AreaInfoHover } from './AreaInfoHover'
 import { SelectedFeature } from './AreaActiveMarker'
 import { OBCustomLayers } from './OBCustomLayers'
 import { AreaType, ClimbType, MediaWithTags } from '@/js/types'
 import { TileProps, transformTileProps } from './utils'
+import MapLayersSelector from './MapLayersSelector'
 
 export type SimpleClimbType = Pick<ClimbType, 'id' | 'name' | 'type'>
 
@@ -48,6 +49,7 @@ export const GlobalMap: React.FC<GlobalMapProps> = ({
   const [selected, setSelected] = useState<Point | Polygon | null>(null)
   const [mapInstance, setMapInstance] = useState<MapInstance | null>(null)
   const [cursor, setCursor] = useState<string>('default')
+  const [mapStyle, setMapStyle] = useState<string>(MAP_STYLES.dataviz)
 
   const onLoad = useCallback((e: MapLibreEvent) => {
     if (e.target == null) return
@@ -106,6 +108,11 @@ export const GlobalMap: React.FC<GlobalMapProps> = ({
     }
   }, [mapInstance])
 
+  const updateMapLayer = (key: keyof MapStyles): void => {
+    const style = MAP_STYLES[key]
+    setMapStyle(style)
+  }
+
   return (
     <div className='relative w-full h-full'>
       <Map
@@ -123,11 +130,12 @@ export const GlobalMap: React.FC<GlobalMapProps> = ({
           setCursor('default')
         }}
         onClick={onClick}
-        mapStyle={MAP_STYLES.dataviz}
+        mapStyle={mapStyle}
         cursor={cursor}
         cooperativeGestures={showFullscreenControl}
         interactiveLayerIds={['crags', 'crag-group-boundaries']}
       >
+        <MapLayersSelector emit={updateMapLayer} />
         <ScaleControl unit='imperial' style={{ marginBottom: 10 }} position='bottom-left' />
         <ScaleControl unit='metric' style={{ marginBottom: 0 }} position='bottom-left' />
 

--- a/src/components/maps/MapLayersSelector.tsx
+++ b/src/components/maps/MapLayersSelector.tsx
@@ -1,4 +1,4 @@
-import * as HoverCard from '@radix-ui/react-hover-card'
+import * as Popover from '@radix-ui/react-popover'
 import { MAP_STYLES, type MapStyles } from './MapSelector'
 import { useState } from 'react'
 
@@ -18,24 +18,23 @@ const MapLayersSelector: React.FC<Props> = ({ emit }) => {
     setMapImgUrl(imgUrl)
     emit(styleKey)
   }
-
   return (
     <>
-      <HoverCard.Root openDelay={0}>
-        <HoverCard.Trigger asChild>
-          <span className='absolute bottom-20 left-3 bg-white rounded p-1'>
+      <Popover.Root>
+        <Popover.Trigger asChild>
+          <button className='absolute bottom-20 left-3 bg-white rounded p-1 shadow'>
             <span>
               <img
-                className='w-12 h-12 rounded'
+                className='w-14 h-14 rounded shadow'
                 src={mapImgUrl}
                 alt='Currently selected maptiler layer'
               />
               <span className={`text-[10px] absolute bottom-2 left-1/2 -translate-x-1/2 ${mapName === 'satellite' ? 'text-white' : ''}`}>{mapName}</span>
             </span>
-          </span>
-        </HoverCard.Trigger>
-        <HoverCard.Portal>
-          <HoverCard.Content className='p-2 bg-white rounded' side='right' sideOffset={20}>
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content className='p-2 bg-white rounded shadow' side='right' sideOffset={20}>
             <button className=' flex justify-between cursor-pointer'>
               {Object.keys(MAP_STYLES).map((key) => {
                 const mapKey = key as keyof typeof MAP_STYLES
@@ -44,7 +43,7 @@ const MapLayersSelector: React.FC<Props> = ({ emit }) => {
                   <div className='p-1' key={key} onClick={() => emitMap(key)}>
                     <span className='grid grid-cols-1 justify-items-center'>
                       <img
-                        className='w-12 h-12 mb-2 rounded col-span-1'
+                        className='w-14 h-14 mb-2 rounded col-span-1 shadow'
                         src={imgUrl}
                         alt='Currently selected maptiler layer'
                       />
@@ -54,10 +53,10 @@ const MapLayersSelector: React.FC<Props> = ({ emit }) => {
                 )
               })}
             </button>
-            <HoverCard.Arrow className=' fill-[white]' />
-          </HoverCard.Content>
-        </HoverCard.Portal>
-      </HoverCard.Root>
+            <Popover.Arrow className='fill-[white]' />
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
     </>
   )
 }

--- a/src/components/maps/MapLayersSelector.tsx
+++ b/src/components/maps/MapLayersSelector.tsx
@@ -7,8 +7,8 @@ interface Props {
 }
 
 const MapLayersSelector: React.FC<Props> = ({ emit }) => {
-  const [mapImgUrl, setMapImgUrl] = useState<string>(MAP_STYLES.dataviz.imgUrl)
-  const [mapName, setMapName] = useState<string>('dataviz')
+  const [mapImgUrl, setMapImgUrl] = useState<string>(MAP_STYLES.minimal.imgUrl)
+  const [mapName, setMapName] = useState<string>('minimal')
 
   const emitMap = (key: string): void => {
     const styleKey = key as keyof MapStyles

--- a/src/components/maps/MapLayersSelector.tsx
+++ b/src/components/maps/MapLayersSelector.tsx
@@ -22,32 +22,32 @@ const MapLayersSelector: React.FC<Props> = ({ emit }) => {
     <>
       <Popover.Root>
         <Popover.Trigger asChild>
-          <button className='absolute bottom-20 left-3 bg-white rounded p-1 shadow'>
+          <button className='absolute bottom-20 left-3 bg-white rounded p-1.5 shadow'>
             <span>
               <img
-                className='w-14 h-14 rounded shadow'
+                className='w-12 h-12 md:w-16 md:h-16 rounded border-[1px] border-slate-300'
                 src={mapImgUrl}
                 alt='Currently selected maptiler layer'
               />
-              <span className={`text-[10px] absolute bottom-2 left-1/2 -translate-x-1/2 ${mapName === 'satellite' ? 'text-white' : ''}`}>{mapName}</span>
+              <span className={`break-word text-[0.65rem] absolute bottom-2 left-1/2 -translate-x-1/2 ${mapName === 'satellite' ? 'text-white' : ''}`}>{mapName}</span>
             </span>
           </button>
         </Popover.Trigger>
         <Popover.Portal>
-          <Popover.Content className='p-2 bg-white rounded shadow' side='right' sideOffset={20}>
-            <button className=' flex justify-between cursor-pointer'>
+          <Popover.Content className=' pt-1.5 bg-white rounded grid grid-cols-1' side='top' sideOffset={20}>
+            <button className='cursor-pointer col-span-1'>
               {Object.keys(MAP_STYLES).map((key) => {
                 const mapKey = key as keyof typeof MAP_STYLES
                 const { imgUrl } = MAP_STYLES[mapKey]
                 return (
-                  <div className='p-1' key={key} onClick={() => emitMap(key)}>
+                  <div className='px-1.5' key={key} onClick={() => emitMap(key)}>
                     <span className='grid grid-cols-1 justify-items-center'>
                       <img
-                        className='w-14 h-14 mb-2 rounded col-span-1 shadow'
+                        className='w-12 h-12 md:w-16 md:h-16 rounded col-span-1 shadow border-[1px] border-slate-300'
                         src={imgUrl}
                         alt='Currently selected maptiler layer'
                       />
-                      <span className='col-span-1 text-xs'>{key}</span>
+                      <span className='col-span-1 text-[0.65rem] '>{key}</span>
                     </span>
                   </div>
                 )

--- a/src/components/maps/MapLayersSelector.tsx
+++ b/src/components/maps/MapLayersSelector.tsx
@@ -7,8 +7,8 @@ interface Props {
 }
 
 const MapLayersSelector: React.FC<Props> = ({ emit }) => {
-  const [mapImgUrl, setMapImgUrl] = useState<string>(MAP_STYLES.minimal.imgUrl)
-  const [mapName, setMapName] = useState<string>('minimal')
+  const [mapImgUrl, setMapImgUrl] = useState<string>(MAP_STYLES.standard.imgUrl)
+  const [mapName, setMapName] = useState<string>('standard')
 
   const emitMap = (key: string): void => {
     const styleKey = key as keyof MapStyles

--- a/src/components/maps/MapLayersSelector.tsx
+++ b/src/components/maps/MapLayersSelector.tsx
@@ -30,7 +30,7 @@ const MapLayersSelector: React.FC<Props> = ({ emit }) => {
                 src={mapImgUrl}
                 alt='Currently selected maptiler layer'
               />
-              <span className=' text-[10px] absolute bottom-2 left-1/2 -translate-x-1/2'>{mapName}</span>
+              <span className={`text-[10px] absolute bottom-2 left-1/2 -translate-x-1/2 ${mapName === 'satellite' ? 'text-white' : ''}`}>{mapName}</span>
             </span>
           </span>
         </HoverCard.Trigger>

--- a/src/components/maps/MapLayersSelector.tsx
+++ b/src/components/maps/MapLayersSelector.tsx
@@ -1,0 +1,43 @@
+import * as HoverCard from '@radix-ui/react-hover-card'
+import { MAP_STYLES, type MapStyles } from './MapSelector'
+
+interface Props {
+  emit: (key: keyof MapStyles) => void
+}
+
+const MapLayersSelector: React.FC<Props> = ({ emit }) => {
+  const emitMap = (key: string): void => {
+    const styleKey = key as keyof MapStyles
+    emit(styleKey)
+  }
+
+  return (
+    <>
+      <HoverCard.Root>
+        <HoverCard.Trigger asChild>
+          <span className='absolute bottom-20 left-3 bg-slate-100 rounded'>
+            <img
+              className='w-6 h-6'
+              src='https://pbs.twimg.com/profile_images/1337055608613253126/r_eiMp2H_400x400.png'
+              alt='Radix UI'
+            />
+          </span>
+        </HoverCard.Trigger>
+        <HoverCard.Portal>
+          <HoverCard.Content className='p-4 bg-slate-100 ' side='right' sideOffset={20}>
+            <div className=' flex justify-between'>
+              {Object.keys(MAP_STYLES).map((key) => (
+                <div className=' p-2' key={key} onClick={() => emitMap(key)}>
+                  {key}
+                </div>
+              ))}
+            </div>
+            <HoverCard.Arrow />
+          </HoverCard.Content>
+        </HoverCard.Portal>
+      </HoverCard.Root>
+
+    </>
+  )
+}
+export default MapLayersSelector

--- a/src/components/maps/MapLayersSelector.tsx
+++ b/src/components/maps/MapLayersSelector.tsx
@@ -1,42 +1,63 @@
 import * as HoverCard from '@radix-ui/react-hover-card'
 import { MAP_STYLES, type MapStyles } from './MapSelector'
+import { useState } from 'react'
 
 interface Props {
   emit: (key: keyof MapStyles) => void
 }
 
 const MapLayersSelector: React.FC<Props> = ({ emit }) => {
+  const [mapImgUrl, setMapImgUrl] = useState<string>(MAP_STYLES.dataviz.imgUrl)
+  const [mapName, setMapName] = useState<string>('dataviz')
+
   const emitMap = (key: string): void => {
     const styleKey = key as keyof MapStyles
+    const imgUrl = MAP_STYLES[styleKey].imgUrl
+
+    setMapName(key)
+    setMapImgUrl(imgUrl)
     emit(styleKey)
   }
 
   return (
     <>
-      <HoverCard.Root>
+      <HoverCard.Root openDelay={0}>
         <HoverCard.Trigger asChild>
-          <span className='absolute bottom-20 left-3 bg-slate-100 rounded'>
-            <img
-              className='w-6 h-6'
-              src='https://pbs.twimg.com/profile_images/1337055608613253126/r_eiMp2H_400x400.png'
-              alt='Radix UI'
-            />
+          <span className='absolute bottom-20 left-3 bg-white rounded p-1'>
+            <span>
+              <img
+                className='w-12 h-12 rounded'
+                src={mapImgUrl}
+                alt='Currently selected maptiler layer'
+              />
+              <span className=' text-[10px] absolute bottom-2 left-1/2 -translate-x-1/2'>{mapName}</span>
+            </span>
           </span>
         </HoverCard.Trigger>
         <HoverCard.Portal>
-          <HoverCard.Content className='p-4 bg-slate-100 ' side='right' sideOffset={20}>
-            <div className=' flex justify-between'>
-              {Object.keys(MAP_STYLES).map((key) => (
-                <div className=' p-2' key={key} onClick={() => emitMap(key)}>
-                  {key}
-                </div>
-              ))}
-            </div>
-            <HoverCard.Arrow />
+          <HoverCard.Content className='p-2 bg-white rounded' side='right' sideOffset={20}>
+            <button className=' flex justify-between cursor-pointer'>
+              {Object.keys(MAP_STYLES).map((key) => {
+                const mapKey = key as keyof typeof MAP_STYLES
+                const { imgUrl } = MAP_STYLES[mapKey]
+                return (
+                  <div className='p-1' key={key} onClick={() => emitMap(key)}>
+                    <span className='grid grid-cols-1 justify-items-center'>
+                      <img
+                        className='w-12 h-12 mb-2 rounded col-span-1'
+                        src={imgUrl}
+                        alt='Currently selected maptiler layer'
+                      />
+                      <span className='col-span-1 text-xs'>{key}</span>
+                    </span>
+                  </div>
+                )
+              })}
+            </button>
+            <HoverCard.Arrow className=' fill-[white]' />
           </HoverCard.Content>
         </HoverCard.Portal>
       </HoverCard.Root>
-
     </>
   )
 }

--- a/src/components/maps/MapSelector.tsx
+++ b/src/components/maps/MapSelector.tsx
@@ -10,6 +10,10 @@ export const MAP_STYLES: MapStyles = {
   basic: {
     style: 'https://api.maptiler.com/maps/basic/style.json?key=ejjLkz58mUNz9TgNs0Ed',
     imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-basic-v2.jpeg'
+  },
+  satellite: {
+    style: 'https://api.maptiler.com/maps/satellite/style.json?key=ejjLkz58mUNz9TgNs0Ed',
+    imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-satellite.jpeg'
   }
 }
 export interface MapStyles {
@@ -22,6 +26,10 @@ export interface MapStyles {
     imgUrl: string
   }
   basic: {
+    style: string
+    imgUrl: string
+  }
+  satellite: {
     style: string
     imgUrl: string
   }

--- a/src/components/maps/MapSelector.tsx
+++ b/src/components/maps/MapSelector.tsx
@@ -1,8 +1,28 @@
 export const MAP_STYLES: MapStyles = {
-  outdoor: 'https://api.maptiler.com/maps/outdoor-v2/style.json?key=ejjLkz58mUNz9TgNs0Ed',
-  dataviz: 'https://api.maptiler.com/maps/dataviz/style.json?key=ejjLkz58mUNz9TgNs0Ed'
+  outdoor: {
+    style: 'https://api.maptiler.com/maps/outdoor-v2/style.json?key=ejjLkz58mUNz9TgNs0Ed',
+    imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-outdoor-v2.jpeg'
+  },
+  dataviz: {
+    style: 'https://api.maptiler.com/maps/dataviz/style.json?key=ejjLkz58mUNz9TgNs0Ed',
+    imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-bright-v2-pastel.jpeg'
+  },
+  basic: {
+    style: 'https://api.maptiler.com/maps/basic/style.json?key=ejjLkz58mUNz9TgNs0Ed',
+    imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-basic-v2.jpeg'
+  }
 }
 export interface MapStyles {
-  outdoor: string
-  dataviz: string
+  outdoor: {
+    style: string
+    imgUrl: string
+  }
+  dataviz: {
+    style: string
+    imgUrl: string
+  }
+  basic: {
+    style: string
+    imgUrl: string
+  }
 }

--- a/src/components/maps/MapSelector.tsx
+++ b/src/components/maps/MapSelector.tsx
@@ -1,4 +1,8 @@
-export const MAP_STYLES = {
+export const MAP_STYLES: MapStyles = {
   outdoor: 'https://api.maptiler.com/maps/outdoor-v2/style.json?key=ejjLkz58mUNz9TgNs0Ed',
   dataviz: 'https://api.maptiler.com/maps/dataviz/style.json?key=ejjLkz58mUNz9TgNs0Ed'
+}
+export interface MapStyles {
+  outdoor: string
+  dataviz: string
 }

--- a/src/components/maps/MapSelector.tsx
+++ b/src/components/maps/MapSelector.tsx
@@ -1,18 +1,19 @@
+const MAPTILER_KEY = process.env.NEXT_PUBLIC_MAPTILER_API_KEY !== undefined ? process.env.NEXT_PUBLIC_MAPTILER_API_KEY : 'key'
 export const MAP_STYLES: MapStyles = {
   outdoor: {
-    style: 'https://api.maptiler.com/maps/outdoor-v2/style.json?key=ejjLkz58mUNz9TgNs0Ed',
+    style: `https://api.maptiler.com/maps/outdoor-v2/style.json?key=${MAPTILER_KEY}`,
     imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-outdoor-v2.jpeg'
   },
-  dataviz: {
-    style: 'https://api.maptiler.com/maps/dataviz/style.json?key=ejjLkz58mUNz9TgNs0Ed',
+  minimal: {
+    style: `https://api.maptiler.com/maps/dataviz/style.json?key=${MAPTILER_KEY}`,
     imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-bright-v2-pastel.jpeg'
   },
-  basic: {
-    style: 'https://api.maptiler.com/maps/basic/style.json?key=ejjLkz58mUNz9TgNs0Ed',
+  standard: {
+    style: `https://api.maptiler.com/maps/basic/style.json?key=${MAPTILER_KEY}`,
     imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-basic-v2.jpeg'
   },
   satellite: {
-    style: 'https://api.maptiler.com/maps/satellite/style.json?key=ejjLkz58mUNz9TgNs0Ed',
+    style: `https://api.maptiler.com/maps/satellite/style.json?key=${MAPTILER_KEY}`,
     imgUrl: 'https://docs.maptiler.com/sdk-js/api/map-styles/img/style-satellite.jpeg'
   }
 }
@@ -21,11 +22,11 @@ export interface MapStyles {
     style: string
     imgUrl: string
   }
-  dataviz: {
+  minimal: {
     style: string
     imgUrl: string
   }
-  basic: {
+  standard: {
     style: string
     imgUrl: string
   }


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues
Not that i know 

Issue #1108 


### What this PR achieves
the pr implements a map layer style switcher by using RadiX UI [Hover Card](https://www.radix-ui.com/primitives/docs/components/hover-card)
When clicked on a certain map tile the style of the whole map switches. So far 4 different styles are implemented (see MapSelector.tsx):
1. outdoor
2. dataviz
3. basic (minimalist)
4. satellite

I knew only the minimalist, outdoor, satellite were required, but in the mapselector there were already 2 different styles (outdoor and dataviz) so i added the ones that were missing instead of deleting. Also the dataviz style was used in the <Map> implemented in the RecentContributionMap.tsx. 

What does this PR:

- A new component is created (maps/MapLayersSelector.tsx):  - in there the Radix UI Hover Card is implemented
- The MapLayersSelector.tsx emits the key of the selected layer and passes it back to it's parent (GlobalMap.tsx)
- In the GlobalMap.tsx a new child component is created (MapLayersSelector) 
- In the GlobalMap.tsx a new reactive variable is created in which the key of the map layer style is hold (  const [mapStyle, setMapStyle] = useState<string>(MAP_STYLES.dataviz.style)).
- The MapSelector.tsx adjusted - MAP_STYLES got more and nested properties
- The MapSelector.tsx now have also types - MAP_STYLES is now of type MapStyles.
- Needed to adjust one line in RecentContributionsMap (line 90) mapStyle={MAP_STYLES.dataviz.style} - as it used the mapstyle - i here adjusted the corresponding nested object so the map still displays the right style.

### Screenshots, recordings
![image](https://github.com/OpenBeta/open-tacos/assets/51745385/330243ce-11f7-4616-ac2b-60cee8c12741)



### Notes
As for the implementation of the map layer icons (tiles) 
![image](https://github.com/OpenBeta/open-tacos/assets/51745385/0db829ba-9f20-4119-9678-c51747dc3d5e)

i needed to get the imageUrls to show example images of the map styles. As of now I got them from here: 
https://docs.maptiler.com/sdk-js/api/map-styles/#referencemapstyle (copied the image url of the respective map layer style)




