### PR TITLE
fix: removed extra '/ ' from base URL

### DIFF
--- a/src/app/(default)/components/SharePageURLButton.tsx
+++ b/src/app/(default)/components/SharePageURLButton.tsx
@@ -10,7 +10,7 @@ import { ControlledTooltip } from '@/components/ui/Tooltip'
  */
 export const SharePageURLButton: React.FC<{ path: string, name: string }> = ({ path, name }) => {
   const slug = getFriendlySlug(name)
-  const url = `https://openbeta.io/${path}/${slug}`
+  const url = `https://openbeta.io${path}/${slug}`
 
   const [clicked, setClicked] = useState(false)
 


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
Previously the base URL had a '/' at the end of the base URL for the 'copy link' feature for climbs and areas. This gave an extra '/' in the complete URL. 


### Related Issues
Issue #1230 


### What this PR achieves
I removed the extra '/' from the base URL string, which caused the issue. 

### Screenshots, recordings

### Notes