### PR TITLE
Disable fetch cache in Apollo client

### DIFF
--- a/src/js/graphql/Client.ts
+++ b/src/js/graphql/Client.ts
@@ -3,7 +3,12 @@ import { onError } from '@apollo/client/link/error'
 
 const uri: string = process.env.NEXT_PUBLIC_API_SERVER ?? ''
 const httpLinkPro = new HttpLink({
-  uri
+  uri,
+  // Prevent Next.js fetch caching
+  fetchOptions: {
+    cache: 'no-store',
+    next: { revalidate: 0 }
+  }
 })
 const errorLink = onError(({ graphQLErrors, networkError, ...rest }) => {
   console.error('#################### GQL Error  ####################')

--- a/src/js/graphql/Client.ts
+++ b/src/js/graphql/Client.ts
@@ -6,8 +6,7 @@ const httpLinkPro = new HttpLink({
   uri,
   // Prevent Next.js fetch caching
   fetchOptions: {
-    cache: 'no-store',
-    next: { revalidate: 0 }
+    cache: 'no-store'
   }
 })
 const errorLink = onError(({ graphQLErrors, networkError, ...rest }) => {


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #1243 


### What this PR achieves
Next extends Node `fetch()` used by the Apollo client.  The new setting completely disables the cache which hopefully reduces ISR Write costs recently introduced by Vercel.com

