### PR TITLE
Fix gallery close button being hidden behind the title

### DIFF
--- a/src/components/ui/MobileDialog.tsx
+++ b/src/components/ui/MobileDialog.tsx
@@ -23,14 +23,14 @@ export const DialogContent = React.forwardRef<any, Props>(
           className={clx(fullScreen ? 'dialog-wide' : 'dialog-default')} {...props} ref={forwardedRef}
         >
           <div className='flex items-center px-2'>
+            <DialogPrimitive.Title className='dialog-title'>
+              {title}
+            </DialogPrimitive.Title>
             <DialogPrimitive.Close aria-label='Close' asChild className='dialog-close-button'>
               <button className='btn btn-circle btn-ghost outline-none'>
                 <XMarkIcon size={24} />
               </button>
             </DialogPrimitive.Close>
-            <DialogPrimitive.Title className='dialog-title'>
-              {title}
-            </DialogPrimitive.Title>
           </div>
           {children}
         </DialogPrimitive.Content>


### PR DESCRIPTION
Current behaviour on openbeta.io:

![image](https://github.com/user-attachments/assets/1591569a-487e-470f-b254-495cc5b5fd99)

The close button is visible, and not clickable.

Noting that alternating the order of elements resolves the overlap issue.

Seems related (regression?) from fdb64aa049e37ee0128942d0e21ca3982e1d28ac which ironically was trying to fix the same thing.

## Reproduction Steps

1. Browse to a climb (e.g. [_Super Solenoid_](https://openbeta.io/climbs/2a25916c-152e-46d2-8b50-9fc909be17ec)), click on the uploaded image.
2. Note that the close button is hidden behind the header.

## Devices, etc.

* Fedora Linux, Firefox and Chromium — Reproduces
* Android, Firefox and Chrome — reproduces