### PR TITLE
Photos with resolutions above 11MB are now auto compressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "awesome-debounce-promise": "^2.1.0",
     "axios": "^0.24.0",
     "classnames": "^2.3.1",
+    "compressorjs": "^1.2.1",
     "csvtojson": "^2.0.10",
     "daisyui": "^3.9.4",
     "date-fns": "^2.28.0",

--- a/src/js/hooks/usePhotoUploader.tsx
+++ b/src/js/hooks/usePhotoUploader.tsx
@@ -116,7 +116,7 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
   const compressImage = async (file: File | Blob): Promise<File | Blob> => {
     return await new Promise((resolve, reject) => {
       void new Compressor(file, {
-        quality: 0.6,
+        quality: 0.9,
         success: (compressedFile: File) => resolve(compressedFile),
         error: (err: Error) => reject(err)
       })

--- a/src/js/hooks/usePhotoUploader.tsx
+++ b/src/js/hooks/usePhotoUploader.tsx
@@ -117,8 +117,8 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
     return await new Promise((resolve, reject) => {
       void new Compressor(file, {
         quality: 0.6,
-        success: (compressedFile) => resolve(compressedFile),
-        error: (err) => reject(err)
+        success: (compressedFile: File) => resolve(compressedFile),
+        error: (err: Error) => reject(err)
       })
     })
   }
@@ -130,13 +130,16 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
     ref.current.hasErrors = false
     const processFile = async (file: File): Promise<void> => {
       try {
-        if (file.size > 11534336) {
+        if (file.size < 11534336) { // less than 11 MB, doesn't need to be compressed
+          const content = await readFile(file)
+          await onload(content, file)
+        } else if (file.size > 11534336 && file.size < 31457280) {
+          // greater than 11 MB and less than 30 MB, undergoes auto compression
           const compressedFile = await compressImage(file)
           const content = await readFile(compressedFile)
           await onload(content, compressedFile)
-        } else {
-          const content = await readFile(file)
-          await onload(content, file)
+        } else { // file size greater than 30 MB
+          ref.current.hasErrors = true
         }
       } catch (error) {
         console.error('Upload error:', error)

--- a/src/js/hooks/usePhotoUploader.tsx
+++ b/src/js/hooks/usePhotoUploader.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useDropzone, DropzoneInputProps, FileRejection } from 'react-dropzone'
 import { toast } from 'react-toastify'
 import { useSession } from 'next-auth/react'
+import Compressor from 'compressorjs'
 
 import { uploadPhoto, deleteMediaFromStorage } from '../userApi/media'
 import useMediaCmd, { invalidateAncestorPagesWithEntity } from './useMediaCmd'
@@ -23,7 +24,7 @@ interface PhotoUploaderReturnType {
   openFileDialog: () => void
 }
 
-async function readFile (file: File): Promise<ProgressEvent<FileReader>> {
+async function readFile (file: File | Blob): Promise<ProgressEvent<FileReader>> {
   return await new Promise((resolve, reject) => {
     const reader = new FileReader()
     reader.onabort = () => reject(new Error('file reading was aborted'))
@@ -56,7 +57,7 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
 
   /** When a file is loaded by the browser (as in, loaded from the local filesystem,
    * not loaded from a webserver) we can begin to upload the bytedata to the provider */
-  const onload = async (event: ProgressEvent<FileReader>, file: File): Promise<void> => {
+  const onload = async (event: ProgressEvent<FileReader>, file: File | Blob): Promise<void> => {
     if (event.target === null || event.target.result === null) return // guard this
 
     const userUuid = sessionData?.user.metadata.uuid
@@ -112,20 +113,37 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
     }
   }
 
+  const compressImage = async (file: File): Promise<File | Blob> => {
+    return await new Promise((resolve, reject) => {
+      void new Compressor(file, {
+        quality: 0.6,
+        success: (compressedFile) => resolve(compressedFile),
+        error: (err) => reject(err)
+      })
+    })
+  }
+
   const onDrop = async (files: File[], rejections: FileRejection[]): Promise<void> => {
     if (rejections.length > 0) { console.warn('Rejected files: ', rejections) }
 
     setUploading(true)
     ref.current.hasErrors = false
-    await Promise.all(files.map(async file => {
-      if (file.size > 11534336) {
-        toast.warn('¡Ay, caramba! one of your photos is too cruxy (please reduce the size to 11MB or under)')
-        return true
+    const processFile = async (file: File): Promise<void> => {
+      try {
+        if (file.size > 11534336) {
+          const compressedFile = await compressImage(file)
+          const content = await readFile(compressedFile)
+          await onload(content, compressedFile)
+        } else {
+          const content = await readFile(file)
+          await onload(content, file)
+        }
+      } catch (error) {
+        console.error('Upload error:', error)
       }
-      const content = await readFile(file)
-      await onload(content, file)
-      return true
-    }))
+    }
+
+    await Promise.all(files.map(async file => await processFile(file)))
 
     setUploading(false)
 

--- a/src/js/hooks/usePhotoUploader.tsx
+++ b/src/js/hooks/usePhotoUploader.tsx
@@ -135,12 +135,13 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
       try {
         let processedFile = file
 
-        if (file.size >= SIZE_LIMIT && file.size < COMPRESSION_THRESHOLD) {
-          processedFile = await compressImage(file)
-        } else if (file.size >= COMPRESSION_THRESHOLD) {
+        if (file.size >= COMPRESSION_THRESHOLD) {
           toast.warn('¡Ay, caramba! one of your photos is too cruxy (please reduce the size to 30MB or under)')
           ref.current.hasErrors = true
           return
+        }
+        if (file.size >= SIZE_LIMIT) {
+          processedFile = await compressImage(file)
         }
 
         const content = await readFile(processedFile)

--- a/src/js/hooks/usePhotoUploader.tsx
+++ b/src/js/hooks/usePhotoUploader.tsx
@@ -113,7 +113,7 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
     }
   }
 
-  const compressImage = async (file: File): Promise<File | Blob> => {
+  const compressImage = async (file: File | Blob): Promise<File | Blob> => {
     return await new Promise((resolve, reject) => {
       void new Compressor(file, {
         quality: 0.6,
@@ -128,20 +128,26 @@ export default function usePhotoUploader ({ tagType, uuid, isProfilePhoto = fals
 
     setUploading(true)
     ref.current.hasErrors = false
-    const processFile = async (file: File): Promise<void> => {
+    const SIZE_LIMIT = 11 * 1024 * 1024 // 11 MB
+    const COMPRESSION_THRESHOLD = 30 * 1024 * 1024 // 30 MB
+
+    const processFile = async (file: File | Blob): Promise<void> => {
       try {
-        if (file.size < 11534336) { // less than 11 MB, doesn't need to be compressed
-          const content = await readFile(file)
-          await onload(content, file)
-        } else if (file.size > 11534336 && file.size < 31457280) {
-          // greater than 11 MB and less than 30 MB, undergoes auto compression
-          const compressedFile = await compressImage(file)
-          const content = await readFile(compressedFile)
-          await onload(content, compressedFile)
-        } else { // file size greater than 30 MB
+        let processedFile = file
+
+        if (file.size >= SIZE_LIMIT && file.size < COMPRESSION_THRESHOLD) {
+          processedFile = await compressImage(file)
+        } else if (file.size >= COMPRESSION_THRESHOLD) {
+          toast.warn('¡Ay, caramba! one of your photos is too cruxy (please reduce the size to 30MB or under)')
           ref.current.hasErrors = true
+          return
         }
+
+        const content = await readFile(processedFile)
+
+        await onload(content, processedFile)
       } catch (error) {
+        ref.current.hasErrors = true
         console.error('Upload error:', error)
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,6 +3397,11 @@ bluebird@^3.5.1:
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+blueimp-canvas-to-blob@^3.29.0:
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.29.0.tgz#d965f06cb1a67fdae207a2be56683f55ef531466"
+  integrity sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg==
+
 boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
@@ -3650,6 +3655,14 @@ commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+compressorjs@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/compressorjs/-/compressorjs-1.2.1.tgz#4dee18ef5032f8166bd0a3258f045eda2cd07671"
+  integrity sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==
+  dependencies:
+    blueimp-canvas-to-blob "^3.29.0"
+    is-blob "^2.1.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -5396,6 +5409,11 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-blob@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-blob/-/is-blob-2.1.0.tgz#e36cd82c90653f1e1b930f11baf9c64216a05385"
+  integrity sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==
 
 is-boolean-object@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION


## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description
There is a notification for users when they upload images of size more than 11 MB, to try again. 

### Related Issues

Issue #1267


### What this PR achieves

It uses Compressor JS to auto-compress the images that are larger in size. 


### Screenshots, recordings

### Notes

