### PR TITLE
chore(docs): add Quinault to contributors map

### DIFF
--- a/src/assets/contributors-map.geojson
+++ b/src/assets/contributors-map.geojson
@@ -255,6 +255,21 @@
           39.7243542
         ]
       }
+    }, 
+    {
+      "type": "Feature",
+      "properties": { 
+        "firstName": "Quinault",
+        "githubId": "quinaltdelete",
+        "favoriteCrag": "f9eeab04-e846-526b-911f-efd7ae2124dc"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.570223,
+          37.314980 
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: 'chore(docs): add Quinault to contributors map'
labels: 'documentation'
assignees: 'actuallyyun'

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ X] documentation
- [ ] optimization
- [ ] other

## Description
Added myself to `src/assets/contributors-map.geojson` as part of the OpenBeta contributor challenge 1.

### Related Issues

Issue #


### What this PR achieves
Adds a new entry to the contributors map.

<!---Briefly explains what this PR does.
-->


### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->




### Notes
<!--Anything in particular you want the reviewer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->
Everything tested clean locally. Skipped Husky pre-commit hook due to 502 issue during export.




