### PR TITLE
fix: api routes should be able to return non-200 status

### DIFF
--- a/src/app/api/mobile/refreshToken/route.ts
+++ b/src/app/api/mobile/refreshToken/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import * as Auth0 from 'auth0'
 import { auth0Client, isNullOrEmpty } from '@/js/auth/mobile'
 import { withMobileAuth } from '@/js/auth/withMobileAuth'
+import { errorHandler } from '../login/route'
 
 /**
  * Mobile refresh token handler
@@ -27,10 +28,9 @@ async function postHandler (request: NextRequest): Promise<any> {
       audience: 'https://api.openbeta.io'
     })
 
-    return NextResponse.json({ data: response.data })
+    return NextResponse.json({ ...response.data }, { status: response.status })
   } catch (error) {
-    console.error('#### Auth0 error ####', error)
-    return NextResponse.json({ error: 'Unexpected auth error', status: 403 })
+    return errorHandler(error)
   }
 }
 

--- a/src/js/auth/withMobileAuth.ts
+++ b/src/js/auth/withMobileAuth.ts
@@ -11,12 +11,12 @@ type Next13ApiHandler = (req: NextRequest) => Promise<NextResponse>
 export const withMobileAuth = (handler: Next13ApiHandler): Next13ApiHandler => {
   return async function (request: NextRequest) {
     if (request.method !== 'POST') {
-      return NextResponse.json({ message: 'Must send POST request', status: 405 })
+      return NextResponse.json({ message: 'Must send POST request' }, { status: 405 })
     }
     const authHeader = request.headers.get('Secret')
     if (mobileAuthSecret != null && authHeader === mobileAuthSecret) {
       return await handler(request)
     }
-    return NextResponse.json({ message: 'Unauthorized', status: 401 })
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
   }
 }


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### What this PR achieves
Mobile auth handlers should return non-200 when there's an error.  Status code should be passed to `NextResponse()` as a 2nd param.


