### PR TITLE
Support HEIC image format

### DIFF
--- a/src/js/hooks/usePhotoUploader.tsx
+++ b/src/js/hooks/usePhotoUploader.tsx
@@ -144,7 +144,14 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
     // also the queue is handled sequentially, with callbacks individually
     // for each file uploads... so it interops nicely with existing function
     maxFiles: 40,
-    accept: { 'image/*': [] },
+    accept: {
+      'image/jpeg': [],
+      'image/jpg': [],
+      'image/gif': [],
+      'image/png': [],
+      'image/webp': [],
+      'image/avif': []
+    },
     useFsAccessApi: false,
     noClick: isUploading
   })


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: Support HEIC image format #1265
labels: bug
assignees: @mikeschen 

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
On image upload don't allow choosing Tiff or HEIC.
React Dropzone does not seem to be able to handle Heic files. https://github.com/react-dropzone/react-dropzone/issues/966
Not allowing Tiff now since they are too large and no browser support.
Web app should still support HEIC uploads (behind the scenes iCloud is converting to jpg, I think).
### Related Issues

Issue #
1265

### What this PR achieves
On image upload don't allow choosing Tiff or HEIC

### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->

![no-heic-low](https://github.com/user-attachments/assets/8d5e0156-3e3c-4bdf-8ec7-61499a5c8738)



### Notes
<!--Anything in particular you want the reviewer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




