### PR TITLE
Edit area flickering due to redirect

### DIFF
--- a/src/app/(default)/components/AreaAndClimbPageActions.tsx
+++ b/src/app/(default)/components/AreaAndClimbPageActions.tsx
@@ -18,7 +18,7 @@ export const AreaAndClimbPageActions: React.FC<{ uuid: string, name: string, tar
   let navigateUuid = ''
   switch (targetType) {
     case TagTargetType.area:
-      url = `/editArea/${uuid}`
+      url = `/editArea/${uuid}/general`
       sharePath = `/area/${uuid}`
       navigateUuid = uuid
       break
@@ -31,7 +31,7 @@ export const AreaAndClimbPageActions: React.FC<{ uuid: string, name: string, tar
   }
   return (
     <ul className='flex items-center justify-between gap-2'>
-      <Link href={url} target='_new' className={clz('btn no-animation shadow-md', enableEdit ? 'btn-solid btn-accent' : 'btn-disabled')}>
+      <Link href={url} className={clz('btn no-animation shadow-md', enableEdit ? 'btn-solid btn-accent' : 'btn-disabled')}>
         <PencilSimple size={20} weight='duotone' /> {editLabel}
       </Link>
 

--- a/src/app/(default)/editArea/[slug]/general/components/AreaItem.tsx
+++ b/src/app/(default)/editArea/[slug]/general/components/AreaItem.tsx
@@ -44,7 +44,7 @@ export const AreaItem: React.FC<{
   // undefined array can mean we forget to include the field in GQL so let's make it not editable
   const canDelete = (children?.length ?? 1) === 0 && (climbs?.length ?? 1) === 0
 
-  const url = editMode ? `/editArea/${uuid}` : `/area/${uuid}/${getFriendlySlug(areaName)}`
+  const url = editMode ? `/editArea/${uuid}/general` : `/area/${uuid}/${getFriendlySlug(areaName)}`
   return (
     <div className='break-inside-avoid-column break-inside-avoid pb-8'>
       <Link href={url} className='block hover:outline hover:outline-1 hover:rounded-box'>
@@ -89,7 +89,7 @@ const Actions: React.FC<{
 }> = ({ uuid, parentUuid, areaName, canDelete = false }) => {
   return (
     <div className='flex items-center divide-x'>
-      <Link className='px-4' href={`/editArea/${uuid}`}>
+      <Link className='px-4' href={`/editArea/${uuid}/general`}>
         <button className='btn btn-link btn-primary btn-sm text-secondary font-semibold'>Edit</button>
       </Link>
       <Link className='px-4' href={`/area/${uuid}`} target='_new'>

--- a/src/components/breadcrumbs/AreaCrumbs.tsx
+++ b/src/components/breadcrumbs/AreaCrumbs.tsx
@@ -57,5 +57,5 @@ const AreaItem = forwardRef<any, AreaItemProps>((props, ref) => {
 })
 
 export const makeUrl = (editMode: boolean, uuid: string, path: string): string => {
-  return editMode ? `/editArea/${uuid}` : getAreaPageFriendlyUrl(uuid, path)
+  return editMode ? `/editArea/${uuid}/general` : getAreaPageFriendlyUrl(uuid, path)
 }


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: Edit area flickering due to redirect
labels: bug
assignees: Greg Hart

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

Per related issue, navigating to edit area page results in flickering due to a double load of data from a redirect. 

### Related Issues

Issue #1294

### What this PR achieves

This PR changes links from `/editArea/{uuid}` to `/editArea/{uuid}/general` to immediately get user to the right spot without an intermediate redirect.

### Screenshots, recordings

![image](https://github.com/user-attachments/assets/4e2bc9db-9abc-4304-8337-2a5a28006109)

Showing screenshots, no flickering or second load of data.

### Notes

I also removed a `target='_new'` -- due to the original issue, this wasn't opening in a new window _anyways_, so this keeps behavior the same (and also more consistent with most links in UI)




