### PR TITLE
fix: make fullName/display name an empty string if null

### DIFF
--- a/src/js/hooks/seo/useUserProfileSeo.ts
+++ b/src/js/hooks/seo/useUserProfileSeo.ts
@@ -15,7 +15,7 @@ interface SeoTagsHookProps {
 export const useUserProfileSeo = ({ username = '', fullName = '', imageList = [] }: SeoTagsHookProps): SeoHookType => {
   const author = `/u/${username}`
   const count = imageList?.length ?? 0
-  const photoCountStr = `${count === 0 ? '' : count} Photo${count > 1 ? 's' : ''}`
+  const photoCountStr = `${count} Photo${count !== 1 ? 's' : ''}`
   const pageTitle = `${fullName ?? ''} (${author}) •  ${photoCountStr} on OpenBeta`
   const pageImages = count > 0 ? getRandomPreviewImages(imageList) : []
   return { author, pageTitle, pageImages }

--- a/src/js/hooks/seo/useUserProfileSeo.ts
+++ b/src/js/hooks/seo/useUserProfileSeo.ts
@@ -16,7 +16,7 @@ export const useUserProfileSeo = ({ username = '', fullName = '', imageList = []
   const author = `/u/${username}`
   const count = imageList?.length ?? 0
   const photoCountStr = `${count === 0 ? '' : count} Photo${count > 1 ? 's' : ''}`
-  const pageTitle = `${fullName} (${author}) •  ${photoCountStr} on OpenBeta`
+  const pageTitle = `${fullName ?? ''} (${author}) •  ${photoCountStr} on OpenBeta`
   const pageImages = count > 0 ? getRandomPreviewImages(imageList) : []
   return { author, pageTitle, pageImages }
 }


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

If a user created an account, set a username but not a display name, the display name (fullName) would be `null`. To prevent this, we can use a nullish coalesce operator to check for null and convert to an empty string. 

NOTE: this did not happen if the user set a display name and then deleted it. In that case, the display name would already be an empty string, not reverted back to null. 

### Related Issues

Issue #1160


### What this PR achieves

<!---Briefly explains what this PR does.
-->
Prevent the user from seeing `null` in the tab title. Instead of null, it will become an empty string. 


### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->
(staging env without change)
![image](https://github.com/user-attachments/assets/947a7fc6-de76-44a2-8fb5-3462968508dd)

(local env with change) 
![image](https://github.com/user-attachments/assets/19a61968-1eaf-48f0-9cf6-37df62218e77)




### Notes
<!--Anything in particular you want the reviwer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




