### PR TITLE
fix: support all discipline types on climb and area pages

### DIFF
--- a/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
+++ b/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
@@ -6,7 +6,7 @@ import RouteTypeChips from '@/components/ui/RouteTypeChips'
 import { ArticleLastUpdate } from '@/components/edit/ArticleLastUpdate'
 import { ClimbType, AreaType } from '@/js/types'
 import Grade from '@/js/grades/Grade'
-import { removeTypenameFromDisciplines } from '@/js/utils'
+import { removeTypenameFromDisciplines, getDisciplineList } from '@/js/utils'
 
 export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { isBoulder: boolean }> = (props) => {
   const { id, name, type, safety, length, grades, fa: legacyFA, authorMetadata, gradeContext, isBoulder } = props
@@ -28,7 +28,7 @@ export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { 
           {gradeStr != null && (
             <RouteGradeChip gradeStr={gradeStr} safety={safety} />
           )}
-          <RouteTypeChips type={type} />
+          <RouteTypeChips types={getDisciplineList(type)} />
         </div>
 
         {length !== -1 && (

--- a/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
+++ b/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
@@ -28,7 +28,7 @@ export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { 
           {gradeStr != null && (
             <RouteGradeChip gradeStr={gradeStr} safety={safety} />
           )}
-          <RouteTypeChips types={getDisciplineList(type)} />
+          <RouteTypeChips types={getDisciplineList(sanitizedDisciplines)} />
         </div>
 
         {length !== -1 && (

--- a/src/components/crag/cragTable.tsx
+++ b/src/components/crag/cragTable.tsx
@@ -2,10 +2,10 @@ import { getScoreForSort, GradeScales } from '@openbeta/sandbag'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { Climb } from '../../js/types'
-import { getSetTypes } from '../ui/RouteTypeChips'
 import ButtonGroup from '../../components/ui/ButtonGroup'
 import { Button } from '../../components/ui/Button'
 import { summarize } from '../ui/Description'
+import { getDisciplineList } from '@/js/utils'
 // import { APIFavouriteCollections } from '../../pages/api/user/fav'
 
 interface CragTableProps {
@@ -87,7 +87,7 @@ function ClimbItem (props: { favs: string[], climb: Climb, hideSummary: boolean 
       )}
 
       <div className='text-sm mt-2'>
-        Discipline(s): {getSetTypes(type).join(', ')}
+        Discipline(s): {getDisciplineList(type).join(', ')}
       </div>
     </div>
   )

--- a/src/components/search/ResultTemplates.tsx
+++ b/src/components/search/ResultTemplates.tsx
@@ -3,7 +3,6 @@ import { NextRouter } from 'next/router'
 
 import RouteCard from '../ui/RouteCard'
 import { TypesenseDocumentType } from '../../js/types'
-import { disciplineArrayToObj } from '../../js/utils'
 
 interface ClimbTemplateType extends TypesenseDocumentType {
   router: NextRouter
@@ -51,7 +50,7 @@ const ClimbTemplate = (props: ClimbTemplateType): JSX.Element => {
     <div className='py-2' onClick={() => { void router.push(url) }}>
       <RouteCard
         routeName={climbName}
-        type={disciplineArrayToObj(disciplines)}
+        type={disciplines}
         yds={grade}
         safety={safety}
         fa={fa}

--- a/src/components/ui/RouteCard.tsx
+++ b/src/components/ui/RouteCard.tsx
@@ -3,11 +3,11 @@ import Card from './Card'
 import RouteTypeChips from './RouteTypeChips'
 import RouteGradeChip from './RouteGradeChip'
 import { MiniCrumbs } from './BreadCrumbs'
-import { ClimbDisciplineRecord, SafetyType } from '../../js/types'
+import { ClimbDiscipline, SafetyType } from '../../js/types'
 
 interface RouteCardProps {
   routeName: string
-  type: Partial<ClimbDisciplineRecord>
+  type: ClimbDiscipline[]
   safety?: SafetyType
   yds: string
   fa?: string
@@ -30,7 +30,7 @@ function RouteCard ({ routeName, type, safety, yds, fa = '', pathTokens }: Route
         {safety != null && <RouteGradeChip gradeStr={yds} safety={safety} />}
       </div>
       <div className='mt-4 flex justify-between items-center'>
-        <RouteTypeChips type={type} />
+        <RouteTypeChips types={type} />
       </div>
     </Card>
   )

--- a/src/components/ui/RouteTypeChips.tsx
+++ b/src/components/ui/RouteTypeChips.tsx
@@ -1,33 +1,17 @@
 import React from 'react'
-import { ClimbDiscipline, ClimbDisciplineRecord } from '../../js/types'
+import { ClimbDiscipline } from '../../js/types'
 import Chip from './Chip'
 
 interface ChipProps {
-  type: Partial<ClimbDisciplineRecord>
+  types: ClimbDiscipline[]
   size?: string
 }
-export default function RouteTypeChips ({ type, size = 'md' }: ChipProps): JSX.Element {
+export default function RouteTypeChips ({ types, size = 'md' }: ChipProps): JSX.Element {
   return (
     <div className='inline-flex flex-wrap items-center space-x-0.5'>
-      {(type?.trad ?? false) && <Chip type='trad' size={size} />}
-      {(type?.sport ?? false) && <Chip type='sport' size={size} />}
-      {(type?.tr ?? false) && <Chip type='tr' size={size} />}
-      {(type?.bouldering ?? false) && <Chip type='bouldering' size={size} />}
-      {(type?.aid ?? false) && <Chip type='aid' size={size} />}
-      {(type?.mixed ?? false) && <Chip type='mixed' size={size} />}
-      {(type?.alpine ?? false) && <Chip type='alpine' size={size} />}
+      {types.map(discipline => {
+        return <Chip key={discipline} type={discipline} size={size} />
+      })}
     </div>
   )
-}
-
-export function getSetTypes (type: ClimbDisciplineRecord): ClimbDiscipline[] {
-  const set: ClimbDiscipline[] = []
-  if (type?.trad) { set.push('trad') }
-  if (type?.sport) { set.push('sport') }
-  if (type?.tr) { set.push('tr') }
-  if (type?.bouldering) { set.push('bouldering') }
-  if (type?.aid) { set.push('aid') }
-  if (type?.mixed) { set.push('mixed') }
-  if (type?.alpine) { set.push('alpine') }
-  return set
 }

--- a/src/js/grades/Grade.ts
+++ b/src/js/grades/Grade.ts
@@ -125,8 +125,9 @@ export default class Grade {
   }
 
   toString (): string | undefined {
-    if (this.isBouldering()) return this.toStringBouldering()
-    if (this.isTradSportTr()) return this.toStringTradSportAid()
+    if (this.isBouldering()) return this.toStringVScale()
+    if (this.isYDS()) return this.toStringYDS()
+    if (this.isIce()) return this.toStringWI()
     return undefined
   }
 
@@ -134,17 +135,27 @@ export default class Grade {
     return this.isBoulder || (this.disciplines?.bouldering ?? false)
   }
 
-  isTradSportTr (): boolean {
-    return (this.disciplines?.sport ?? false) || (this.disciplines?.trad ?? false) || (this.disciplines?.tr ?? false) || (this.disciplines?.aid ?? false)
+  isYDS (): boolean {
+    return (this.disciplines?.sport ?? false) || (this.disciplines?.trad ?? false) || (this.disciplines?.tr ?? false) || (this.disciplines?.aid ?? false) || (this.disciplines?.deepwatersolo ?? false) || (this.disciplines?.snow ?? false)
   }
 
-  toStringBouldering (): string | undefined {
+  isIce (): boolean {
+    return (this.disciplines?.ice ?? false)
+  }
+
+  toStringWI (): string | undefined {
+    const key = this.gradescales.ice
+    // @ts-expect-error
+    return this.values?.[key] ?? undefined
+  }
+
+  toStringVScale (): string | undefined {
     const key: string = this.gradescales.bouldering
     // @ts-expect-error
     return this.values?.[key] ?? undefined
   }
 
-  toStringTradSportAid (): string | undefined {
+  toStringYDS (): string | undefined {
     const key = this.gradescales.sport
     // @ts-expect-error
     return this.values?.[key] ?? undefined

--- a/src/js/graphql/gql/areaById.ts
+++ b/src/js/graphql/gql/areaById.ts
@@ -2,10 +2,11 @@ import { gql } from '@apollo/client'
 
 import { FRAGMENT_AUTHOR_METADATA } from './contribs'
 import { FRAGMENT_MEDIA_WITH_TAGS } from './tags'
-import { FRAGMENT_CLIMB_DISCIPLINES } from './climbById'
+import { FRAGMENT_CLIMB_DISCIPLINES, FRAGMENT_CLIMB_TYPES } from './climbById'
 
 export const QUERY_AREA_BY_ID = gql`
   ${FRAGMENT_CLIMB_DISCIPLINES}
+  ${FRAGMENT_CLIMB_TYPES}
   ${FRAGMENT_MEDIA_WITH_TAGS}
   ${FRAGMENT_AUTHOR_METADATA}
   query ($uuid: ID) {
@@ -74,13 +75,7 @@ export const QUERY_AREA_BY_ID = gql`
         }
         safety
         type {
-          trad
-          tr
-          sport
-          mixed
-          bouldering
-          alpine
-          aid
+          ...ClimbTypeFields
         }
         metadata {
           climbId
@@ -158,13 +153,7 @@ query AreaByID($uuid: ID) {
       }
       safety
       type {
-        trad
-        tr
-        sport
-        mixed
-        bouldering
-        alpine
-        aid
+        ...ClimbTypeFields
       }
       metadata {
         climbId

--- a/src/js/graphql/gql/climbById.ts
+++ b/src/js/graphql/gql/climbById.ts
@@ -16,8 +16,24 @@ export const FRAGMENT_CLIMB_DISCIPLINES = gql`
     uiaa
   }`
 
+export const FRAGMENT_CLIMB_TYPES = gql`
+  fragment ClimbTypeFields on ClimbType {
+    trad
+    sport
+    bouldering
+    deepwatersolo
+    alpine
+    snow
+    ice
+    mixed
+    aid
+    tr
+  }
+`
+
 export const QUERY_CLIMB_BY_ID = gql`
   ${FRAGMENT_CLIMB_DISCIPLINES}
+  ${FRAGMENT_CLIMB_TYPES}
   ${FRAGMENT_MEDIA_WITH_TAGS}
   ${FRAGMENT_AUTHOR_METADATA}
   query ClimbByUUID($id: ID) {
@@ -33,13 +49,7 @@ export const QUERY_CLIMB_BY_ID = gql`
       }
       safety
       type {
-        sport
-        bouldering
-        alpine
-        tr
-        trad
-        mixed
-        aid
+        ...ClimbTypeFields
       }
       media {
         ... MediaWithTagsFields
@@ -71,13 +81,7 @@ export const QUERY_CLIMB_BY_ID = gql`
           }
           safety
           type {
-            sport
-            bouldering
-            alpine
-            tr
-            trad
-            mixed
-            aid
+            ...ClimbTypeFields
           }
           metadata {
             leftRightIndex

--- a/src/js/graphql/gql/climbById.ts
+++ b/src/js/graphql/gql/climbById.ts
@@ -14,6 +14,7 @@ export const FRAGMENT_CLIMB_DISCIPLINES = gql`
     vscale
     yds
     uiaa
+    wi
   }`
 
 export const FRAGMENT_CLIMB_TYPES = gql`

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -126,18 +126,19 @@ function debouncePromise (fn: Function, time: number): any {
 export const debounced = debouncePromise(async (items: object[]): Promise<object[]> => await Promise.resolve(items), 300)
 
 /**
- * Convert array of disciplines ['trad', 'sport'] => {trad: true, sport: true}
- * @param types
- * @returns ClimbDisciplineRecord
+ * Convert record of climbing disciplines to an array
+ * @param {ClimbDisciplineRecord} types
+ * @returns {ClimbDiscipline[]}
  */
-export const disciplineArrayToObj = (types: ClimbDiscipline[]): Partial<ClimbDisciplineRecord> => {
-  // use Array.reduce() because ts-jest doesn't support for..of
-  const z: Partial<ClimbDisciplineRecord> = types.reduce((acc, curr) => {
-    // @ts-expect-error
-    acc[curr] = true
-    return acc
-  }, {})
-  return z
+export function getDisciplineList (type: ClimbDisciplineRecord): ClimbDiscipline[] {
+  const set: ClimbDiscipline[] = []
+  for (const discipline of Object.keys(type) as ClimbDiscipline[]) {
+    // stricter assertion so we don't include __typename
+    if (type[discipline]) {
+      set.push(discipline)
+    }
+  }
+  return set
 }
 
 const regUsername = /^[a-zA-Z0-9]+([_\\.-]?[a-zA-Z0-9])*$/i

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -130,11 +130,11 @@ export const debounced = debouncePromise(async (items: object[]): Promise<object
  * @param {ClimbDisciplineRecord} types
  * @returns {ClimbDiscipline[]}
  */
-export function getDisciplineList (type: ClimbDisciplineRecord): ClimbDiscipline[] {
+export function getDisciplineList (type: Partial<ClimbDisciplineRecord>): ClimbDiscipline[] {
   const set: ClimbDiscipline[] = []
   for (const discipline of Object.keys(type) as ClimbDiscipline[]) {
     // stricter assertion so we don't include __typename
-    if (type[discipline]) {
+    if (type[discipline] === true) {
       set.push(discipline)
     }
   }

--- a/src/pages/climbs/[id].tsx
+++ b/src/pages/climbs/[id].tsx
@@ -25,7 +25,7 @@ import { ClientSideFormSaveAction, Skeleton as ContentSkeleton } from '../../com
 import { ArticleLastUpdate } from '../../components/edit/ArticleLastUpdate'
 import { TradSportGradeInput, BoulderingGradeInput } from '../../components/edit/form/GradeTextInput'
 import Grade from '../../js/grades/Grade'
-import { removeTypenameFromDisciplines } from '../../js/utils'
+import { getDisciplineList, removeTypenameFromDisciplines } from '../../js/utils'
 import { TotalLengthInput } from '../../components/edit/form/TotalLengthInput'
 import { LegacyFAInput } from '../../components/edit/form/LegacyFAInput'
 import { getClimbById } from '../../js/graphql/api'
@@ -411,7 +411,7 @@ const ClimbData: React.FC<{
           {!editMode && cache.gradeStr != null && (
             <RouteGradeChip gradeStr={cache.gradeStr} safety={safety} />
           )}
-          {!editMode && <RouteTypeChips type={disciplinesField} />}
+          {!editMode && <RouteTypeChips types={getDisciplineList(disciplinesField)} />}
         </div>
 
         {length !== -1 && !editMode && (


### PR DESCRIPTION
---
name: Pull request for Issue #1262 
about: Add ice, dws, and snow disciplines 
---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
Ice, snow and DWS are missing in several places. This PR remedies that and consolidates the listing of some of these fields into a GraphQL fragment and a util function

### Related Issues

Issue #1262 


### What this PR achieves
Add missing climbing disciplines to areas and climb pages
- Create fragment for climbing disciplines and add to queries
- Add util to convert `ClimbDisciplineRecord` to simple array of `ClimbDiscipline[]`
- Remove now unused `disciplineArrayToObj` function

### Screenshots, recordings
<img width="786" alt="Screenshot 2025-02-18 at 12 06 30 PM" src="https://github.com/user-attachments/assets/b7b04576-d282-4daf-8f9c-93de5b687c7b" />
<img width="1144" alt="Screenshot 2025-02-18 at 12 07 35 PM" src="https://github.com/user-attachments/assets/ba1936d8-896d-411f-9213-07f4fb5572ed" />






