### PR TITLE
fix: quick links to countries are slow

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react": "^18.2.0",
     "react-content-loader": "^6.2.0",
     "react-dom": "^18.2.0",
-    "react-dropzone": "^14.2.1",
+    "react-dropzone": "^14.3.5",
     "react-hook-form": "^7.34.2",
     "react-hotkeys-hook": "^3.4.7",
     "react-infinite-scroll-component": "^6.1.0",

--- a/src/app/(default)/area/[[...slug]]/page.tsx
+++ b/src/app/(default)/area/[[...slug]]/page.tsx
@@ -23,7 +23,6 @@ import { PageWithCatchAllUuidProps, PageSlugType } from '@/js/types/pages'
  * Page cache settings
  */
 export const revalidate = 3600 // 1 hr
-export const fetchCache = 'force-no-store' // opt out of Nextjs version of 'fetch'
 
 /**
  * Area/crag page

--- a/src/app/(default)/area/[[...slug]]/page.tsx
+++ b/src/app/(default)/area/[[...slug]]/page.tsx
@@ -22,7 +22,7 @@ import { PageWithCatchAllUuidProps, PageSlugType } from '@/js/types/pages'
 /**
  * Page cache settings
  */
-export const revalidate = 300 // 5 mins
+export const revalidate = 3600 // 1 hr
 export const fetchCache = 'force-no-store' // opt out of Nextjs version of 'fetch'
 
 /**

--- a/src/app/(default)/components/DesktopHeader.tsx
+++ b/src/app/(default)/components/DesktopHeader.tsx
@@ -115,6 +115,7 @@ const QuickLinks: React.FC = () => {
         <Link
           key={href}
           href={href}
+          prefetch={false}
           className='text-xs font-semibold text-primary/80 flex items-center whitespace-nowrap hover:underline hover:decoration-1 gap-1.5'
         >
           {icon}{label}

--- a/src/app/(default)/components/InternationalToC.tsx
+++ b/src/app/(default)/components/InternationalToC.tsx
@@ -25,7 +25,7 @@ const CountryCard: React.FC<{ country: ToCCountry }> = ({ country }) => {
   const { areaName, uuid, children } = country
   return (
     <div className='mb-10 break-inside-avoid-column'>
-      <Link href={getAreaPageFriendlyUrl(uuid, areaName)}>
+      <Link prefetch={false} href={getAreaPageFriendlyUrl(uuid, areaName)}>
         <span className=' font-semibold'>{areaName}</span>
       </Link>
       <hr className='mb-2 border-1 border-base-content/60' />

--- a/src/app/(default)/components/USAToC.tsx
+++ b/src/app/(default)/components/USAToC.tsx
@@ -11,7 +11,7 @@ export const USAToC: React.FC = async () => {
   return (
     <SectionContainer
       header={
-        <Link href={getAreaPageFriendlyUrl('1db1e8ba-a40e-587c-88a4-64f5ea814b8e', 'usa')} className='flex flex-row items-center gap-2'>
+        <Link prefetch={false} href={getAreaPageFriendlyUrl('1db1e8ba-a40e-587c-88a4-64f5ea814b8e', 'usa')} className='flex flex-row items-center gap-2'>
           <h2>USA</h2><ArrowRightCircleIcon className='w-4 h-4' />
         </Link>
       }
@@ -21,7 +21,7 @@ export const USAToC: React.FC = async () => {
           const { name, uuid, totalClimbs, areas } = state
           return (
             <div key={name} className='mb-10 break-inside-avoid-column break-inside-avoid'>
-              <Link href={getAreaPageFriendlyUrl(uuid, name)} className='flex items-end justify-between'>
+              <Link prefetch={false} href={getAreaPageFriendlyUrl(uuid, name)} className='flex items-end justify-between'>
                 <span className=' font-semibold'>{name}</span>
                 <span className='text-xs text-base-content/80'>
                   {new Intl.NumberFormat().format(totalClimbs)}

--- a/src/components/media/Tag.tsx
+++ b/src/components/media/Tag.tsx
@@ -6,7 +6,7 @@ import clx from 'classnames'
 import { EntityTag, TagTargetType } from '../../js/types'
 import { OnDeleteCallback } from './TagList'
 import { MouseEventHandler } from 'react'
-import { getAreaPageFriendlyUrl } from '@/js/utils'
+import { getAreaPageFriendlyUrl, getClimbPageFriendlyUrl } from '@/js/utils'
 
 interface PhotoTagProps {
   mediaId: string
@@ -68,7 +68,7 @@ export const resolver = (props: EntityTag): [string, string] | [null, null] => {
   const { targetId: id, climbName, areaName, type } = props
   switch (type) {
     case TagTargetType.climb: {
-      return [`/climb/${id}`, climbName ?? '']
+      return [getClimbPageFriendlyUrl(id, climbName ?? ''), climbName ?? '']
     }
     case TagTargetType.area: {
       return [getAreaPageFriendlyUrl(id, areaName), areaName]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3217,10 +3217,10 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-attr-accept@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz"
-  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+attr-accept@^2.2.4:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.5.tgz#d7061d958e6d4f97bf8665c68b75851a0713ab5e"
+  integrity sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==
 
 auth0@^4.12.0:
   version "4.12.0"
@@ -4754,12 +4754,12 @@ file-saver@^2.0.5:
   resolved "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz"
   integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
-file-selector@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz"
-  integrity sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==
+file-selector@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-2.1.2.tgz#fe7c7ee9e550952dfbc863d73b14dc740d7de8b4"
+  integrity sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==
   dependencies:
-    tslib "^2.4.0"
+    tslib "^2.7.0"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -7468,13 +7468,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-dropzone@^14.2.1:
-  version "14.2.3"
-  resolved "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz"
-  integrity sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==
+react-dropzone@^14.3.5:
+  version "14.3.5"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.3.5.tgz#1a8bd312c8a353ec78ef402842ccb3589c225add"
+  integrity sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==
   dependencies:
-    attr-accept "^2.2.2"
-    file-selector "^0.6.0"
+    attr-accept "^2.2.4"
+    file-selector "^2.1.0"
     prop-types "^15.8.1"
 
 react-error-boundary@^3.1.4:
@@ -8677,6 +8677,11 @@ tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description

### What this PR achieves
- [x] upgrade react-dropzone which has been the source of a calling `.every()` on an undefined reference which crashes server-side rendering code causing area page not to cache
- [x] disable prefetching 


