### PR TITLE
add hero alert for "Find Climbings by State "  at home page 

### DIFF
--- a/src/app/(default)/components/LandingHero.tsx
+++ b/src/app/(default)/components/LandingHero.tsx
@@ -8,15 +8,26 @@ export const LandingHero: React.FC = () => {
       <div className='font-medium text-neutral/80'>
         Join us to help improve this comprehensive climbing resource for the community.
       </div>
-      <div className='mt-2'>
-        <HeroAlert />
+      <div className='mt-2 flex gap-6'>
+        <HeroAlert link="/maps" text="Clmbing Areas By State" badge='Find'/>
+        <HeroAlert link="/maps" text="Crag maps" badge='New'/>
+
       </div>
     </section>
   )
 }
 
-export const HeroAlert: React.FC = () => (
-  <div className='alert alert-warning'>
-    <span className='badge badge-sm badge-primary'>NEW</span>
-    <Link href='/maps' className='underline flex items-center gap-1 text-sm'>Crag maps<ArrowRight size={20} /></Link>
-  </div>)
+interface HeroAlertProps {
+  link: string;
+  text: string;
+  badge: string;
+}
+
+export const HeroAlert: React.FC<HeroAlertProps> = ({ link, text,badge }) => (
+  <div className='alert alert-warning w-[50%]'>
+    <span className='badge badge-sm badge-primary'>{ badge}</span>
+    <Link href={link} className='underline flex items-center gap-1 text-sm'>
+      {text} <ArrowRight size={20} />
+    </Link>
+  </div>
+)


### PR DESCRIPTION
Fix  #1177
## What type of PR is this? (check all applicable)
- [x] feature

## Description
This PR adds a **hero alert** component to the homepage. The alert is meant to draw user attention to important updates or messages.



### What this PR achieves
- Adds a new hero alert component to the homepage.


### Screenshots, recordings
![image](https://github.com/user-attachments/assets/e04d52b8-2e7d-4c12-bd34-320bb86e9a5a)


### Notes
The hero alert is designed to be dismissible and positioned at the top of the homepage. Feedback on the design or positioning would be appreciated.

