### PR TITLE
refactor: run import ticks on Next server

### DIFF
--- a/src/js/auth/withUserAuth.ts
+++ b/src/js/auth/withUserAuth.ts
@@ -1,0 +1,23 @@
+import { getServerSession } from 'next-auth'
+import { NextRequest, NextResponse } from 'next/server'
+import { authOptions } from 'pages/api/auth/[...nextauth]'
+
+type Next13APIHandler = (req: NextRequest) => Promise<any>
+
+/*
+* A high-order function to protect Next 13 (and later) API route
+* by checking that the user has a valid session.
+*/
+export const withUserAuth = (handler: Next13APIHandler): Next13APIHandler => {
+  return async (req: NextRequest) => {
+    const session = await getServerSession({ req, ...authOptions })
+    if (session != null) {
+      // Passing useful session data downstream
+      req.headers.set('x-openbeta-user-uuid', session.user.metadata.uuid)
+      req.headers.set('x-auth0-userid', session.id)
+      return await handler(req)
+    } else {
+      return NextResponse.json({ status: 401 })
+    }
+  }
+}


### PR DESCRIPTION

## What type of PR is this?(check all applicable)
- [x] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #590 


### What this PR achieves
- [x] Push ticks directly on Next API route (server-side) instead of doing it from the browser
- [x] Introduce High-order route protector function 
- [x] Disable form elements while uploading


### Notes
This is a temporary fix.  Ideally, we should process ticks on the API server.  Test imported ~ 3K ticks without any problem.

---

<img width="1277" alt="Screenshot 2024-11-12 at 12 03 47 PM" src="https://github.com/user-attachments/assets/77762083-3e69-4b79-bf3f-7ae77679d61c">

