### PR TITLE
fix: og:image tags for /area/ and /climbs/

### DIFF
--- a/src/app/(default)/area/[[...slug]]/page.tsx
+++ b/src/app/(default)/area/[[...slug]]/page.tsx
@@ -199,7 +199,7 @@ export async function generateMetadata ({ params }: PageWithCatchAllUuidProps): 
 
   const name = sanitizeName(areaName)
 
-  const previewImage = media.length > 0 ? `${CLIENT_CONFIG.CDN_BASE_URL}/${media[0].mediaUrl}?w=1200q=75` : null
+  const previewImage = media.length > 0 ? `${CLIENT_CONFIG.CDN_BASE_URL}${media[0].mediaUrl}?w=1200&q=75` : null
 
   const description = `Community knowledge • ${wall}${name}`
 

--- a/src/js/hooks/seo/useClimbSeo.ts
+++ b/src/js/hooks/seo/useClimbSeo.ts
@@ -48,5 +48,5 @@ export const useClimbSeo = ({ climb }: ClimbSeoProps): SeoHookType => {
  */
 const getRandomPreviewImages = (list: MediaWithTags[]): string[] => {
   const shortList = shuffle(list.slice(0, 10)) // shuffle the first 10
-  return shortList.slice(0, 4).map(image => (`${CLIENT_CONFIG.CDN_BASE_URL}/${image.mediaUrl}?w=1200&ch=630&cy=center&format=jpg&q=85`))
+  return shortList.slice(0, 4).map(image => (`${CLIENT_CONFIG.CDN_BASE_URL}${image.mediaUrl}?w=1200&ch=630&cy=center&format=jpg&q=85`))
 }


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

- og:image tags for areas do not work (invalid URL)
- ~og:image tags for climbs do not work (shows default south africa image)~
    - Same issue as below, router is called twice, but `og:image` is not properly retrieved the first time due to null uid
- ~og:image tags for profiles do not work (arguments are double escaped)~
    - Upstream issue: https://github.com/facebook/react/issues/13838
    - Passing in restricted characters like `&` cause them to be escaped. There are workarounds but none that look simple (or maintainable) enough to implement.
    - When a user profile is loaded, `useUserProfileSeo` is called to load the photos for `og:image`
    - This is called by the react router, but the router is called **twice**. Once with a `null` uid (causing the `og:image` tag to be the default image), and a second time in-client causing the tags to be properly set in DOM. However, that is too late for link-preview services, because they don't parse js.


### What this PR achieves

<!---Briefly explains what this PR does.
-->
Fixed the above issues.

### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->




### Notes
<!--Anything in particular you want the reviwer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->

Query parameters are being escaped but I can't work around them. e.g. `?w=600&q=75` has the `&` replaced with `&amp;` which isn't read correctly by the image server. (full quality image is sent)


