### PR TITLE
fix: use Lead Style from MP tick import instead of Style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,5 +80,8 @@ content
 *.pem
 .vscode/launch.json
 
+# for anyone using asdf
+.tool-versions
+
 .lighthouseci
 .idea/


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: 'correctly import attemptStyle from MP tick import'
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [X] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
When importing ticks from Mountain Project, the `attemptStyle` field was being populated with the `Style` field from MP. It should use the `Lead Style` field instead.

### Related Issues

Issue #
The issue was created in openbeta-graphql, but the code is in open-tacos.

https://github.com/OpenBeta/openbeta-graphql/issues/424

### What this PR achieves
When converting a MPTick to a Tick object, set `attemptStyle` on Tick to be the value from `Lead Style` on MPTick (if present).



### Notes
I don't see an obvious way to write tests for this. everything in __tests__/ticks.ts mocks out Tick objects after the conversion from MPTick has already happened, so a new test would probably have to be more of an end-to-end tests.

Below  screenshot shows imported ticks locally, and the attemptType fields being populated with correct values.
![Screenshot 2025-01-23 at 3 44 06 PM](https://github.com/user-attachments/assets/f37b1225-5730-4253-91cb-756d24bff2d0)

