### PR TITLE
fix: use `100vw` for `sizes` attribute in ResponsiveImage handler

### DIFF
--- a/src/components/media/PhotoGalleryModal.tsx
+++ b/src/components/media/PhotoGalleryModal.tsx
@@ -58,7 +58,7 @@ const PhotoGalleryModal = ({
                   </button>
                 </div>
                 <div className='flex items-center justify-center h-full'>
-                  <ResponsiveImage mediaUrl={ShowImage} isHero={false} />
+                  <ResponsiveImage mediaUrl={ShowImage} isHero={false} sizes='100vw' />
                 </div>
               </div>
             </div>

--- a/src/components/media/slideshow/ResponsiveImage.tsx
+++ b/src/components/media/slideshow/ResponsiveImage.tsx
@@ -13,7 +13,7 @@ interface ResponsiveImageProps {
 /**
  * NextJS image wrapper with loading indicator
  */
-export default function ResponsiveImage ({ mediaUrl, isHero = true, isSquare = false, sizes = '20vw' }: ResponsiveImageProps): JSX.Element {
+export default function ResponsiveImage ({ mediaUrl, isHero = true, isSquare = false, sizes = '100vw' }: ResponsiveImageProps): JSX.Element {
   const [isLoading, setLoading] = useState<boolean>(true)
   useEffect(() => {
     setLoading(true)

--- a/src/components/media/slideshow/ResponsiveImage.tsx
+++ b/src/components/media/slideshow/ResponsiveImage.tsx
@@ -13,7 +13,7 @@ interface ResponsiveImageProps {
 /**
  * NextJS image wrapper with loading indicator
  */
-export default function ResponsiveImage ({ mediaUrl, isHero = true, isSquare = false, sizes = '100vw' }: ResponsiveImageProps): JSX.Element {
+export default function ResponsiveImage ({ mediaUrl, isHero = true, isSquare = false, sizes = '20vw' }: ResponsiveImageProps): JSX.Element {
   const [isLoading, setLoading] = useState<boolean>(true)
   useEffect(() => {
     setLoading(true)


### PR DESCRIPTION
During an area editing refactor (48acddda6c84803566a54e935e7ac35251d0c21c), a change was made that altered the `sizes` attribute from `100vw` to `20vw`.

This causes issues with images in the climb gallery; the browser chooses the wrong size.

e.g. given the `srcset` as follows:

```
srcset="https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=128&q=75 128w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=256&q=75 256w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=384&q=75 384w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=640&q=75 640w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=750&q=75 750w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=828&q=75 828w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=1080&q=75 1080w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=1200&q=75 1200w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=1920&q=75 1920w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=2048&q=75 2048w,
 https://media.openbeta.io/u/27339796-f8b5-48ed-b1bf-856dbd5289a2/7pmtjHGW76.png?w=3840&q=75 3840w"
```

... and a resolution of 1080x2340 (Google Pixel 5), if `sizes` is `20vw`, then the browser will choose the image just larger than 218px, which is the 384px image. The 1200px image should be the correct selection.

This pull request restores the `sizes` attribute to `100vw` so the `srcset` calculation and selection is correct.