### PR TITLE
View tick button bug 1278

### DIFF
--- a/src/components/users/TickButton.tsx
+++ b/src/components/users/TickButton.tsx
@@ -35,8 +35,10 @@ export default function TickButton ({ climbId, areaId, name, grade, climbType }:
   const session = useSession()
 
   useEffect(() => {
-    getTicks()
-  }, [])
+    if (session.status === 'authenticated') {
+      getTicks()
+    }
+  }, [session.status])
 
   function getTicks (): void {
     const userId = session.data?.user.metadata.uuid ?? ''

--- a/src/components/users/TickForm.tsx
+++ b/src/components/users/TickForm.tsx
@@ -54,7 +54,8 @@ const allAttemptTypes = [
   { id: 4, name: 'Pinkpoint' },
   { id: 5, name: 'Send' },
   { id: 6, name: 'Attempt' },
-  { id: 7, name: 'Frenchfree' }
+  { id: 7, name: 'Frenchfree' },
+  { id: 8, name: 'Repeat' }
 ]
 
 function hasKey (climbType: object, myList: string[]): boolean { return Object.keys(climbType).some(key => myList.includes(key)) }
@@ -82,11 +83,11 @@ function attemptTypesForStyle (styleName: string): Array<{ id: number, name: str
   const emptyOption = { id: 10, name: '\u00A0' }
   switch (styleName) {
     case 'Lead':
-      return [...allAttemptTypes.filter(type => ['Onsight', 'Flash', 'Redpoint', 'Pinkpoint', 'Attempt', 'Frenchfree'].includes(type.name)), emptyOption]
+      return [...allAttemptTypes.filter(type => ['Onsight', 'Flash', 'Redpoint', 'Pinkpoint', 'Attempt', 'Frenchfree', 'Repeat'].includes(type.name)), emptyOption]
     case 'Solo':
-      return [...allAttemptTypes.filter(type => ['Onsight', 'Flash', 'Redpoint', 'Attempt'].includes(type.name)), emptyOption]
+      return [...allAttemptTypes.filter(type => ['Onsight', 'Flash', 'Redpoint', 'Attempt', 'Repeat'].includes(type.name)), emptyOption]
     case 'Boulder':
-      return [...allAttemptTypes.filter(type => ['Flash', 'Send', 'Attempt'].includes(type.name)), emptyOption]
+      return [...allAttemptTypes.filter(type => ['Flash', 'Send', 'Attempt', 'Repeat'].includes(type.name)), emptyOption]
     case 'TR':
     case 'Follow':
     case 'Aid':


### PR DESCRIPTION
## Fix Tick button race condition & add Repeat option for ticks
---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [X] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
There was a race condition when loading the climb page. the Tick button loaded before the session was 'authenticated', so even if a user had previously ticked a route, it would show the "Tick this climb" button instead of "View Ticks" most of the time.

I also combined this with the very simple request to add a Repeat option to ticks.

### Related Issues
https://github.com/OpenBeta/open-tacos/issues/1278. (view ticks button bug)
https://github.com/OpenBeta/open-tacos/issues/1277.  (repeat option feature request)
Issue #

Corresponding back-end change for "Repeat" option
https://github.com/OpenBeta/openbeta-graphql/pull/450

### What this PR achieves

It adds a check to see if the session is 'authenticated' before deciding which tick button to show, and adds a callback to re-run the tick button check when the session changes. It also just add 'Repeat' to the options for 'Attempt Type'


https://github.com/user-attachments/assets/36961296-dd2e-40ac-8a7b-74551c734a10

![Screenshot 2025-02-22 at 2 40 52 PM](https://github.com/user-attachments/assets/447c14ae-fb8a-4971-af4b-c12655a08b45)

