### PR TITLE
refactor summary sections

### DIFF
--- a/src/app/(default)/area/[[...slug]]/page.tsx
+++ b/src/app/(default)/area/[[...slug]]/page.tsx
@@ -18,6 +18,7 @@ import { SubAreasSection } from './sections/SubAreasSection'
 import { ClimbListSection } from './sections/ClimbListSection'
 import { CLIENT_CONFIG } from '@/js/configs/clientConfig'
 import { PageBanner as LCOBanner } from '@/components/lco/PageBanner'
+import { AuthorMetadata, OrganizationType } from '@/js/types'
 /**
  * Page cache settings
  */
@@ -77,55 +78,13 @@ export default async function Page ({ params }: PageWithCatchAllUuidProps): Prom
           area={area}
         />
       }
+      summary={{
+        left: <AreaData areaName={areaName} lat={lat} lng={lng} authorMetadata={authorMetadata} />,
+        right: (
+          <DescriptionSection uuid={uuid} description={description} organizations={organizations} />
+        )
+      }}
     >
-      <div className='area-climb-page-summary'>
-        <div className='area-climb-page-summary-left'>
-          <h1>{areaName}</h1>
-
-          <div className='mt-6 flex flex-col text-xs text-secondary border-t border-b divide-y'>
-            <a
-              href={getMapHref({
-                lat,
-                lng
-              })}
-              target='blank'
-              className='flex items-center gap-2 py-3'
-            >
-              <MapPinLine size={20} />
-              <span className='mt-0.5'>
-                <b>LAT,LNG</b>&nbsp;
-                <span className='link-dotted'>
-                  {lat.toFixed(5)}, {lng.toFixed(5)}
-                </span>
-              </span>
-            </a>
-            <ArticleLastUpdate {...authorMetadata} />
-          </div>
-        </div>
-
-        <div className='area-climb-page-summary-right'>
-          <div className='flex items-center gap-2'>
-            <h3 className='font-bold'>Description</h3>
-            <span className='text-xs inline-block align-baseline'>
-              [
-              <Link
-                href={`/editArea/${uuid}/general#description`}
-                target='_new'
-                className='hover:underline'
-              >
-                Edit
-              </Link>]
-            </span>
-          </div>
-          {(description == null || description.trim() === '') && <EditDescriptionCTA uuid={uuid} />}
-          <Markdown className='wiki-content'>{description}</Markdown>
-
-          <hr className='border-1 mt-8 mb-4' />
-
-          <LCOBanner orgs={organizations} />
-        </div>
-      </div>
-
       <hr className='border-1 my-8' />
 
       {/* An area can only have either subareas or climbs, but not both. */}
@@ -163,6 +122,65 @@ const EditDescriptionCTA: React.FC<{ uuid: string }> = ({ uuid }) => (
     </div>
   </div>
 )
+
+const DescriptionSection: React.FC<{ uuid: string, description: string, organizations: OrganizationType[] }> = ({
+  uuid, description, organizations
+}) => {
+  return (
+    <>
+      <div className='flex items-center gap-2'>
+        <h3 className='font-bold'>Description</h3>
+        <span className='text-xs inline-block align-baseline'>
+          [
+          <Link
+            href={`/editArea/${uuid}/general#description`}
+            target='_new'
+            className='hover:underline'
+          >
+            Edit
+          </Link>
+          ]
+        </span>
+      </div>
+      {(description == null || description.trim() === '') && <EditDescriptionCTA uuid={uuid} />}
+      <Markdown className='wiki-content'>{description}</Markdown>
+
+      <hr className='border-1 mt-8 mb-4' />
+
+      <LCOBanner orgs={organizations} />
+    </>
+  )
+}
+
+const AreaData: React.FC<{ areaName: string, lat: number, lng: number, authorMetadata: AuthorMetadata }> = ({
+  areaName, lat, lng, authorMetadata
+}) => {
+  return (
+    <>
+      <h1>{areaName}</h1>
+
+      <div className='mt-6 flex flex-col text-xs text-secondary border-t border-b divide-y'>
+        <a
+          href={getMapHref({
+            lat,
+            lng
+          })}
+          target='blank'
+          className='flex items-center gap-2 py-3'
+        >
+          <MapPinLine size={20} />
+          <span className='mt-0.5'>
+            <b>LAT,LNG</b>&nbsp;
+            <span className='link-dotted'>
+              {lat.toFixed(5)}, {lng.toFixed(5)}
+            </span>
+          </span>
+        </a>
+        <ArticleLastUpdate {...authorMetadata} />
+      </div>
+    </>
+  )
+}
 
 /**
  * List of area pages to prebuild

--- a/src/app/(default)/components/ui/AreaPageContainer.tsx
+++ b/src/app/(default)/components/ui/AreaPageContainer.tsx
@@ -2,6 +2,7 @@ import { GallerySkeleton } from '@/components/media/PhotoMontage'
 import React from 'react'
 import { AreaPageActionsSkeleton } from '../AreaPageActions'
 import { HeroAlert } from '../LandingHero'
+import { Summary } from './Summary'
 
 /**
  * Area page containter.  Show loading skeleton if no params are provided.
@@ -11,8 +12,9 @@ export const AreaPageContainer: React.FC<{
   pageActions?: React.ReactNode
   breadcrumbs?: React.ReactNode
   map?: React.ReactNode
+  summary?: { left: React.ReactNode, right: React.ReactNode }
   children?: React.ReactNode
-}> = ({ photoGallery, pageActions, breadcrumbs, map, children }) => {
+}> = ({ photoGallery, pageActions, breadcrumbs, map, summary, children }) => {
   return (
     <article>
       <div className='default-page-margins my-2'>
@@ -24,6 +26,7 @@ export const AreaPageContainer: React.FC<{
           {pageActions == null ? <AreaPageActionsSkeleton /> : pageActions}
         </div>
         {breadcrumbs == null ? <BreadCrumbsSkeleton /> : breadcrumbs}
+        {summary != null && <Summary columns={summary} />}
         {children == null ? <ContentSkeleton /> : children}
       </div>
       <div id='map' className='w-full mt-16 relative h-[90vh] border-t'>

--- a/src/app/(default)/components/ui/Summary.tsx
+++ b/src/app/(default)/components/ui/Summary.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react'
+
+interface Props {
+  columns: {
+    left: ReactNode
+    right?: ReactNode
+  }
+}
+
+export const Summary: React.FC<Props> = ({ columns: { left, right } }) => (
+  <div className='area-summary'>
+    <div className='area-summary-left'>{left}</div>
+    {right !== undefined ? <div className='area-summary-right'>{right}</div> : null}
+  </div>
+)

--- a/src/app/(default)/components/ui/Summary.tsx
+++ b/src/app/(default)/components/ui/Summary.tsx
@@ -10,6 +10,6 @@ interface Props {
 export const Summary: React.FC<Props> = ({ columns: { left, right } }) => (
   <div className='area-summary'>
     <div className='area-summary-left'>{left}</div>
-    {right !== undefined ? <div className='area-summary-right'>{right}</div> : null}
+    {right != null ? <div className='area-summary-right'>{right}</div> : null}
   </div>
 )

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -49,16 +49,16 @@ A slightly deemphasized dotted underline for a tag in order to not competing wit
   @apply underline decoration-dotted underline-offset-2 decoration-inherit;
 }
 
-/* Layout for summary section of the area and climb page. 2 columns on desktop, normal stack div on mobile. */
-.area-climb-page-summary {
+/* Layout for summary section. 2 columns on desktop, normal stack div on mobile. */
+.area-summary {
   @apply mt-6 lg:grid lg:grid-cols-3 w-full;
 }
 
-.area-climb-page-summary-left {
+.area-summary-left {
   @apply  lg:pr-8 border-base-content;
 }
 
-.area-climb-page-summary-right {
+.area-summary-right {
   @apply mt-6 lg:mt-0 lg:col-span-2 lg:pl-16 w-full;
 }
 

--- a/src/components/crag/cragSummary.tsx
+++ b/src/components/crag/cragSummary.tsx
@@ -6,8 +6,9 @@ import { useSession } from 'next-auth/react'
 import * as Portal from '@radix-ui/react-portal'
 import { MapPinIcon } from '@heroicons/react/24/outline'
 import { toast } from 'react-toastify'
+import { Summary } from '@/app/(default)/components/ui/Summary'
 
-import { AreaUpdatableFieldsType, AreaType, ClimbDisciplineRecord, ClimbDiscipline, ChangesetType } from '../../js/types'
+import { AreaUpdatableFieldsType, AreaType, ClimbDisciplineRecord, ClimbDiscipline, ChangesetType, AuthorMetadata, OrganizationType } from '../../js/types'
 import { IndividualClimbChangeInput, UpdateOneAreaInputType } from '../../js/graphql/gql/contribs'
 import { getMapHref, sortByLeftRightIndex, removeTypenameFromDisciplines } from '../../js/utils'
 import { AREA_NAME_FORM_VALIDATION_RULES, AREA_LATLNG_FORM_VALIDATION_RULES, AREA_DESCRIPTION_FORM_VALIDATION_RULES } from '../edit/EditAreaForm'
@@ -409,91 +410,29 @@ export default function CragSummary ({ area, history }: CragSummaryProps): JSX.E
               </MobileDialog>
             )}
           </div>
-
-          <div className='area-climb-page-summary'>
-            <div className='area-climb-page-summary-left'>
-              <h1 className='text-4xl md:text-5xl'>
-                <InplaceTextInput
-                  initialValue={areaName}
-                  name='areaName'
-                  reset={resetSignal}
-                  editable={editMode}
-                  placeholder='Area name'
-                  rules={AREA_NAME_FORM_VALIDATION_RULES}
+          <Summary
+            columns={{
+              left: (
+                <AreaSection
+                  areaName={areaName}
+                  resetSignal={resetSignal}
+                  editMode={editMode}
+                  currentLatLngStr={currentLatLngStr}
+                  latlngPair={latlngPair}
+                  authorMetadata={authorMetadata}
+                  canChangeAreaType={canChangeAreaType}
                 />
-              </h1>
-
-              {editMode
-                ? (
-                  <InplaceTextInput
-                    initialValue={currentLatLngStr}
-                    name='latlng'
-                    reset={resetSignal}
-                    editable={editMode}
-                    placeholder='Enter a latitude,longitude. Ex: 46.433333,11.85'
-                    rules={AREA_LATLNG_FORM_VALIDATION_RULES}
-                  />
-                  )
-                : (
-                    latlngPair != null && (
-                      <div className='flex flex-col text-xs text-base-300 border-t border-b  divide-y'>
-                        <a
-                          href={getMapHref({
-                            lat: latlngPair[0],
-                            lng: latlngPair[1]
-                          })}
-                          target='blank'
-                          className='flex items-center gap-2 py-3'
-                        >
-                          <MapPinIcon className='w-5 h-5' />
-                          <span className='mt-0.5'>
-                            <b>LAT,LNG</b>&nbsp;
-                            <span className='link-dotted'>
-                              {latlngPair[0].toFixed(5)}, {latlngPair[1].toFixed(5)}
-                            </span>
-                          </span>
-                        </a>
-                        <ArticleLastUpdate {...authorMetadata} />
-                      </div>
-                    )
-                  )}
-
-              {editMode && (
-                <div className='fadeinEffect'>
-                  <div className='mt-8'>
-                    <h3>Housekeeping</h3>
-                    <AreaDesignationRadioGroup disabled={!canChangeAreaType} />
-                  </div>
-                  <div className='mt-6 form-control'>
-                    <label className='label'>
-                      <span className='label-text font-semibold'>
-                        Permanently delete this area
-                      </span>
-                    </label>
-                    <div className='ml-2' id='deleteButtonPlaceholder' />
-                  </div>
-                </div>
-              )}
-            </div>
-            <div className='area-climb-page-summary-right'>
-              {/* <div className='flex-1 flex justify-end'>
-        // vnguyen: temporarily removed until we have view favorites feature
-        <FavouriteButton areaId={props.areaMeta.areaId} />
-      </div> */}
-
-              <h3>Description</h3>
-
-              <InplaceEditor
-                initialValue={description}
-                name='description'
-                reset={resetSignal}
-                editable={editMode}
-                placeholder='Area description'
-                rules={AREA_DESCRIPTION_FORM_VALIDATION_RULES}
-              />
-              {!editMode && <LCOBanner orgs={organizations} />}
-            </div>
-          </div>
+              ),
+              right: (
+                <DescriptionSection
+                  description={description}
+                  resetSignal={resetSignal}
+                  editMode={editMode}
+                  organizations={organizations}
+                />
+              )
+            }}
+          />
 
           <div className='mt-4 block lg:hidden'>
             {/* Mobile-only */}
@@ -630,3 +569,92 @@ const AreaDesignationRadioGroup = dynamic<AreaDesignationRadioGroupProps>(
       (module) => module.AreaDesignationRadioGroup
     )
 )
+
+const AreaSection: React.FC<{ areaName: string, resetSignal: number, editMode: boolean, currentLatLngStr: string, latlngPair: [number, number] | null, authorMetadata: AuthorMetadata, canChangeAreaType: boolean }> = ({
+  areaName, resetSignal, editMode, currentLatLngStr, latlngPair, authorMetadata, canChangeAreaType
+}) => {
+  return (
+    <>
+      <h1 className='text-4xl md:text-5xl'>
+        <InplaceTextInput
+          initialValue={areaName}
+          name='areaName'
+          reset={resetSignal}
+          editable={editMode}
+          placeholder='Area name'
+          rules={AREA_NAME_FORM_VALIDATION_RULES}
+        />
+      </h1>
+
+      {editMode
+        ? (
+          <InplaceTextInput
+            initialValue={currentLatLngStr}
+            name='latlng'
+            reset={resetSignal}
+            editable={editMode}
+            placeholder='Enter a latitude,longitude. Ex: 46.433333,11.85'
+            rules={AREA_LATLNG_FORM_VALIDATION_RULES}
+          />
+          )
+        : (
+            latlngPair != null && (
+              <div className='flex flex-col text-xs text-base-300 border-t border-b  divide-y'>
+                <a
+                  href={getMapHref({
+                    lat: latlngPair[0],
+                    lng: latlngPair[1]
+                  })}
+                  target='blank'
+                  className='flex items-center gap-2 py-3'
+                >
+                  <MapPinIcon className='w-5 h-5' />
+                  <span className='mt-0.5'>
+                    <b>LAT,LNG</b>&nbsp;
+                    <span className='link-dotted'>
+                      {latlngPair[0].toFixed(5)}, {latlngPair[1].toFixed(5)}
+                    </span>
+                  </span>
+                </a>
+                <ArticleLastUpdate {...authorMetadata} />
+              </div>
+            )
+          )}
+
+      {editMode && (
+        <div className='fadeinEffect'>
+          <div className='mt-8'>
+            <h3>Housekeeping</h3>
+            <AreaDesignationRadioGroup disabled={!canChangeAreaType} />
+          </div>
+          <div className='mt-6 form-control'>
+            <label className='label'>
+              <span className='label-text font-semibold'>Permanently delete this area</span>
+            </label>
+            <div className='ml-2' id='deleteButtonPlaceholder' />
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+const DescriptionSection: React.FC<{ description: string, resetSignal: number, editMode: boolean, organizations: OrganizationType[] }> = ({
+  description, resetSignal, editMode, organizations
+}) => {
+  return (
+    <>
+      <h3>Description</h3>
+
+      <InplaceEditor
+        initialValue={description}
+        name='description'
+        reset={resetSignal}
+        editable={editMode}
+        placeholder='Area description'
+        rules={AREA_DESCRIPTION_FORM_VALIDATION_RULES}
+      />
+      {!editMode && <LCOBanner orgs={organizations} />}
+    </>
+  )
+}

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -8,10 +8,11 @@ import * as Portal from '@radix-ui/react-portal'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useSwipeable } from 'react-swipeable'
 import { toast } from 'react-toastify'
+import { Summary } from '@/app/(default)/components/ui/Summary'
 import ArrowVertical from '../../assets/icons/arrow-vertical.svg'
 
 import Layout from '../../components/layout'
-import { AreaType, ClimbDisciplineRecord, ClimbType, RulesType } from '../../js/types'
+import { AreaType, AuthorMetadata, ClimbDisciplineRecord, ClimbType, RulesType, SafetyType } from '../../js/types'
 import SeoTags from '../../components/SeoTags'
 import RouteGradeChip from '../../components/ui/RouteGradeChip'
 import RouteTypeChips from '../../components/ui/RouteTypeChips'
@@ -244,120 +245,231 @@ const Body = ({ climb, leftClimb, rightClimb, parentArea }: ClimbPageProps): JSX
           <NeighboringRoutesNav climbs={[leftClimb, rightClimb]} parentArea={parentArea} />
 
           <div className='mt-4 text-right' id='editTogglePlaceholder' />
-
-          <div className='area-climb-page-summary'>
-            <div
-              id='Title Information'
-              className='area-climb-page-summary-left'
-            >
-
-              <h1 className='text-4xl md:text-5xl mr-10'>
-                <InplaceTextInput
-                  reset={resetSignal}
-                  name='name'
-                  editable={editMode}
-                  initialValue={cache.name}
-                  placeholder='Climb name'
-                  rules={AREA_NAME_FORM_VALIDATION_RULES}
+          <Summary
+            columns={{
+              left: (
+                <ClimbData
+                  resetSignal={resetSignal}
+                  editMode={editMode}
+                  cache={cache}
+                  isBouldering={isBouldering}
+                  gradesObj={gradesObj}
+                  safety={safety}
+                  disciplinesField={disciplinesField}
+                  length={length}
+                  legacyFA={legacyFA}
+                  authorMetadata={authorMetadata}
+                  climbId={climbId}
+                  name={name}
+                  yds={yds}
                 />
-              </h1>
-              <div className='mt-6'>
-                {editMode && isBouldering &&
-                  <BoulderingGradeInput gradeObj={gradesObj} />}
-                {editMode && !isBouldering &&
-                  <TradSportGradeInput gradeObj={gradesObj} />}
-                <div className='flex items-center space-x-2 w-full'>
-                  {!editMode && cache.gradeStr != null && <RouteGradeChip gradeStr={cache.gradeStr} safety={safety} />}
-                  {!editMode && <RouteTypeChips type={disciplinesField} />}
-                </div>
-
-                {length !== -1 && !editMode && (
-                  <div className='mt-6 inline-flex items-center justify-left border-2 border-neutral/80 rounded'>
-                    <ArrowVertical className='h-5 w-5' />
-                    <span className='bg-neutral/80 text-base-100 px-2 text-sm'>{length}m</span>
-                  </div>
-                )}
-                {editMode && <TotalLengthInput />}
-
-                <div className='mt-6'>{editMode
-                  ? (<LegacyFAInput />)
-                  : (
-                    <div className='text-sm font-medium text-base-content'>
-                      {trimLegacyFA(legacyFA)}
-                    </div>)}
-                </div>
-
-                {(authorMetadata.createdAt != null || authorMetadata.updatedAt != null) &&
-                  <div className='mt-8  border-t border-b'>
-                    <ArticleLastUpdate {...authorMetadata} />
-                  </div>}
-
-                {!editMode &&
-                  <div className='mt-8'>
-                    <TickButton climbId={climbId} name={name} grade={yds} />
-                  </div>}
-
-              </div>
-            </div>
-
-            <div className='area-climb-page-summary-right col-start-2 col-end-4 row-start-1 row-end-3'>
-              <div className='mb-3 flex justify-between items-center'>
-                <h3>Description</h3>
-              </div>
-              <Editor
-                reset={resetSignal}
-                initialValue={cache.description}
-                editable={editMode}
-                name='description'
-                placeholder={editMode ? 'Enter a description' : 'This climb is missing some beta. Turn on Edit mode and help us improve this page.'}
-                rules={CLIMB_DESCRIPTION_FORM_VALIDATION_RULES}
-              />
-
-              {(cache.location?.trim() !== '' || editMode) &&
-                  (
-                    <>
-                      <h3 className='mb-3 mt-6'>Location</h3>
-                      <Editor
-                        reset={resetSignal}
-                        name='location'
-                        initialValue={cache.location}
-                        editable={editMode}
-                        placeholder='How to find this climb'
-                        rules={CLIMB_LOCATION_FORM_VALIDATION_RULES}
-                      />
-
-                    </>
-                  )}
-
-              {(cache.protection?.trim() !== '' || editMode) &&
-                  (
-                    <>
-                      <h3 className='mb-3 mt-6'>Protection</h3>
-                      <Editor
-                        reset={resetSignal}
-                        name='protection'
-                        initialValue={cache.protection}
-                        editable={editMode}
-                        placeholder='Example: 16 quickdraws'
-                        rules={CLIMB_PROTECTON_FORM_VALIDATION_RULES}
-                      />
-                    </>
-                  )}
-
-              <div className='mt-4 block lg:hidden'>
-                {/* Mobile-only */}
-                {FormAction}
-              </div>
-            </div>
-            <div className='col-start-1 col-end-2 mt-8'>
-              <h4>Routes in {parentArea.areaName.includes(', The') ? 'The '.concat(parentArea.areaName.slice(0, -5)) : parentArea.areaName}</h4>
-              <hr className='mt-2 mb-2 border-1 border-base-content' />
-              {!editMode && <ClimbList gradeContext={parentArea.gradeContext} climbs={parentArea.climbs} areaMetadata={parentArea.metadata} editMode={editMode} routePageId={climbId} />}
-            </div>
-          </div>
+              ),
+              right: (
+                <DescriptionSection
+                  resetSignal={resetSignal}
+                  cache={cache}
+                  editMode={editMode}
+                  FormAction={FormAction}
+                />
+              )
+            }}
+          />
+          <Summary
+            columns={{ left: <Routes parentArea={parentArea} editMode={editMode} climbId={climbId} /> }}
+          />
         </form>
       </FormProvider>
     </div>
+  )
+}
+
+const DescriptionSection: React.FC<{
+  resetSignal: number
+  cache: {
+    disciplines: Partial<ClimbDisciplineRecord>
+    gradeStr: string | undefined
+    length?: number | undefined
+    legacyFA: string
+    description: string
+    location: string
+    protection: string
+    name: string
+  }
+  editMode: boolean
+  FormAction: React.JSX.Element
+}> = ({ resetSignal, cache, editMode, FormAction }) => {
+  return (
+    <>
+      <div className='mb-3 flex justify-between items-center'>
+        <h3>Description</h3>
+      </div>
+      <Editor
+        reset={resetSignal}
+        initialValue={cache.description}
+        editable={editMode}
+        name='description'
+        placeholder={
+          editMode
+            ? 'Enter a description'
+            : 'This climb is missing some beta. Turn on Edit mode and help us improve this page.'
+        }
+        rules={CLIMB_DESCRIPTION_FORM_VALIDATION_RULES}
+      />
+
+      {(cache.location?.trim() !== '' || editMode) && (
+        <>
+          <h3 className='mb-3 mt-6'>Location</h3>
+          <Editor
+            reset={resetSignal}
+            name='location'
+            initialValue={cache.location}
+            editable={editMode}
+            placeholder='How to find this climb'
+            rules={CLIMB_LOCATION_FORM_VALIDATION_RULES}
+          />
+        </>
+      )}
+
+      {(cache.protection?.trim() !== '' || editMode) && (
+        <>
+          <h3 className='mb-3 mt-6'>Protection</h3>
+          <Editor
+            reset={resetSignal}
+            name='protection'
+            initialValue={cache.protection}
+            editable={editMode}
+            placeholder='Example: 16 quickdraws'
+            rules={CLIMB_PROTECTON_FORM_VALIDATION_RULES}
+          />
+        </>
+      )}
+
+      <div className='mt-4 block lg:hidden'>
+        {/* Mobile-only */}
+        {FormAction}
+      </div>
+    </>
+  )
+}
+
+const Routes: React.FC<{ parentArea: AreaType, editMode: boolean, climbId: string }> = ({
+  parentArea,
+  editMode,
+  climbId
+}) => {
+  return (
+    <>
+      <h4>
+        Routes in{' '}
+        {parentArea.areaName.includes(', The')
+          ? 'The '.concat(parentArea.areaName.slice(0, -5))
+          : parentArea.areaName}
+      </h4>
+      <hr className='mt-2 mb-2 border-1 border-base-content' />
+      {!editMode && (
+        <ClimbList
+          gradeContext={parentArea.gradeContext}
+          climbs={parentArea.climbs}
+          areaMetadata={parentArea.metadata}
+          editMode={editMode}
+          routePageId={climbId}
+        />
+      )}
+    </>
+  )
+}
+
+const ClimbData: React.FC<{
+  resetSignal: number
+  editMode: boolean
+  cache: {
+    disciplines: Partial<ClimbDisciplineRecord>
+    gradeStr: string | undefined
+    length?: number | undefined
+    legacyFA: string
+    description: string
+    location: string
+    protection: string
+    name: string
+  }
+  isBouldering: boolean
+  gradesObj: Grade
+  safety: SafetyType
+  disciplinesField: ClimbDisciplineRecord
+  length: number
+  legacyFA: string
+  authorMetadata: AuthorMetadata
+  climbId: string
+  name: string
+  yds: string
+}> = ({
+  resetSignal,
+  editMode,
+  cache,
+  isBouldering,
+  gradesObj,
+  safety,
+  disciplinesField,
+  length,
+  legacyFA,
+  authorMetadata,
+  climbId,
+  name,
+  yds
+}) => {
+  return (
+    <>
+      <h1 className='text-4xl md:text-5xl mr-10'>
+        <InplaceTextInput
+          reset={resetSignal}
+          name='name'
+          editable={editMode}
+          initialValue={cache.name}
+          placeholder='Climb name'
+          rules={AREA_NAME_FORM_VALIDATION_RULES}
+        />
+      </h1>
+      <div className='mt-6'>
+        {editMode && isBouldering && <BoulderingGradeInput gradeObj={gradesObj} />}
+        {editMode && !isBouldering && <TradSportGradeInput gradeObj={gradesObj} />}
+        <div className='flex items-center space-x-2 w-full'>
+          {!editMode && cache.gradeStr != null && (
+            <RouteGradeChip gradeStr={cache.gradeStr} safety={safety} />
+          )}
+          {!editMode && <RouteTypeChips type={disciplinesField} />}
+        </div>
+
+        {length !== -1 && !editMode && (
+          <div className='mt-6 inline-flex items-center justify-left border-2 border-neutral/80 rounded'>
+            <ArrowVertical className='h-5 w-5' />
+            <span className='bg-neutral/80 text-base-100 px-2 text-sm'>{length}m</span>
+          </div>
+        )}
+        {editMode && <TotalLengthInput />}
+
+        <div className='mt-6'>
+          {editMode
+            ? (
+              <LegacyFAInput />
+              )
+            : (
+              <div className='text-sm font-medium text-base-content'>{trimLegacyFA(legacyFA)}</div>
+              )}
+        </div>
+
+        {(authorMetadata.createdAt != null || authorMetadata.updatedAt != null) && (
+          <div className='mt-8  border-t border-b'>
+            <ArticleLastUpdate {...authorMetadata} />
+          </div>
+        )}
+
+        {!editMode && (
+          <div className='mt-8'>
+            <TickButton climbId={climbId} name={name} grade={yds} />
+          </div>
+        )}
+      </div>
+    </>
   )
 }
 

--- a/src/styles/defaults.css
+++ b/src/styles/defaults.css
@@ -31,17 +31,17 @@ a:active, a:focus {
   @apply max-w-4xl mx-auto flex flex-col gap-y-8;
 }
 
-/* Layout for summary section of the area and climb page. 2 columns on desktop, normal stack div on mobile. */
-.area-climb-page-summary {
+/* Layout for summary section. 2 columns on desktop, normal stack div on mobile. */
+.area-summary {
   @apply mt-6 lg:grid lg:grid-cols-3 w-full;
 }
 
-.area-climb-page-summary-left {
+.area-summary-left {
   @apply  lg:pr-8 border-base-content;
 }
 
-.area-climb-page-summary-right {
-  @apply mt-6 lg:mt-0 lg:pl-16 w-full;
+.area-summary-right {
+  @apply mt-6 lg:mt-0 lg:col-span-2 lg:pl-16 w-full;
 }
 
 /**


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [x] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #1066


### What this PR achieves

Currently, we have a common pattern where when we want to add a summary section (two columns), we create divs and add the classes that handle the grid layout. This PR encapsulates that logic into a single `<Summary />` component, which accepts two children (one for each column), and also implements it in places where the old logic was implemented:

- climb page 
- area page (through implementing it on `AreaPageContainer`)
- crag summary

### Screenshots, recordings
After refactor, should present no changes with current views:

- Area page, desktop
<img width="500" alt="Screenshot 2024-04-17 at 18 01 57" src="https://github.com/OpenBeta/open-tacos/assets/67206170/0b29b068-ea83-4709-b3f7-b099172487a0">

- Climb page, desktop
<img width="500" alt="Screenshot 2024-04-17 at 18 01 42" src="https://github.com/OpenBeta/open-tacos/assets/67206170/66c97c10-2a14-402e-883d-46ddc5cd019e">

- Area page, mobile
<img width="300" alt="Screenshot 2024-04-17 at 18 02 22" src="https://github.com/OpenBeta/open-tacos/assets/67206170/dff807af-9414-4ad3-b8ab-965be75ff71a">

- Climb page, mobile 
<img width="300" alt="Screenshot 2024-04-17 at 18 02 38" src="https://github.com/OpenBeta/open-tacos/assets/67206170/f568f1f5-ca07-4e51-8e14-63e2e96a400b">


### Notes

- I saw that crag summary used the same pattern so I used the <Summary /> component there too. It should be pretty straightforward since the previous implementation was identical to the other section. However, I couldn't test changes on that section since I'm not very familiar yet so I don't how to reach that page.
- For each implementation, I extracted the component corresponding to the `left` and `right` columns into their own component. Let me know if this approach is ok or if you'd prefer that pass them directly to the props of `<Summary />`



