### PR TITLE
feat: Restrict attemptType based on style selected for ticks

### DIFF
--- a/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
+++ b/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
@@ -1,5 +1,4 @@
 'use client'
-// import React, { useState } from 'react'
 import { ArrowsVertical } from '@phosphor-icons/react/dist/ssr'
 
 import TickButton from '@/components/users/TickButton'
@@ -12,7 +11,6 @@ import { removeTypenameFromDisciplines } from '@/js/utils'
 
 export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { isBoulder: boolean }> = (props) => {
   const { id, name, type, safety, length, grades, fa: legacyFA, authorMetadata, gradeContext, isBoulder } = props
-  // const [editMode, _setEditMode] = useState(false)
   const sanitizedDisciplines = removeTypenameFromDisciplines(type)
 
   const gradeStr = new Grade(
@@ -52,9 +50,9 @@ export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { 
           </div>
         )}
 
-        {/* TODO: Hike the TickButton in editMode */}
+        {/* TODO: Hide the TickButton in editMode */}
         <div className='mt-8'>
-          <TickButton climbId={id} name={name} grade={gradeStr} />
+          <TickButton climbId={id} name={name} grade={gradeStr} climbType={sanitizedDisciplines} />
         </div>
       </div>
     </>

--- a/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
+++ b/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
@@ -1,4 +1,3 @@
-'use client'
 import { ArrowsVertical } from '@phosphor-icons/react/dist/ssr'
 
 import TickButton from '@/components/users/TickButton'

--- a/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
+++ b/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
@@ -1,5 +1,8 @@
+'use client'
+// import React, { useState } from 'react'
 import { ArrowsVertical } from '@phosphor-icons/react/dist/ssr'
 
+import TickButton from '@/components/users/TickButton'
 import RouteGradeChip from '@/components/ui/RouteGradeChip'
 import RouteTypeChips from '@/components/ui/RouteTypeChips'
 import { ArticleLastUpdate } from '@/components/edit/ArticleLastUpdate'
@@ -8,8 +11,8 @@ import Grade from '@/js/grades/Grade'
 import { removeTypenameFromDisciplines } from '@/js/utils'
 
 export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { isBoulder: boolean }> = (props) => {
-  const { name, type, safety, length, grades, fa: legacyFA, authorMetadata, gradeContext, isBoulder } = props
-
+  const { id, name, type, safety, length, grades, fa: legacyFA, authorMetadata, gradeContext, isBoulder } = props
+  // const [editMode, _setEditMode] = useState(false)
   const sanitizedDisciplines = removeTypenameFromDisciplines(type)
 
   const gradeStr = new Grade(
@@ -49,11 +52,10 @@ export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { 
           </div>
         )}
 
-        {/* {!editMode && (
-          <div className='mt-8'>
-            <TickButton climbId={climbId} name={name} grade={yds} />
-          </div>
-        )} */}
+        {/* TODO: Hike the TickButton in editMode */}
+        <div className='mt-8'>
+          <TickButton climbId={id} name={name} grade={gradeStr} />
+        </div>
       </div>
     </>
   )

--- a/src/app/(default)/editArea/[slug]/manageClimbs/components/DisciplinesSelection.tsx
+++ b/src/app/(default)/editArea/[slug]/manageClimbs/components/DisciplinesSelection.tsx
@@ -71,6 +71,7 @@ export const DisciplinesSelection: React.FC<FieldArrayInputProps> = ({ formConte
             <Checkbox label='Mixed' index={index} discipline='mixed' formContext={formContext} />
             <Checkbox label='Ice' index={index} discipline='ice' formContext={formContext} />
             <Checkbox label='Snow' index={index} discipline='snow' formContext={formContext} />
+            <Checkbox label='Alpine' index={index} discipline='alpine' formContext={formContext} />
           </div>
 
           <div className='self-end'>

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,30 +1,22 @@
 import * as Popover from '@radix-ui/react-popover'
-import { ReactNode, useState } from 'react'
+import { ReactNode } from 'react'
 
 interface Props {
   content: string | ReactNode
   enabled?: boolean
   children: JSX.Element | JSX.Element [] | null
   className?: string
-  trigger?: 'click' | 'hover'
 }
 
 /**
  * A Tooltip that activates on mouse click or touch.
  * @param enabled false to disable tooltip but still render the trigger element
  * @param children Trigger element
- * @param trigger 'click' to activate on click, 'hover' to activate on hover. defaults to click
  */
-export default function Tooltip ({ content, enabled = true, className = '', children, trigger = 'click' }: Props): JSX.Element {
-  const [open, setOpen] = useState(false)
-  const handleMouseEnter = (): void => { if (trigger === 'hover') { setOpen(true) } }
-  const handleMouseLeave = (): void => { if (trigger === 'hover') { setOpen(false) } }
-
+export default function Tooltip ({ content, enabled = true, className = '', children }: Props): JSX.Element {
   return (
-    <Popover.Root open={trigger === 'hover' ? open : undefined} onOpenChange={setOpen}>
-      <Popover.Trigger className={className} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-        {children}
-      </Popover.Trigger>
+    <Popover.Root>
+      <Popover.Trigger className={className}>{children}</Popover.Trigger>
       {enabled &&
         <Content>
           {content}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,22 +1,30 @@
 import * as Popover from '@radix-ui/react-popover'
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 
 interface Props {
   content: string | ReactNode
   enabled?: boolean
   children: JSX.Element | JSX.Element [] | null
   className?: string
+  trigger?: 'click' | 'hover'
 }
 
 /**
  * A Tooltip that activates on mouse click or touch.
  * @param enabled false to disable tooltip but still render the trigger element
  * @param children Trigger element
+ * @param trigger 'click' to activate on click, 'hover' to activate on hover. defaults to click
  */
-export default function Tooltip ({ content, enabled = true, className = '', children }: Props): JSX.Element {
+export default function Tooltip ({ content, enabled = true, className = '', children, trigger = 'click' }: Props): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const handleMouseEnter = (): void => { if (trigger === 'hover') { setOpen(true) } }
+  const handleMouseLeave = (): void => { if (trigger === 'hover') { setOpen(false) } }
+
   return (
-    <Popover.Root>
-      <Popover.Trigger className={className}>{children}</Popover.Trigger>
+    <Popover.Root open={trigger === 'hover' ? open : undefined} onOpenChange={setOpen}>
+      <Popover.Trigger className={className} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        {children}
+      </Popover.Trigger>
       {enabled &&
         <Content>
           {content}

--- a/src/components/users/TickButton.tsx
+++ b/src/components/users/TickButton.tsx
@@ -11,6 +11,7 @@ interface Props {
   areaId?: string
   name?: string
   grade?: string
+  climbType: object
 }
 
 const IsTicked: React.FC<any> = ({ loading, onClick }) => {
@@ -25,7 +26,7 @@ const IsTicked: React.FC<any> = ({ loading, onClick }) => {
   )
 }
 
-export default function TickButton ({ climbId, areaId, name, grade }: Props): JSX.Element | null {
+export default function TickButton ({ climbId, areaId, name, grade, climbType }: Props): JSX.Element | null {
   const [loading, setLoading] = useState(false)
   const [isTicked, setIsTicked] = useState<boolean>(false)
   const [viewTicks, setViewTicks] = useState<boolean>(false)
@@ -79,7 +80,7 @@ export default function TickButton ({ climbId, areaId, name, grade }: Props): JS
             : 'Tick this climb'}
         </button>}
       {isTicked && <IsTicked loading={loading} onClick={() => setViewTicks(true)} />}
-      <TickForm open={open} setTicks={setTicks} ticks={ticks} setOpen={setOpen} isTicked={setIsTicked} climbId={climbId} name={name} grade={grade} />
+      <TickForm open={open} setTicks={setTicks} ticks={ticks} setOpen={setOpen} isTicked={setIsTicked} climbId={climbId} name={name} grade={grade} climbType={climbType} />
       <TicksModal open={viewTicks} setOpen={setViewTicks} climbName={name} ticks={ticks} setTicks={setTicks} setOpenForm={setOpen} />
     </>
   )

--- a/src/components/users/TickButton.tsx
+++ b/src/components/users/TickButton.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useSession } from 'next-auth/react'
 import React, { useEffect, useState } from 'react'
 import { getTicksByUserAndClimb } from '../../js/graphql/api'

--- a/src/components/users/TickCard.tsx
+++ b/src/components/users/TickCard.tsx
@@ -11,9 +11,10 @@ interface Props {
   dateClimbed: number
   notes: string
   style: string
+  attemptType: string
 }
 
-export default function TickCard ({ tickId, ticks, setTicks, dateClimbed, notes, style }: Props): JSX.Element {
+export default function TickCard ({ tickId, ticks, setTicks, dateClimbed, notes, style, attemptType }: Props): JSX.Element {
   const [deleteTick] = useMutation(
     MUTATION_REMOVE_TICK_BY_ID, {
       client: graphqlClient,
@@ -37,7 +38,10 @@ export default function TickCard ({ tickId, ticks, setTicks, dateClimbed, notes,
         <p className='text-sm text-gray-500 mb-0'>{notes}</p>
       </div>
       <div className='flex flex-row'>
-        <p className='text-sm text-gray-500 pr-5'>{style}</p>
+        <div className='flex flex-col'>
+          <p className='text-sm text-gray-500 pr-5'>{style}</p>
+          <p className='text-sm text-gray-500 pr-5'>{attemptType}</p>
+        </div>
         <AlertDialogue
           onConfirm={() => { void remove() }}
           hideTitle

--- a/src/components/users/TickForm.tsx
+++ b/src/components/users/TickForm.tsx
@@ -28,17 +28,18 @@ const TickSchema = Yup.object().shape({
   grade: Yup.string()
     .required('Something went wrong fetching the climbs grade, please try again')
 })
+
 /**
  * Options for the dropdown comboboxes
- * Feel free to add any you think are valuable for our users
- */
-const styles = [
+ * The logic here can get quite complicated. There is a hierarchy of "Climb type" -> "Style" -> "Attempt Type"
+ **/
+const allStyles = [
   { id: 1, name: 'Lead' },
-  { id: 2, name: 'TR' },
-  { id: 3, name: 'Follow' },
+  { id: 2, name: 'Follow' },
+  { id: 3, name: 'TR' },
   { id: 4, name: 'Solo' },
   { id: 5, name: 'Boulder' },
-  { id: 6, name: '\u00A0' }
+  { id: 6, name: 'Aid' }
 ]
 
 const allAttemptTypes = [
@@ -51,12 +52,27 @@ const allAttemptTypes = [
   { id: 7, name: 'Frenchfree' }
 ]
 
-// Small info icon with a link to the Wikipedia glossary of climbing terms
-const climbingGlossaryLink = 'https://en.wikipedia.org/wiki/Glossary_of_climbing_terms#'
+function hasKey (climbType: object, myList: string[]): boolean { return Object.keys(climbType).some(key => myList.includes(key)) }
 
-// Dynamically offer relevant options depending on the style chosen. This is fairly open to allow multiple options, with some restrictions based on common climber nomenclature.
-// Note that both style and attemptType can be empty. This code is likley coupled with the db validation logic on the backend, and a future improvement could be to decouple these.
-function attemptTypes ({ styleName }: { styleName: string }): Array<{ id: number, name: string }> {
+function leadable (climbType: object): boolean { return hasKey(climbType, ['trad', 'sport', 'snow', 'ice', 'mixed', 'alpine']) }
+function topropeable (climbType: object): boolean { return hasKey(climbType, ['tr']) || (leadable(climbType)) }
+function aidable (climbType: object): boolean { return hasKey(climbType, ['aid']) }
+function soloable (climbType: object): boolean { return hasKey(climbType, ['deepwatersolo']) || leadable(climbType) || aidable(climbType) || topropeable(climbType) }
+function boulderable (climbType: object): boolean { return hasKey(climbType, ['bouldering']) }
+
+function stylesForClimbType (climbType: object): Array<{ id: number, name: string }> {
+  let styles: Array<{ id: number, name: string }> = []
+  if (leadable(climbType)) { styles.push(...allStyles.filter(style => ['Lead', 'Follow'].includes(style.name))) }
+  if (topropeable(climbType)) { styles.push(...allStyles.filter(style => ['TR'].includes(style.name))) }
+  if (soloable(climbType)) { styles.push(...allStyles.filter(style => ['Solo'].includes(style.name))) }
+  if (boulderable(climbType)) { styles.push(...allStyles.filter(style => ['Boulder'].includes(style.name))) }
+  if (aidable(climbType)) { styles.push(...allStyles.filter(style => ['Aid'].includes(style.name))) }
+  if (styles.length === 0) { styles = [...allStyles] } // If a climb doesn't have a type, anything goes
+  styles.push({ id: 0, name: '\u00A0' })
+  return styles
+}
+
+function attemptTypesForStyle (styleName: string): Array<{ id: number, name: string }> {
   const emptyOption = { id: 0, name: '\u00A0' }
   switch (styleName) {
     case 'Lead':
@@ -68,6 +84,8 @@ function attemptTypes ({ styleName }: { styleName: string }): Array<{ id: number
       return [...allAttemptTypes.filter(type => ['Send', 'Attempt', 'Frenchfree'].includes(type.name)), emptyOption]
     case 'Boulder':
       return [...allAttemptTypes.filter(type => ['Flash', 'Send', 'Attempt'].includes(type.name)), emptyOption]
+    case 'Aid':
+      return [...allAttemptTypes.filter(type => ['Send', 'Attempt'].includes(type.name)), emptyOption]
     default:
       return [emptyOption]
   }
@@ -82,15 +100,20 @@ interface Props {
   climbId: string
   name?: string
   grade?: string
+  climbType: object
 }
 
-export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, climbId, name, grade }: Props): JSX.Element {
+export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, climbId, name, grade, climbType }: Props): JSX.Element {
+  const styles = stylesForClimbType(climbType)
   const [style, setStyle] = useState(styles[0])
-  const [attemptType, setAttemptType] = useState(attemptTypes({ styleName: styles[0].name })[0])
+
+  const [attemptTypes, setAttemptTypes] = useState(attemptTypesForStyle(style.name))
+  const [attemptType, setAttemptType] = useState(attemptTypes[0])
   const [dateClimbed, setDateClimbed] = useState<string>(new Date().toLocaleDateString('fr-CA')) // Default is today, use fr-CA to get YYYY-MM-DD format.
   const [notes, setNotes] = useState<string>('')
   const [errors, setErrors] = useState<string[]>()
   const session = useSession()
+  const climbingGlossaryLink = 'https://en.wikipedia.org/wiki/Glossary_of_climbing_terms#'
   const [addTick] = useMutation(
     MUTATION_ADD_TICK, {
       client: graphqlClient,
@@ -103,14 +126,17 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
    */
   function resetInputs (): void {
     setDateClimbed(new Date().toLocaleDateString('fr-CA'))
-    setAttemptType(attemptTypes({ styleName: styles[0].name })[0])
+    const newAttemptTypes = attemptTypesForStyle(styles[0].name)
+    setAttemptTypes(newAttemptTypes)
+    setAttemptType(newAttemptTypes[0])
     setNotes('')
     setStyle(styles[0])
   }
 
   function handleStyleChange (newStyle: { id: number, name: string }): void {
     setStyle(newStyle)
-    const newAttemptTypes = attemptTypes({ styleName: newStyle.name })
+    const newAttemptTypes = attemptTypesForStyle(newStyle.name)
+    setAttemptTypes(newAttemptTypes)
     setAttemptType(newAttemptTypes[0])
   }
 
@@ -218,7 +244,7 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
                       <InformationCircleIcon className='h-5 w-5' />
                     </a>
                   </div>
-                  <ComboBox options={attemptTypes({ styleName: style.name })} value={attemptType} onChange={setAttemptType} label='' />
+                  <ComboBox options={attemptTypesForStyle(style.name)} value={attemptType} onChange={setAttemptType} label='' />
                   <div>
                     <label htmlFor='comment' className='block text-sm font-medium text-gray-700 mt-2'>
                       Notes

--- a/src/components/users/TickForm.tsx
+++ b/src/components/users/TickForm.tsx
@@ -10,6 +10,11 @@ import ComboBox from '../ui/ComboBox'
 import * as Yup from 'yup'
 import { Info } from '@phosphor-icons/react/dist/ssr'
 
+const climbingGlossaryLink = 'https://en.wikipedia.org/wiki/Glossary_of_climbing_terms#'
+const CustomTooltip: React.FC<any> = () => {
+  return (<p>A Glossary of Climbing Terms<br />can be found <a href={climbingGlossaryLink} target='_blank' rel='noreferrer' className='ml-2 mt-1 text-blue-500 underline'>Here</a></p>)
+}
+
 // validation schema for ticks
 const TickSchema = Yup.object().shape({
   name: Yup.string()
@@ -113,7 +118,6 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
   const [notes, setNotes] = useState<string>('')
   const [errors, setErrors] = useState<string[]>()
   const session = useSession()
-  const climbingGlossaryLink = 'https://en.wikipedia.org/wiki/Glossary_of_climbing_terms#'
   const [addTick] = useMutation(
     MUTATION_ADD_TICK, {
       client: graphqlClient,
@@ -240,11 +244,9 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
                     <label htmlFor='attemptType' className='block text-sm font-medium text-gray-700'>
                       Attempt Type
                     </label>
-                    <a href={climbingGlossaryLink} target='_blank' rel='noreferrer' className='ml-2 mt-1'>
-                      <Tooltip content='Glossary of Climbing Terms' trigger='hover'>
-                        <Info className='h-5 w-5' />
-                      </Tooltip>
-                    </a>
+                    <Tooltip content={<CustomTooltip />}>
+                      <Info className='h-5 w-5' />
+                    </Tooltip>
                   </div>
                   <ComboBox options={attemptTypesForStyle(style.name)} value={attemptType} onChange={setAttemptType} label='' />
                   <div>

--- a/src/components/users/TickForm.tsx
+++ b/src/components/users/TickForm.tsx
@@ -7,6 +7,7 @@ import { graphqlClient } from '../../js/graphql/Client'
 import { MUTATION_ADD_TICK } from '../../js/graphql/gql/fragments'
 import ComboBox from '../ui/ComboBox'
 import * as Yup from 'yup'
+import { InformationCircleIcon } from '@heroicons/react/20/solid'
 
 // validation schema for ticks
 const TickSchema = Yup.object().shape({
@@ -19,10 +20,8 @@ const TickSchema = Yup.object().shape({
     .required('Something went wrong fetching the climb Id, please try again'),
   userId: Yup.string()
     .required('Something went wrong fetching your user Id, please try again'),
-  style: Yup.string()
-    .required('Please choose an ascent style'),
-  attemptType: Yup.string()
-    .required('Please choose an ascent type'),
+  style: Yup.string(),
+  attemptType: Yup.string(),
   dateClimbed: Yup.date()
     .required('Please include a date')
     .max(new Date(), 'Please include a date in the past'),
@@ -34,19 +33,45 @@ const TickSchema = Yup.object().shape({
  * Feel free to add any you think are valuable for our users
  */
 const styles = [
-  { id: 1, name: 'Solo' },
+  { id: 1, name: 'Lead' },
   { id: 2, name: 'TR' },
   { id: 3, name: 'Follow' },
-  { id: 4, name: 'Lead' },
-  { id: 5, name: 'Boulder' }
+  { id: 4, name: 'Solo' },
+  { id: 5, name: 'Boulder' },
+  { id: 6, name: '\u00A0' }
 ]
 
-const attemptTypes = [
+const allAttemptTypes = [
   { id: 1, name: 'Onsight' },
   { id: 2, name: 'Flash' },
   { id: 3, name: 'Redpoint' },
-  { id: 4, name: 'Pinkpoint' }
+  { id: 4, name: 'Pinkpoint' },
+  { id: 5, name: 'Send' },
+  { id: 6, name: 'Attempt' },
+  { id: 7, name: 'Frenchfree' }
 ]
+
+// Small info icon with a link to the Wikipedia glossary of climbing terms
+const climbingGlossaryLink = 'https://en.wikipedia.org/wiki/Glossary_of_climbing_terms#'
+
+// Dynamically offer relevant options depending on the style chosen. This is fairly open to allow multiple options, with some restrictions based on common climber nomenclature.
+// Note that both style and attemptType can be empty. This code is likley coupled with the db validation logic on the backend, and a future improvement could be to decouple these.
+function attemptTypes ({ styleName }: { styleName: string }): Array<{ id: number, name: string }> {
+  const emptyOption = { id: 0, name: '\u00A0' }
+  switch (styleName) {
+    case 'Lead':
+      return [...allAttemptTypes.filter(type => ['Onsight', 'Flash', 'Redpoint', 'Pinkpoint', 'Attempt', 'Frenchfree'].includes(type.name)), emptyOption]
+    case 'Solo':
+      return [...allAttemptTypes.filter(type => ['Onsight', 'Flash', 'Redpoint', 'Attempt'].includes(type.name)), emptyOption]
+    case 'TR':
+    case 'Follow':
+      return [...allAttemptTypes.filter(type => ['Send', 'Attempt', 'Frenchfree'].includes(type.name)), emptyOption]
+    case 'Boulder':
+      return [...allAttemptTypes.filter(type => ['Flash', 'Send', 'Attempt'].includes(type.name)), emptyOption]
+    default:
+      return [emptyOption]
+  }
+}
 
 interface Props {
   open: boolean
@@ -60,8 +85,8 @@ interface Props {
 }
 
 export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, climbId, name, grade }: Props): JSX.Element {
-  const [style, setStyle] = useState(styles[1])
-  const [attemptType, setAttemptType] = useState(attemptTypes[1])
+  const [style, setStyle] = useState(styles[0])
+  const [attemptType, setAttemptType] = useState(attemptTypes({ styleName: styles[0].name })[0])
   const [dateClimbed, setDateClimbed] = useState<string>(new Date().toLocaleDateString('fr-CA')) // Default is today, use fr-CA to get YYYY-MM-DD format.
   const [notes, setNotes] = useState<string>('')
   const [errors, setErrors] = useState<string[]>()
@@ -78,9 +103,15 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
    */
   function resetInputs (): void {
     setDateClimbed(new Date().toLocaleDateString('fr-CA'))
-    setAttemptType(attemptTypes[1])
+    setAttemptType(attemptTypes({ styleName: styles[0].name })[0])
     setNotes('')
-    setStyle(styles[1])
+    setStyle(styles[0])
+  }
+
+  function handleStyleChange (newStyle: { id: number, name: string }): void {
+    setStyle(newStyle)
+    const newAttemptTypes = attemptTypes({ styleName: newStyle.name })
+    setAttemptType(newAttemptTypes[0])
   }
 
   async function submitTick (): Promise<void> {
@@ -121,7 +152,8 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
       .catch((error) => {
         const gqlErrs = error.graphQLErrors ?? []
         if (gqlErrs.length > 0) {
-          switch (gqlErrs[0].extensions.exception.code) {
+          const code = gqlErrs[0].extensions.exception?.code
+          switch (code) {
             case 11000:
             case 11001:
               setErrors(['Error, duplicate tick found'])
@@ -137,7 +169,7 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as='div' className='relative z-10' onClose={() => setOpen(false)}>
+      <Dialog as='div' className='relative z-50' onClose={() => setOpen(false)}>
         <Transition.Child
           as={Fragment}
           enter='ease-out duration-300'
@@ -150,7 +182,7 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
           <div className='fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity' />
         </Transition.Child>
 
-        <div className='fixed z-10 inset-0 overflow-y-auto'>
+        <div className='fixed z-50 inset-0 overflow-y-auto'>
           <div className='flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0'>
             <Transition.Child
               as={Fragment}
@@ -177,15 +209,23 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
                       className='py-2 px-3 border border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md'
                     />
                   </div>
-                  <ComboBox options={styles} value={style} onChange={setStyle} label='Style' />
-                  <ComboBox options={attemptTypes} value={attemptType} onChange={setAttemptType} label='Attempt Type' />
+                  <ComboBox options={styles} value={style} onChange={handleStyleChange} label='Style' />
+                  <div className='flex items-center'>
+                    <label htmlFor='attemptType' className='block text-sm font-medium text-gray-700'>
+                      Attempt Type
+                    </label>
+                    <a href={climbingGlossaryLink} target='_blank' rel='noopener noreferrer' className='ml-2 text-gray-500 hover:text-gray-700' title='climbing terminology'>
+                      <InformationCircleIcon className='h-5 w-5' />
+                    </a>
+                  </div>
+                  <ComboBox options={attemptTypes({ styleName: style.name })} value={attemptType} onChange={setAttemptType} label='' />
                   <div>
                     <label htmlFor='comment' className='block text-sm font-medium text-gray-700 mt-2'>
                       Notes
                     </label>
                     <div className='mt-1'>
                       <textarea
-                        rows={4}
+                        rows={6}
                         name='comment'
                         value={notes}
                         onChange={(e) => setNotes(e.target.value)}

--- a/src/components/users/TickForm.tsx
+++ b/src/components/users/TickForm.tsx
@@ -2,12 +2,13 @@ import { Fragment, useState } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import { useMutation } from '@apollo/client'
 import { useSession } from 'next-auth/react'
-import { TickType } from '../../js/types'
-import { graphqlClient } from '../../js/graphql/Client'
-import { MUTATION_ADD_TICK } from '../../js/graphql/gql/fragments'
+import { TickType } from '@/js/types'
+import Tooltip from '../ui/Tooltip'
+import { graphqlClient } from '@/js/graphql/Client'
+import { MUTATION_ADD_TICK } from '@/js/graphql/gql/fragments'
 import ComboBox from '../ui/ComboBox'
 import * as Yup from 'yup'
-import { InformationCircleIcon } from '@heroicons/react/20/solid'
+import { Info } from '@phosphor-icons/react/dist/ssr'
 
 // validation schema for ticks
 const TickSchema = Yup.object().shape({
@@ -26,12 +27,11 @@ const TickSchema = Yup.object().shape({
     .required('Please include a date')
     .max(new Date(), 'Please include a date in the past'),
   grade: Yup.string()
-    .required('Something went wrong fetching the climbs grade, please try again')
 })
 
 /**
  * Options for the dropdown comboboxes
- * The logic here can get quite complicated. There is a hierarchy of "Climb type" -> "Style" -> "Attempt Type"
+ * Tick validation logic is complicated. see [tick_logic.md](https://github.com/OpenBeta/openbeta-graphql/blob/develop/documentation/tick_logic.md).
  **/
 const allStyles = [
   { id: 1, name: 'Lead' },
@@ -54,36 +54,36 @@ const allAttemptTypes = [
 
 function hasKey (climbType: object, myList: string[]): boolean { return Object.keys(climbType).some(key => myList.includes(key)) }
 
-function leadable (climbType: object): boolean { return hasKey(climbType, ['trad', 'sport', 'snow', 'ice', 'mixed', 'alpine']) }
-function topropeable (climbType: object): boolean { return hasKey(climbType, ['tr']) || (leadable(climbType)) }
-function aidable (climbType: object): boolean { return hasKey(climbType, ['aid']) }
-function soloable (climbType: object): boolean { return hasKey(climbType, ['deepwatersolo']) || leadable(climbType) || aidable(climbType) || topropeable(climbType) }
-function boulderable (climbType: object): boolean { return hasKey(climbType, ['bouldering']) }
-
 function stylesForClimbType (climbType: object): Array<{ id: number, name: string }> {
+  const leadable = hasKey(climbType, ['trad', 'sport', 'snow', 'ice', 'mixed', 'alpine'])
+  const topropeable = hasKey(climbType, ['tr']) || (leadable)
+  const aidable = hasKey(climbType, ['aid'])
+  const boulderable = hasKey(climbType, ['bouldering'])
+  const soloable = hasKey(climbType, ['deepwatersolo']) || leadable || aidable || (topropeable && !boulderable)
+
   let styles: Array<{ id: number, name: string }> = []
-  if (leadable(climbType)) { styles.push(...allStyles.filter(style => ['Lead', 'Follow'].includes(style.name))) }
-  if (topropeable(climbType)) { styles.push(...allStyles.filter(style => ['TR'].includes(style.name))) }
-  if (soloable(climbType)) { styles.push(...allStyles.filter(style => ['Solo'].includes(style.name))) }
-  if (boulderable(climbType)) { styles.push(...allStyles.filter(style => ['Boulder'].includes(style.name))) }
-  if (aidable(climbType)) { styles.push(...allStyles.filter(style => ['Aid'].includes(style.name))) }
+
+  if (leadable) { styles.push(...allStyles.filter(style => ['Lead', 'Follow'].includes(style.name))) }
+  if (boulderable) { styles.push(...allStyles.filter(style => ['Boulder'].includes(style.name))) }
+  if (topropeable) { styles.push(...allStyles.filter(style => ['TR'].includes(style.name))) }
+  if (aidable) { styles.push(...allStyles.filter(style => ['Aid'].includes(style.name))) }
+  if (soloable) { styles.push(...allStyles.filter(style => ['Solo'].includes(style.name))) }
   if (styles.length === 0) { styles = [...allStyles] } // If a climb doesn't have a type, anything goes
-  styles.push({ id: 0, name: '\u00A0' })
+  styles.push({ id: 10, name: '\u00A0' })
   return styles
 }
 
 function attemptTypesForStyle (styleName: string): Array<{ id: number, name: string }> {
-  const emptyOption = { id: 0, name: '\u00A0' }
+  const emptyOption = { id: 10, name: '\u00A0' }
   switch (styleName) {
     case 'Lead':
       return [...allAttemptTypes.filter(type => ['Onsight', 'Flash', 'Redpoint', 'Pinkpoint', 'Attempt', 'Frenchfree'].includes(type.name)), emptyOption]
     case 'Solo':
       return [...allAttemptTypes.filter(type => ['Onsight', 'Flash', 'Redpoint', 'Attempt'].includes(type.name)), emptyOption]
-    case 'TR':
-    case 'Follow':
-      return [...allAttemptTypes.filter(type => ['Send', 'Attempt', 'Frenchfree'].includes(type.name)), emptyOption]
     case 'Boulder':
       return [...allAttemptTypes.filter(type => ['Flash', 'Send', 'Attempt'].includes(type.name)), emptyOption]
+    case 'TR':
+    case 'Follow':
     case 'Aid':
       return [...allAttemptTypes.filter(type => ['Send', 'Attempt'].includes(type.name)), emptyOption]
     default:
@@ -147,8 +147,8 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
       notes,
       climbId,
       userId: session.data?.user.metadata.uuid,
-      style: style.name,
-      attemptType: attemptType.name,
+      style: style.name === '\u00A0' ? undefined : style.name,
+      attemptType: attemptType.name === '\u00A0' ? undefined : attemptType.name,
       dateClimbed: new Date(Date.parse(`${dateClimbed}T00:00:00`)), // Date.parse without timezone converts dateClimbed into local timezone.
       grade,
       source: 'OB' // source manually set as Open Beta
@@ -240,8 +240,10 @@ export default function TickForm ({ open, setOpen, setTicks, ticks, isTicked, cl
                     <label htmlFor='attemptType' className='block text-sm font-medium text-gray-700'>
                       Attempt Type
                     </label>
-                    <a href={climbingGlossaryLink} target='_blank' rel='noopener noreferrer' className='ml-2 text-gray-500 hover:text-gray-700' title='climbing terminology'>
-                      <InformationCircleIcon className='h-5 w-5' />
+                    <a href={climbingGlossaryLink} target='_blank' rel='noreferrer' className='ml-2 mt-1'>
+                      <Tooltip content='Glossary of Climbing Terms' trigger='hover'>
+                        <Info className='h-5 w-5' />
+                      </Tooltip>
                     </a>
                   </div>
                   <ComboBox options={attemptTypesForStyle(style.name)} value={attemptType} onChange={setAttemptType} label='' />

--- a/src/components/users/TicksModal.tsx
+++ b/src/components/users/TicksModal.tsx
@@ -12,7 +12,7 @@ const TicksModal: React.FC<any> = ({ open, setOpen, setTicks, setOpenForm, climb
   }
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as='div' className='relative z-10' initialFocus={cancelButtonRef} onClose={setOpen}>
+      <Dialog as='div' className='relative z-50' initialFocus={cancelButtonRef} onClose={setOpen}>
         <Transition.Child
           as={Fragment}
           enter='ease-out duration-300'
@@ -25,7 +25,7 @@ const TicksModal: React.FC<any> = ({ open, setOpen, setTicks, setOpenForm, climb
           <div className='fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity' />
         </Transition.Child>
 
-        <div className='fixed inset-0 z-10 overflow-y-auto'>
+        <div className='fixed inset-0 z-50 overflow-y-auto'>
           <div className='flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0'>
             <Transition.Child
               as={Fragment}
@@ -44,7 +44,7 @@ const TicksModal: React.FC<any> = ({ open, setOpen, setTicks, setOpenForm, climb
                     </Dialog.Title>
                     <div className='mt-2 max-h-96 overflow-auto'>
                       {ticks?.map((tick: TickType, idx: number) => {
-                        return <TickCard key={idx} tickId={tick._id} setTicks={setTicks} ticks={ticks} dateClimbed={tick.dateClimbed} notes={tick.notes} style={tick.style} />
+                        return <TickCard key={idx} tickId={tick._id} setTicks={setTicks} ticks={ticks} dateClimbed={tick.dateClimbed} notes={tick.notes} style={tick.style} attemptType={tick.attemptType} />
                       })}
                     </div>
                   </div>

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -440,7 +440,7 @@ const ClimbData: React.FC<{
 
         {!editMode && (
           <div className='mt-8'>
-            <TickButton climbId={climbId} name={name} grade={gradesObj.toString()} />
+            <TickButton climbId={climbId} name={name} grade={gradesObj.toString()} climbType={{}} />
           </div>
         )}
       </div>


### PR DESCRIPTION

---
name: Pull request
about: Create a pull request
title: 'Restrict tick Attempt Type'
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [X] refactor
- [X] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

[Issue #411](https://github.com/OpenBeta/openbeta-graphql/issues/411)


### What this PR achieves

* add the "Tick the Route" button to the newer climbs page (it was previously only on the old page)
* dynamically populate available attemptType based on chosen style
* display attemptType in TickCard when viewing listed ticks
* add subtle info icon with link to Wikipedia's Glossary of Climbing Terms
* tinker with z values because the breadcrumb nav bar was overlapping the tick dialog
* increase notes size slightly to accomodate for longer list of attempt styles in the dropdown.


### Screenshots, recordings

![Screenshot 2025-01-24 at 5 06 16 PM](https://github.com/user-attachments/assets/07e34cfc-d265-41bd-af33-1e4082d10678)




### Notes
this is closely tied to https://github.com/OpenBeta/openbeta-graphql/pull/444. and is essentially the front-end version of the same restrictions.

One thing i could use help with:
Style and attemptType can be empty, but right now thats getting sent as a string with a space. I'd like them to be nullable, but was running into issues with that.

