### PR TITLE
fix: prod tenant requires explicit realm

### DIFF
--- a/.env
+++ b/.env
@@ -11,6 +11,7 @@ NEXTAUTH_SECRET=vQyFR7gskaqxehN0cI/53r+duWc5Et0ktdoz6KozTCo=
 # Auth0 Management API
 AUTH0_MGMT_CLIENT_ID=Ecyj4oke3Cpk1khRsdKr8njen6ZZKePF
 AUTH0_MGMT_CLIENT_SECRET=send request to hello at openbeta.io
+AUTH0_MGMT_CLIENT_AUDIENCE=https://dev-fmjy7n5n.us.auth0.com/api/v2/
 
 ######### Client-side vars ############
 # Must prefix with NEXT_PUBLIC_in order to expose vars to the browser

--- a/src/app/api/mobile/login/route.ts
+++ b/src/app/api/mobile/login/route.ts
@@ -27,7 +27,8 @@ async function postHandler (request: NextRequest): Promise<NextResponse> {
       username,
       password,
       scope: 'openid profile email offline_access',
-      audience: 'https://api.openbeta.io'
+      audience: 'https://api.openbeta.io',
+      realm: 'Username-Password-Authentication'
     })
 
     return NextResponse.json({ data: response.data })


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue https://github.com/OpenBeta/open-tacos/pull/1207


### What this PR achieves
Auth0 test tenant seems to set username/password connection as the default.  The prod tenant doesn't have the default.