### PR TITLE
Migrate pulse page to Next 13 Issue: 1276

### DIFF
--- a/src/app/(default)/pulse/page.tsx
+++ b/src/app/(default)/pulse/page.tsx
@@ -1,48 +1,34 @@
 import React, { ReactNode } from 'react'
-import { NextPage, GetStaticProps } from 'next'
 import Link from 'next/link'
-import Layout from '../components/layout'
-import SeoTags from '../components/SeoTags'
 import clz from 'classnames'
 
-import { getSummaryReport } from '../js/graphql/opencollective'
-import { getTagsLeaderboard } from '../js/graphql/pulse'
-import { FinancialReportType, TagsByUserType, TagsLeaderboardType } from '../js/types'
-import BackerCard from '../components/ui/BackerCard'
+import { getSummaryReport } from '../../../js/graphql/opencollective'
+import { getTagsLeaderboard } from '../../../js/graphql/pulse'
+import { FinancialReportType, TagsByUserType, TagsLeaderboardType } from '../../../js/types'
+import BackerCard from '../../../components/ui/BackerCard'
 
-interface HomePageType {
-  donationSummary: FinancialReportType
-  tagsLeaderboard: TagsLeaderboardType
-}
+export default async function Page (): Promise<JSX.Element> {
+  const donationSummary: FinancialReportType = await getSummaryReport()
+  const tagsLeaderboard: TagsLeaderboardType = await getTagsLeaderboard()
 
-/**
- *  Display key metrics and statistics
- */
-const Page: NextPage<HomePageType> = ({ donationSummary, tagsLeaderboard }) => {
   return (
     <>
-      <SeoTags
-        title='OpenBeta pulse'
-        description='Stats and activities'
-      />
-      <Layout
-        contentContainerClass='content-default bg-gradient-to-br from-cyan-600 to-sky-400 py-6'
-        showFilterBar={false}
-        showFooter
-      >
-        <div className='lg:columns-2 sm:mx-auto sm:block flex flex-col items-center'>
+      <div className='default-page-margins grid grid-cols-1 lg:grid-cols-2 sm:mx-auto'>
+        <div>
           <TagsSummary tagsLeaderboard={tagsLeaderboard} />
           <TagsLeaderboard tagsLeaderboard={tagsLeaderboard} />
+        </div>
+        <div>
           <FinancialReport donationSummary={donationSummary} />
         </div>
-      </Layout>
+      </div>
     </>
   )
 }
 
 const TagsSummary = ({ tagsLeaderboard }: TagsLeaderboardProps): JSX.Element => {
   return (
-    <Box className='bg-purple-400 mt-0 stats shadow p-0'>
+    <Box className='mt-4 max-w-md'>
       <div className='stat'>
         <div className='stat-title font-bold'>Photos with tags</div>
         <div className='stat-value'>
@@ -58,9 +44,9 @@ interface TagsLeaderboardProps {
 }
 const TagsLeaderboard = ({ tagsLeaderboard }: TagsLeaderboardProps): JSX.Element => {
   return (
-    <Box className='bg-purple-700'>
+    <Box className='max-w-md'>
       <h2>Tags Leaderboard</h2>
-      <div className='mt-4 grid grid-cols-6 gap-2 items-center'>
+      <div className='grid grid-cols-6 gap-2 items-center'>
         {tagsLeaderboard.allTime.byUsers.map(LeaderboardRow)}
       </div>
     </Box>
@@ -100,9 +86,9 @@ const FinancialReport: React.FC<FinancialReportProps> = ({ donationSummary }) =>
   const { totalRaised, donors } = donationSummary
 
   return (
-    <Box className='bg-accent bg-opacity-90 text-center'>
+    <Box className='text-center mt-4'>
       <h2>Donations</h2>
-      <p className='mt-4 text-sm'>This platform is supported by climbers like you.  Thanks to our financial backers we've raised ${totalRaised}.</p>
+      <p className='my-4 text-sm'>This platform is supported by climbers like you.  Thanks to our financial backers we've raised ${totalRaised}.</p>
       <div className='flex gap-2 xl:gap-4 flex-wrap items-center justify-center'>
         {donors.map(({ account }) =>
           <BackerCard key={account.id} name={account.name} imageUrl={account.imageUrl} />
@@ -113,24 +99,15 @@ const FinancialReport: React.FC<FinancialReportProps> = ({ donationSummary }) =>
   )
 }
 
-const Box: React.FC<{ className: string, children: ReactNode }> = ({ className, children }) => {
+const Box: React.FC<{ className?: string, children: ReactNode }> = ({ className, children }) => {
   return (
-    <section className={clz('break-inside-avoid-column break-inside-avoid relative block max-w-md  border-4 p-4 mb-4 border-black rounded-box', className)}>
+    <section
+      className={clz(
+        'break-inside-avoid-column break-inside-avoid relative block border-4 p-4 mb-4 border-black rounded-box',
+        className
+      )}
+    >
       {children}
     </section>
   )
 }
-
-export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const openCollectiveReport = await getSummaryReport()
-  const leaderboard = await getTagsLeaderboard()
-  return {
-    props: {
-      donationSummary: openCollectiveReport,
-      tagsLeaderboard: leaderboard
-    },
-    revalidate: 60
-  }
-}
-
-export default Page

--- a/src/app/(default)/pulse/page.tsx
+++ b/src/app/(default)/pulse/page.tsx
@@ -7,6 +7,9 @@ import { getTagsLeaderboard } from '@/js/graphql/pulse'
 import { FinancialReportType, TagsByUserType, TagsLeaderboardType } from '@/js/types'
 import BackerCard from '@/components/ui/BackerCard'
 
+/**
+ *  Display key metrics and statistics
+ */
 export default async function Page (): Promise<JSX.Element> {
   const donationSummary: FinancialReportType = await getSummaryReport()
   const tagsLeaderboard: TagsLeaderboardType = await getTagsLeaderboard()
@@ -28,7 +31,7 @@ export default async function Page (): Promise<JSX.Element> {
 
 const TagsSummary = ({ tagsLeaderboard }: TagsLeaderboardProps): JSX.Element => {
   return (
-    <Box className='mt-4'>
+    <Box className='mt-4 stats'>
       <div className='stat'>
         <div className='stat-title font-bold'>Photos with tags</div>
         <div className='stat-value'>

--- a/src/app/(default)/pulse/page.tsx
+++ b/src/app/(default)/pulse/page.tsx
@@ -2,10 +2,10 @@ import React, { ReactNode } from 'react'
 import Link from 'next/link'
 import clz from 'classnames'
 
-import { getSummaryReport } from '../../../js/graphql/opencollective'
-import { getTagsLeaderboard } from '../../../js/graphql/pulse'
-import { FinancialReportType, TagsByUserType, TagsLeaderboardType } from '../../../js/types'
-import BackerCard from '../../../components/ui/BackerCard'
+import { getSummaryReport } from '@/js/graphql/opencollective'
+import { getTagsLeaderboard } from '@/js/graphql/pulse'
+import { FinancialReportType, TagsByUserType, TagsLeaderboardType } from '@/js/types'
+import BackerCard from '@/components/ui/BackerCard'
 
 export default async function Page (): Promise<JSX.Element> {
   const donationSummary: FinancialReportType = await getSummaryReport()
@@ -13,12 +13,12 @@ export default async function Page (): Promise<JSX.Element> {
 
   return (
     <>
-      <div className='default-page-margins grid grid-cols-1 lg:grid-cols-2 sm:mx-auto'>
+      <div className='default-page-margins grid grid-cols-1 lg:grid-cols-3 gap-4'>
         <div>
           <TagsSummary tagsLeaderboard={tagsLeaderboard} />
           <TagsLeaderboard tagsLeaderboard={tagsLeaderboard} />
         </div>
-        <div>
+        <div className='lg:col-span-2'>
           <FinancialReport donationSummary={donationSummary} />
         </div>
       </div>
@@ -28,7 +28,7 @@ export default async function Page (): Promise<JSX.Element> {
 
 const TagsSummary = ({ tagsLeaderboard }: TagsLeaderboardProps): JSX.Element => {
   return (
-    <Box className='mt-4 max-w-md'>
+    <Box className='mt-4'>
       <div className='stat'>
         <div className='stat-title font-bold'>Photos with tags</div>
         <div className='stat-value'>
@@ -44,7 +44,7 @@ interface TagsLeaderboardProps {
 }
 const TagsLeaderboard = ({ tagsLeaderboard }: TagsLeaderboardProps): JSX.Element => {
   return (
-    <Box className='max-w-md'>
+    <Box className='mt-4'>
       <h2>Tags Leaderboard</h2>
       <div className='grid grid-cols-6 gap-2 items-center'>
         {tagsLeaderboard.allTime.byUsers.map(LeaderboardRow)}
@@ -86,7 +86,7 @@ const FinancialReport: React.FC<FinancialReportProps> = ({ donationSummary }) =>
   const { totalRaised, donors } = donationSummary
 
   return (
-    <Box className='text-center mt-4'>
+    <Box className='text-center mb-4 lg:mt-4'>
       <h2>Donations</h2>
       <p className='my-4 text-sm'>This platform is supported by climbers like you.  Thanks to our financial backers we've raised ${totalRaised}.</p>
       <div className='flex gap-2 xl:gap-4 flex-wrap items-center justify-center'>
@@ -103,7 +103,7 @@ const Box: React.FC<{ className?: string, children: ReactNode }> = ({ className,
   return (
     <section
       className={clz(
-        'break-inside-avoid-column break-inside-avoid relative block border-4 p-4 mb-4 border-black rounded-box',
+        'break-inside-avoid-column break-inside-avoid relative block border-4 p-4 border-black rounded-box',
         className
       )}
     >

--- a/src/components/SeoTags.tsx
+++ b/src/components/SeoTags.tsx
@@ -11,7 +11,7 @@ interface SEOProps {
 
 const siteMetadata = {
   title: 'OpenBeta',
-  description: 'Share your climbing adventure photos and contribute to the climbing route cataog.',
+  description: 'Share your climbing adventure photos and contribute to the climbing route catalog.',
   author: 'hello@openbeta.io',
   keywords: 'rock climbing wiki, climbing api, climbing beta, climbing guidebooks, openbeta, open data'
 }


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: Migrate pulse page to Next 13 #1276
labels: refactor/redesign
assignees: @mikeschen 

---

## What type of PR is this?(check all applicable)
- [x] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description
Migrate pulse page to Next 13
### Related Issues
https://github.com/OpenBeta/open-tacos/issues/1270
Issue #1276


### What this PR achieves

Pulse page (link at top of home page) goes to our depreciated Header and Layout from Next 12.
Update uses Next 13 routing and updates design to match our current site.

### Screenshots, recordings
**Before**
<img width="1386" alt="Screenshot 2025-02-19 at 11 48 46 AM" src="https://github.com/user-attachments/assets/a0c23d04-e921-401d-91cf-9d6e83f8c708" />
<img width="309" alt="Screenshot 2025-02-19 at 11 48 56 AM" src="https://github.com/user-attachments/assets/79591d48-2566-4c62-9ef2-1cccb483fd7d" />


**After**

![Screenshot 2025-02-19 at 11 47 52 AM](https://github.com/user-attachments/assets/6ec85d23-3dab-40f1-a958-cf2e9f7cb41a)
![Screenshot 2025-02-19 at 11 48 04 AM](https://github.com/user-attachments/assets/6bb243a8-1432-4d6e-bf70-e75982d93e44)


### Notes





