### PR TITLE
Add the header for naviage to map

### DIFF
--- a/src/app/(default)/components/LandingHero.tsx
+++ b/src/app/(default)/components/LandingHero.tsx
@@ -17,15 +17,15 @@ export const LandingHero: React.FC = () => {
 }
 
 interface HeroAlertProps {
-  link: string
-  text: string
-  badge: string
+  link?: string
+  text?: string
+  badge?: string
 }
 
 export const HeroAlert: React.FC<HeroAlertProps> = ({ link, text, badge }) => (
   <div className='alert alert-warning w-[50%]'>
     <span className='badge badge-sm badge-primary'>{badge}</span>
-    <Link href={link} className='underline flex items-center gap-1 text-sm'>
+    <Link href={link ?? '#'} className='underline flex items-center gap-1 text-sm'>
       {text} <ArrowRight size={20} />
     </Link>
   </div>

--- a/src/app/(default)/components/LandingHero.tsx
+++ b/src/app/(default)/components/LandingHero.tsx
@@ -3,20 +3,30 @@ import { ArrowRight } from '@phosphor-icons/react/dist/ssr'
 
 export const LandingHero: React.FC = () => {
   return (
-    <section className='mt-6'>
-      <h1 className='text-2xl tracking-tighter font-bold'>Share your climbing route knowledge!</h1>
-      <div className='font-medium text-neutral/80'>
+    <section className="mt-6">
+      <h1 className="text-2xl tracking-tighter font-bold">Share your climbing route knowledge!</h1>
+      <div className="font-medium text-neutral/80">
         Join us to help improve this comprehensive climbing resource for the community.
       </div>
-      <div className='mt-2'>
-        <HeroAlert />
+      <div className="mt-2 flex gap-6">
+        <HeroAlert link="/maps" text="Climbing Areas By State" badge="Find" />
+        <HeroAlert link="/maps" text="Crag maps" badge="New" />
       </div>
     </section>
   )
 }
 
-export const HeroAlert: React.FC = () => (
-  <div className='alert alert-warning'>
-    <span className='badge badge-sm badge-primary'>NEW</span>
-    <Link href='/maps' className='underline flex items-center gap-1 text-sm'>Crag maps<ArrowRight size={20} /></Link>
-  </div>)
+interface HeroAlertProps {
+  link: string
+  text: string
+  badge: string
+}
+
+export const HeroAlert: React.FC<HeroAlertProps> = ({ link, text, badge }) => (
+  <div className="alert alert-warning w-[50%]">
+    <span className="badge badge-sm badge-primary">{badge}</span>
+    <Link href={link} className="underline flex items-center gap-1 text-sm">
+      {text} <ArrowRight size={20} />
+    </Link>
+  </div>
+)

--- a/src/app/(default)/components/LandingHero.tsx
+++ b/src/app/(default)/components/LandingHero.tsx
@@ -3,14 +3,14 @@ import { ArrowRight } from '@phosphor-icons/react/dist/ssr'
 
 export const LandingHero: React.FC = () => {
   return (
-    <section className="mt-6">
-      <h1 className="text-2xl tracking-tighter font-bold">Share your climbing route knowledge!</h1>
-      <div className="font-medium text-neutral/80">
+    <section className='mt-6'>
+      <h1 className='text-2xl tracking-tighter font-bold'>Share your climbing route knowledge!</h1>
+      <div className='font-medium text-neutral/80'>
         Join us to help improve this comprehensive climbing resource for the community.
       </div>
-      <div className="mt-2 flex gap-6">
-        <HeroAlert link="/maps" text="Climbing Areas By State" badge="Find" />
-        <HeroAlert link="/maps" text="Crag maps" badge="New" />
+      <div className='mt-2 flex gap-6'>
+        <HeroAlert link='/maps' text='Climbing Areas By State' badge='Find' />
+        <HeroAlert link='/maps' text='Crag maps' badge='New' />
       </div>
     </section>
   )
@@ -23,9 +23,9 @@ interface HeroAlertProps {
 }
 
 export const HeroAlert: React.FC<HeroAlertProps> = ({ link, text, badge }) => (
-  <div className="alert alert-warning w-[50%]">
-    <span className="badge badge-sm badge-primary">{badge}</span>
-    <Link href={link} className="underline flex items-center gap-1 text-sm">
+  <div className='alert alert-warning w-[50%]'>
+    <span className='badge badge-sm badge-primary'>{badge}</span>
+    <Link href={link} className='underline flex items-center gap-1 text-sm'>
       {text} <ArrowRight size={20} />
     </Link>
   </div>


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title:  add hero alert for "Find Climbings by State " at home page
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ x] optimization


## Description
Add the header for naviage to map

### Related Issues

Issue # #1177


### What this PR achieves

<!---Briefly explains what this PR does.
-->

Add a button to navigate the page to search the locations by state



### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->
![image](https://github.com/user-attachments/assets/e9053e77-8d4a-443c-8f89-1301a53257d8)






