### PR TITLE
Add link to forums to navigation elements

### DIFF
--- a/src/app/(default)/components/DesktopHeader.tsx
+++ b/src/app/(default)/components/DesktopHeader.tsx
@@ -12,8 +12,8 @@ export const DesktopHeader: React.FC = () => {
 
   const navListDefault: NavMenuItemProps[] = [
     {
-      to: process.env.NEXT_PUBLIC_DISCORD_INVITE,
-      label: 'Discord'
+      to: 'https://community.openbeta.io',
+      label: 'Forums'
     },
     {
       to: '/about',

--- a/src/app/(default)/components/PageFooter.tsx
+++ b/src/app/(default)/components/PageFooter.tsx
@@ -16,6 +16,7 @@ export const PageFooter: React.FC = () => {
       </nav>
       <nav>
         <header className='footer-title'>Social</header>
+        <a className='link link-hover' href='https://community.openbeta.io/'>Forums</a>
         <a className='link link-hover' href={process.env.NEXT_PUBLIC_DISCORD_INVITE}>Discord chat</a>
         <a className='link link-hover' href='https://www.instagram.com/openbetaproject/'>Instagram</a>
         <a className='link link-hover' href='https://www.linkedin.com/company/openbetahq/'>LinkedIn</a>

--- a/src/components/AuthenticatedProfileNavButton.tsx
+++ b/src/components/AuthenticatedProfileNavButton.tsx
@@ -69,6 +69,7 @@ export default function AuthenticatedProfileNavButton ({ isMobile = true }: Prof
             <DropdownSeparator />
 
             <DropdownItem text='About' onSelect={() => { void router.push('/about') }} />
+            <DropdownItem text='Forums' onSelect={() => { void router.push('https://community.openbeta.io/') }} />
             <DropdownItem text='Documentation' onSelect={() => { void router.push('https://docs.openbeta.io') }} />
             <DropdownItem text='Blog' onSelect={() => { void router.push('https://openbeta.io/blog') }} />
 

--- a/src/components/MobileAppBar.tsx
+++ b/src/components/MobileAppBar.tsx
@@ -85,6 +85,7 @@ export const More = (): JSX.Element => {
           <a className='btn btn-ghost no-animation btn-block' href='/partner-with-us'>Become a Partner</a>
           <hr />
           <a className='btn btn-ghost no-animation btn-block' href='/about'>About</a>
+          <a className='btn btn-ghost no-animation btn-block' href='https://community.openbeta.io/'>Forums</a>
           <a className='btn btn-ghost no-animation btn-block' href='https://docs.openbeta.io'>Documentation</a>
           <a className='btn btn-ghost no-animation btn-block' href='https://openbeta.io/blog'>Blog</a>
           <hr />


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: 'Add link to forums to navigation elements'
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [x] other

## Description

Added a link to the forums to navigation elements:
- Footer
- Unauthenticated desktop header
- "Profile" dropdown element

### Related Issues

Issue # N/A


### What this PR achieves

<!---Briefly explains what this PR does.
-->
The main website will now point users to the forums in a few locations. In the unauthenticated desktop header, **the Discord link has been replaced with a link to the forums**. I believe the forums would be a better place to highlight for users that are looking for community. The Discord invite link is still very accessible via the footer and the "profile" dropdown element, it has just been de-prioritized.

### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->

N/A


### Notes
<!--Anything in particular you want the reviwer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->

I did not build the project to test the changes, primarily because I expect them to be purely cosmetic