### PR TITLE
fix: base64 encode GC private key

### DIFF
--- a/src/js/media/storageClient.ts
+++ b/src/js/media/storageClient.ts
@@ -6,7 +6,7 @@ import { Storage, GetSignedUrlConfig } from '@google-cloud/storage'
 const storage = new Storage({
   credentials: {
     type: 'service_account',
-    private_key: process.env.GC_BUCKET_PRIVATE_KEY ?? '',
+    private_key: atob(process.env.GC_BUCKET_PRIVATE_KEY ?? ''),
     client_email: process.env.GC_BUCKET_CLIENT_EMAIL ?? ''
   }
 })

--- a/src/js/media/storageClient.ts
+++ b/src/js/media/storageClient.ts
@@ -6,7 +6,7 @@ import { Storage, GetSignedUrlConfig } from '@google-cloud/storage'
 const storage = new Storage({
   credentials: {
     type: 'service_account',
-    private_key: atob(process.env.GC_BUCKET_PRIVATE_KEY ?? ''),
+    private_key: Buffer.from(process.env.GC_BUCKET_PRIVATE_KEY ?? '', 'base64').toString('utf-8'),
     client_email: process.env.GC_BUCKET_CLIENT_EMAIL ?? ''
   }
 })


### PR DESCRIPTION
## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #1300 


### What this PR achieves
GC private key is multi-line string (.pem file) and stored in an env variable.  In the new self-hosted deployment we store this value in a GH action env var.  This PR switches this value to Bae64 encode.



