### PR TITLE
fix: use flex to prevent overlap of title to close button

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -114,7 +114,7 @@ A slightly deemphasized dotted underline for a tag in order to not competing wit
   }
 
   .dialog-close-button {
-    @apply absolute top-1 left-1 z-50;
+    @apply mx-auto z-auto;
   }
 
   .dialog-form-default {
@@ -122,7 +122,7 @@ A slightly deemphasized dotted underline for a tag in order to not competing wit
   }
 
   .dialog-title {
-    @apply py-2 w-full text-center bg-base-100 z-50 leading-none;
+    @apply flex-grow text-center bg-base-100 leading-none;
   }
 
   .minimal-scrollbar::-webkit-scrollbar {

--- a/src/components/ui/MobileDialog.tsx
+++ b/src/components/ui/MobileDialog.tsx
@@ -22,15 +22,16 @@ export const DialogContent = React.forwardRef<any, Props>(
           data-no-dnd='true'
           className={clx(fullScreen ? 'dialog-wide' : 'dialog-default')} {...props} ref={forwardedRef}
         >
-          <DialogPrimitive.Title className='dialog-title'>
-            {title}
-          </DialogPrimitive.Title>
-          {/* Use absolute positioning to place the close button on the upper left corner */}
-          <DialogPrimitive.Close aria-label='Close' asChild className='dialog-close-button'>
-            <button className='btn btn-circle btn-ghost outline-none'>
-              <XMarkIcon size={24} />
-            </button>
-          </DialogPrimitive.Close>
+          <div className='flex items-center px-2'>
+            <DialogPrimitive.Close aria-label='Close' asChild className='dialog-close-button'>
+              <button className='btn btn-circle btn-ghost outline-none'>
+                <XMarkIcon size={24} />
+              </button>
+            </DialogPrimitive.Close>
+            <DialogPrimitive.Title className='dialog-title'>
+              {title}
+            </DialogPrimitive.Title>
+          </div>
           {children}
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

refactor the MobileDialog title from being full width. Manage positioning by flex classes.

### Related Issues

Issue #1147 


### What this PR achieves

Prevents 


### Screenshots, recordings
![image](https://github.com/OpenBeta/open-tacos/assets/24685932/b28087cf-f210-4929-9594-6490d9aadbbb)
![image](https://github.com/OpenBeta/open-tacos/assets/24685932/86412ead-73a7-4c98-bd55-09da720ac748)
![image](https://github.com/OpenBeta/open-tacos/assets/24685932/c9e17f3f-f870-4acb-9b88-99cb47de4954)




### Notes
<!--Anything in particular you want the reviwer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




