### PR TITLE
Exclude certain fields from landing page under Recent Contributions

### DIFF
--- a/src/components/edit/RecentChangeHistory.tsx
+++ b/src/components/edit/RecentChangeHistory.tsx
@@ -23,14 +23,14 @@ export default function RecentChangeHistory ({ history }: RecentChangeHistoryPro
   )
 }
 
-interface ChangsetRowProps {
+interface ChangesetRowProps {
   changeset: ChangesetType
 }
 
 /**
  * A card showing individual changeset
  */
-export const ChangesetCard: React.FC<ChangsetRowProps> = ({ changeset }) => {
+export const ChangesetCard: React.FC<ChangesetRowProps> = ({ changeset }) => {
   const { createdAt, editedByUser, operation, changes } = changeset
 
   // @ts-expect-error
@@ -89,7 +89,7 @@ const Header: React.FC<{ userId?: string, opStr: string, createdAt: number }> = 
   )
 }
 
-const ClimbChange = ({ changeId, fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
+const ClimbChange = ({ fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
   if (fullDocument.__typename !== DocumentTypeName.Climb) {
     return null
   }
@@ -122,7 +122,7 @@ const ClimbChange = ({ changeId, fullDocument, updateDescription, dbOp }: Change
   )
 }
 
-const AreaChange = ({ changeId, fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
+const AreaChange = ({ fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
   if (fullDocument.__typename !== DocumentTypeName.Area) {
     return null
   }
@@ -148,7 +148,7 @@ const AreaChange = ({ changeId, fullDocument, updateDescription, dbOp }: ChangeT
   )
 }
 
-const OrganizationChange = ({ changeId, fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
+const OrganizationChange = ({ fullDocument, updateDescription, dbOp }: ChangeType): JSX.Element | null => {
   if (fullDocument.__typename !== DocumentTypeName.Organization) {
     return null
   }


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: Exclude certain fields from landing page under Latest Contributions
labels: ''
assignees: @mikeschen 

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [ ] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description
Exclude certain fields from landing page under Latest Contributions
### Related Issues

Issue #1339 


### What this PR achieves
Exclude certain fields from landing page under Latest Contributions


### Screenshots, recordings
Before:
<img width="487" height="502" alt="Screenshot 2025-07-16 at 9 47 29 AM" src="https://github.com/user-attachments/assets/d3051f8b-5d8c-4e90-8434-253875ecf454" />
After:

<img width="375" height="451" alt="Screenshot 2025-07-16 at 10 00 39 AM" src="https://github.com/user-attachments/assets/93fd2107-4c68-4bc7-8a19-c22c0637bac6" />

### Notes
<!--Anything in particular you want the reviewer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




