### PR TITLE
Ask users to type 'delete' before deleting a climb

### DIFF
--- a/src/app/(default)/editArea/[slug]/manageClimbs/components/ClimbListMiniToolbar.tsx
+++ b/src/app/(default)/editArea/[slug]/manageClimbs/components/ClimbListMiniToolbar.tsx
@@ -7,6 +7,9 @@ import DeleteAreaAndClimbForm from '@/components/edit/DeleteAreaAndClimbForm'
 
 export const ClimbListMiniToolbar: React.FC<{ parentAreaId: string, climbId: string, climbName: string }> = ({ parentAreaId, climbId, climbName }) => {
   const [isOpen, setOpen] = useState(false)
+  const onSuccessHandler = (): void => {
+    setOpen(false)
+  }
 
   return (
     <div className='flex justify-end mb-2 py-1'>
@@ -23,6 +26,7 @@ export const ClimbListMiniToolbar: React.FC<{ parentAreaId: string, climbId: str
             uuid={climbId}
             parentUuid={parentAreaId}
             isClimb
+            onSuccess={onSuccessHandler}
           />
         </DialogContent>
       </MobileDialog>

--- a/src/app/(default)/editArea/[slug]/manageClimbs/components/ClimbListMiniToolbar.tsx
+++ b/src/app/(default)/editArea/[slug]/manageClimbs/components/ClimbListMiniToolbar.tsx
@@ -1,35 +1,31 @@
 'use client'
-import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import { Trash } from '@phosphor-icons/react/dist/ssr'
-import useUpdateClimbsCmd from '@/js/hooks/useUpdateClimbsCmd'
-import Confirmation from '@/components/ui/micro/AlertDialogue'
+
+import { MobileDialog, DialogContent, DialogTrigger } from '@/components/ui/MobileDialog'
+import DeleteAreaAndClimbForm from '@/components/edit/DeleteAreaAndClimbForm'
 
 export const ClimbListMiniToolbar: React.FC<{ parentAreaId: string, climbId: string, climbName: string }> = ({ parentAreaId, climbId, climbName }) => {
-  const session = useSession({ required: true })
-  const router = useRouter()
-  const { deleteClimbsCmd } = useUpdateClimbsCmd({ parentId: parentAreaId, accessToken: session.data?.accessToken ?? '' })
-  const onConfirm = (): void => {
-    deleteClimbsCmd([climbId]).then((count) => {
-      router.refresh()
-    }).catch((error) => {
-      console.error(error)
-    })
-  }
+  const [isOpen, setOpen] = useState(false)
+
   return (
     <div className='flex justify-end mb-2 py-1'>
-      <Confirmation
-        title='Please confirm'
-        confirmText='Delete'
-        button={
-          <button className='btn btn-xs btn-glass'>
-            <Trash size={16} /> Delete
-          </button>
-        }
-        onConfirm={onConfirm}
-      >
-        You're about to delete climb "<i>{climbName}"</i>. <strong>This cannot be undone.</strong>
-      </Confirmation>
+      <MobileDialog modal open={isOpen} onOpenChange={setOpen}>
+        <DialogTrigger
+          className='btn btn-xs btn-glass'
+          type='button'
+        >
+          <Trash size={16} />Delete
+        </DialogTrigger>
+        <DialogContent title='Delete climb'>
+          <DeleteAreaAndClimbForm
+            name={climbName}
+            uuid={climbId}
+            parentUuid={parentAreaId}
+            isClimb
+          />
+        </DialogContent>
+      </MobileDialog>
     </div>
   )
 }

--- a/src/components/edit/DeleteAreaAndClimbForm.tsx
+++ b/src/components/edit/DeleteAreaAndClimbForm.tsx
@@ -7,11 +7,14 @@ import { GraphQLError } from 'graphql'
 import { signIn, useSession } from 'next-auth/react'
 import useUpdateAreasCmd from '../../js/hooks/useUpdateAreasCmd'
 import Input from '../ui/form/Input'
-export interface DeleteAreaProps {
+import useUpdateClimbsCmd from '@/js/hooks/useUpdateClimbsCmd'
+
+export interface DeleteProps {
   parentUuid: string
-  areaUuid: string
-  areaName: string
+  uuid: string
+  name: string
   returnToParentPageAfterDelete?: boolean
+  isClimb?: boolean
   onSuccess?: () => void
   onError?: (error: GraphQLError) => void
 }
@@ -19,16 +22,15 @@ export interface DeleteAreaProps {
 interface HtmlFormProps {
   confirmation: string
 }
-
 /**
- * Delete area dialog.  Users must be authenticated.
- * @param areaUuid ID of deleting area
- * @param areaName Name of deleting area
+ * Delete area/climb dialog.  Users must be authenticated.
+ * @param uuid ID of deleting area/climb
+ * @param name Name of deleting area/climb
  * @param parentUuid ID of parent area (for redirection and revalidating SSG page purpose)
  * @param returnToParentPageAfterDelete true to be redirected to parent area page
  * @param onSuccess Optional callback
  */
-export default function DeleteAreaForm ({ areaUuid, areaName, parentUuid, returnToParentPageAfterDelete = false, onSuccess }: DeleteAreaProps): JSX.Element {
+export default function DeleteAreaAndClimbForm ({ uuid, name, parentUuid, returnToParentPageAfterDelete = false, isClimb = false, onSuccess }: DeleteProps): JSX.Element {
   const session = useSession()
   const router = useRouter()
 
@@ -48,6 +50,12 @@ export default function DeleteAreaForm ({ areaUuid, areaName, parentUuid, return
     }
   }
 
+  const { deleteClimbsCmd } = useUpdateClimbsCmd({
+    parentId: parentUuid,
+    accessToken: session.data?.accessToken as string ?? '',
+    onDeleteCompleted: () => router.refresh()
+  })
+
   const { deleteOneAreaCmd } = useUpdateAreasCmd({
     areaId: parentUuid,
     accessToken: session?.data?.accessToken as string ?? '',
@@ -64,7 +72,15 @@ export default function DeleteAreaForm ({ areaUuid, areaName, parentUuid, return
   const { handleSubmit, setFocus, formState: { isSubmitting } } = form
 
   const submitHandler = async (): Promise<void> => {
-    await deleteOneAreaCmd({ uuid: areaUuid })
+    try {
+      if (isClimb) {
+        await deleteClimbsCmd([uuid])
+      } else {
+        await deleteOneAreaCmd({ uuid })
+      }
+    } catch (error) {
+      console.error('Error deleting climb/area:', error)
+    }
   }
 
   if (session.status !== 'authenticated') {
@@ -81,7 +97,7 @@ export default function DeleteAreaForm ({ areaUuid, areaName, parentUuid, return
     <FormProvider {...form}>
       {/* eslint-disable-next-line */}
       <form onSubmit={handleSubmit(submitHandler)} className='dialog-form-default'>
-        <div>You're about to delete '<span className='font-semibold'>{areaName}</span>'.  Type <b>DELETE</b> to confirm.</div>
+        <div>You're about to delete '<span className='font-semibold'>{name}</span>'.  Type <b>DELETE</b> to confirm.</div>
         <Input
           label=''
           name='confirmation'

--- a/src/components/edit/DeleteAreaAndClimbForm.tsx
+++ b/src/components/edit/DeleteAreaAndClimbForm.tsx
@@ -2,14 +2,13 @@
 import { useEffect } from 'react'
 import { useForm, FormProvider } from 'react-hook-form'
 import { useRouter } from 'next/navigation'
-import clx from 'classnames'
 import { GraphQLError } from 'graphql'
 import { signIn, useSession } from 'next-auth/react'
 import useUpdateAreasCmd from '../../js/hooks/useUpdateAreasCmd'
 import Input from '../ui/form/Input'
 import useUpdateClimbsCmd from '@/js/hooks/useUpdateClimbsCmd'
 
-export interface DeleteProps {
+interface DeleteFormProps {
   parentUuid: string
   uuid: string
   name: string
@@ -30,7 +29,7 @@ interface HtmlFormProps {
  * @param returnToParentPageAfterDelete true to be redirected to parent area page
  * @param onSuccess Optional callback
  */
-export default function DeleteAreaAndClimbForm ({ uuid, name, parentUuid, returnToParentPageAfterDelete = false, isClimb = false, onSuccess }: DeleteProps): JSX.Element {
+export default function DeleteAreaAndClimbForm ({ uuid, name, parentUuid, returnToParentPageAfterDelete = false, isClimb = false, onSuccess }: DeleteFormProps): JSX.Element {
   const session = useSession()
   const router = useRouter()
 
@@ -53,7 +52,7 @@ export default function DeleteAreaAndClimbForm ({ uuid, name, parentUuid, return
   const { deleteClimbsCmd } = useUpdateClimbsCmd({
     parentId: parentUuid,
     accessToken: session.data?.accessToken as string ?? '',
-    onDeleteCompleted: () => router.refresh()
+    onDeleteCompleted: onSuccessHandler
   })
 
   const { deleteOneAreaCmd } = useUpdateAreasCmd({
@@ -114,13 +113,10 @@ export default function DeleteAreaAndClimbForm ({ uuid, name, parentUuid, return
           className='input input-primary input-bordered input-md'
         />
         <button
-          className={
-            clx('mt-4 btn btn-primary w-full',
-              isSubmitting ? 'loading btn-disabled' : ''
-            )
-          }
+          className='mt-4 btn btn-primary w-full'
+          disabled={isSubmitting}
           type='submit'
-        >Delete
+        >{isSubmitting ? 'Deleting...' : 'Delete'}
         </button>
       </form>
     </FormProvider>

--- a/src/components/edit/Triggers.tsx
+++ b/src/components/edit/Triggers.tsx
@@ -1,16 +1,24 @@
 'use client'
 import { useState, useCallback } from 'react'
+import { GraphQLError } from 'graphql'
 import { Trash } from '@phosphor-icons/react/dist/ssr'
 import { PlusIcon, PlusCircleIcon } from '@heroicons/react/20/solid'
 import { MobileDialog, DialogContent, DialogTrigger } from '../ui/MobileDialog'
-import DeleteAreaForm, { DeleteAreaProps } from './DeleteAreaForm'
+import DeleteAreaAndClimbForm from './DeleteAreaAndClimbForm'
 import AddAreaForm, { AddAreaFormProps } from './AddChildAreaForm'
 import { toast } from 'react-toastify'
 import Tooltip from '../ui/Tooltip'
 
-export type DeleteAreaTriggerProps = DeleteAreaProps & {
+export interface DeleteAreaTriggerProps {
+  parentUuid: string
+  areaUuid: string
+  areaName: string
+  returnToParentPageAfterDelete?: boolean
+  onSuccess?: () => void
+  onError?: (error: GraphQLError) => void
   disabled?: boolean
-  children?: JSX.Element }
+  children?: JSX.Element
+}
 
 /**
  * A high level component that triggers the Delete Area dialog.  You can pass an optional nested component to customize the look and feel of the trigger button.
@@ -38,9 +46,9 @@ export const DeleteAreaTrigger = ({ areaName, areaUuid, parentUuid, disabled = f
         ? <DeleteAreaTriggerButtonDefault disabled={disabled} />
         : children}
       <DialogContent title='Delete area'>
-        <DeleteAreaForm
-          areaName={areaName}
-          areaUuid={areaUuid}
+        <DeleteAreaAndClimbForm
+          name={areaName}
+          uuid={areaUuid}
           parentUuid={parentUuid}
           onSuccess={onSuccessHandler}
           returnToParentPageAfterDelete={returnToParentPageAfterDelete}

--- a/src/components/edit/Triggers.tsx
+++ b/src/components/edit/Triggers.tsx
@@ -9,7 +9,7 @@ import AddAreaForm, { AddAreaFormProps } from './AddChildAreaForm'
 import { toast } from 'react-toastify'
 import Tooltip from '../ui/Tooltip'
 
-export interface DeleteAreaTriggerProps {
+interface DeleteAreaTriggerProps {
   parentUuid: string
   areaUuid: string
   areaName: string

--- a/src/js/hooks/useUpdateClimbsCmd.tsx
+++ b/src/js/hooks/useUpdateClimbsCmd.tsx
@@ -30,7 +30,7 @@ interface UpdateClimbsHookReturn {
  */
 export default function useUpdateClimbsCmd ({ parentId, accessToken = '', onUpdateCompleted, onUpdateError, onDeleteCompleted, onDeleteError }: UpdateClimbsHookProps): UpdateClimbsHookReturn {
   /**
-   * Add/Update Clims API
+   * Add/Update Climbs API
    */
   const [updateClimbsApi] = useMutation<{ updateClimbs: string[] }, { input: UpdateClimbsInput }>(
     MUTATION_UPDATE_CLIMBS, {


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: Ask users to type 'delete' before deleting a climb
labels: improvement
assignees: @mikeschen 

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description
Ask users to type 'delete' before deleting a climb, similiar to the way we do Delete for areas.
### Related Issues

Issue #1312 


### What this PR achieves

Ask users to type 'delete' before deleting a climb, similiar to the way we do Delete for areas.
- Choose a climb
- Choose a crag or boulder with climbs and Edit.
- Scroll to bottom and click Manage Climbs
- Delete a climb

### Screenshots, recordings

![delete](https://github.com/user-attachments/assets/f4916877-5790-4281-9ce7-a5128fee08ca)
![deleteclimb](https://github.com/user-attachments/assets/1b9f197b-9ba1-492c-a5e9-e5d5e3e213f1)

### Notes
Delete button updated for loading, before it showed two glitchy loading images.




