### PR TITLE
Fix tag delete x-icon visibility in Safari

### DIFF
--- a/src/components/media/Tag.tsx
+++ b/src/components/media/Tag.tsx
@@ -46,7 +46,7 @@ export default function Tag ({ mediaId, tag, onDelete, size = 'md', showDelete =
             }}
             title='Delete tag'
           >
-            <div className='rounded-full -mr-2.5'>
+            <div className='rounded-full relative -mr-2.5'>
               <XCircleIcon className={clx('cursor-pointer stroke-1 hover:stroke-2', size === 'lg' ? 'w-6 h-6' : 'w-5 h-5')} />
             </div>
           </button>}


### PR DESCRIPTION
Related to #699

Fix the visibility of the X-icon in Safari when viewing tags on a photo in the profile section.

* Change the class in `src/components/media/Tag.tsx` from `rounded-full -mr-2.5` to `rounded-full relative -mr-2.5`
* Ensure the X-icon is fully visible in Safari

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OpenBeta/open-tacos/issues/699?shareId=e20c6602-b3b2-408c-9cd4-bd6cfada863f).