### PR TITLE
Add Android asset links

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,20 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "openbeta.io.debug",
+      "sha256_cert_fingerprints":
+        ["F4:32:1C:12:02:48:08:7D:02:96:33:5B:93:58:77:EE:0D:EC:A0:46:E4:84:42:3D:27:21:EE:E6:F2:14:CF:DF"]
+    }
+  },
+   {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "openbeta.io",
+      "sha256_cert_fingerprints":
+        ["8E:38:28:3A:23:35:D3:08:57:4F:D2:33:42:33:A4:87:2D:16:6F:E0:DF:16:85:5A:7D:D6:E5:8D:DE:12:5B:D3"]
+    }
+  }
+]


### PR DESCRIPTION
## What type of PR is this?
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [x] other

### What this PR achieves
This adds asset links that allow openbeta.io to trust the mobile application as a verified source for opening openbeta.io links. This will allow us to deeplink into the app at a specified page. For example, clicking the link https://openbeta.io/area/8ab53875-745f-5076-b396-d3d84945e52c/yosemite-national-park would open up the mobile app if you have it installed rather than opening the webpage. This is essential for allowing users to share climbs and areas with each other




