### PR TITLE
fix: #1130, use gradesObj in TickButton instead of deprecated `yds` property

### DIFF
--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -440,7 +440,7 @@ const ClimbData: React.FC<{
 
         {!editMode && (
           <div className='mt-8'>
-            <TickButton climbId={climbId} name={name} grade={yds} />
+            <TickButton climbId={climbId} name={name} grade={gradesObj.toStringTradSportAid()} />
           </div>
         )}
       </div>

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -440,7 +440,7 @@ const ClimbData: React.FC<{
 
         {!editMode && (
           <div className='mt-8'>
-            <TickButton climbId={climbId} name={name} grade={gradesObj.toStringTradSportAid()} />
+            <TickButton climbId={climbId} name={name} grade={gradesObj.toString()} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Observed in Production

* Certain climbs are un-tickable. Attempting to tick them causes the TickForm to display the following error (image courtesy of @emilyg1709):
    * ![](https://private-user-images.githubusercontent.com/169106792/348886564-0839d8e6-0fa6-4768-9c55-7fc3ea6dfe3b.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzAzOTcyMjYsIm5iZiI6MTczMDM5NjkyNiwicGF0aCI6Ii8xNjkxMDY3OTIvMzQ4ODg2NTY0LTA4MzlkOGU2LTBmYTYtNDc2OC05YzU1LTdmYzNlYTZkZmUzYi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQxMDMxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MTAzMVQxNzQ4NDZaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01Nzg1NTNkMzc4M2EzYzU3NTQxMmI1OTQxMmRkMzgyNWM5NTY5ZjliOTQyZGE2YTI1OTY0NDQ3Mjk4YjBmNjI3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.Gwa4rkr0OJqYxVQ45_WIt1sLPEfXlzvuLqryl6Q-c2c)
* It was also observed that some climbs are tickable, namely older ones in the United States.

## Reproduction in staging

* I was unable to find a suitable climb in staging that reproduced the issue, until @musoke suggested I create my own climb. Sure enough, the issue reproduced, which suggests that this occurs with newer climbs.

## The fix

* @daneashman commented in #1130 that a data issue may be the culprit. Affected climbs do not have a `yds` property, while unaffected climbs do.
* TypeScript hinting in code stated that `yds` is deprecated
* The `TickForm` component is dynamically built when the `TickButton` component is clicked.
* The `TickButton` component is rendered in the ClimbData page, and passes in `grade={yds}`, which is `null` on newer climbs
* I noticed that places where the grade was shown now used the `Grade` object(?) which had a `.toString()` method that worked on both Sport/Trad climbs and boulders. I updated the TickButton component to pass in `gradesObj.toString()` instead of `yds`
* Ticking the affected climb on staging now worked.