### PR TITLE
fix: Redirect climbs/:uuid/name to climb/:uuid/name

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -66,13 +66,13 @@ module.exports = {
         permanent: true
       },
       {
-        source: '/areas/:uuid',
-        destination: '/area/:uuid/',
+        source: '/areas/:uuid*',
+        destination: '/area/:uuid*',
         permanent: true
       },
       {
-        source: '/climbs/:uuid',
-        destination: '/climb/:uuid/',
+        source: '/climbs/:uuid*',
+        destination: '/climb/:uuid*',
         permanent: true
       },
       {


### PR DESCRIPTION
PR #1341 redirected /climbs/:uuid to /climb/:uuid.  It did not handle redirecting links with a name appended.
This patch does that, and the same for areas.

Fixes #1337


## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other
