### PR TITLE
 Show updated profile toast after user updates her profile

### DIFF
--- a/src/components/users/account/UpdateProfileForm.tsx
+++ b/src/components/users/account/UpdateProfileForm.tsx
@@ -76,7 +76,7 @@ export const UpdateProfileForm: React.FC = () => {
     const successful = await updatePublicProfileCmd({ userUuid, displayName, bio, website })
     if (successful) {
       reset({ displayName, bio, website })
-      toast.info('Username updated')
+      toast.info('Profile updated')
     } else {
       toast.error('Unexpected error.  Please try again.')
     }


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title:  Show updated profile toast after user updates her profile
labels: enhancement
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description
 Show "profile updated" toast after user updates her profile
### Related Issues

Issue #762 


### What this PR achieves

 Show "profile updated" toast after user updates her profile information (prev. said "username updated")

### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->
![Screenshot 2025-03-05 at 3 40 23 PM](https://github.com/user-attachments/assets/b4a2324f-7621-4a43-8309-863a358e9506)




### Notes
<!--Anything in particular you want the reviewer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




