### PR TITLE
update scopes for mobile endpoints

### DIFF
--- a/src/app/api/mobile/login/route.ts
+++ b/src/app/api/mobile/login/route.ts
@@ -18,7 +18,8 @@ async function postHandler (request: NextRequest): Promise<NextResponse> {
       console.error('Empty username/password!')
       throw new Error('Invalid payload')
     }
-  } catch (error) {
+  } catch (err) {
+    console.error('POST /login error:', err)
     return NextResponse.json({ error: 'Unexpected error' }, { status: 400 })
   }
 
@@ -27,7 +28,7 @@ async function postHandler (request: NextRequest): Promise<NextResponse> {
     response = await auth0Client.oauth.passwordGrant({
       username,
       password,
-      scope: 'openid profile email offline_access',
+      scope: 'offline_access access_token_authz openid email profile read:current_user create:current_user_metadata update:current_user_metadata read:stats update:area_attrs',
       audience: 'https://api.openbeta.io',
       realm: 'Username-Password-Authentication'
     })

--- a/src/app/api/mobile/refreshToken/route.ts
+++ b/src/app/api/mobile/refreshToken/route.ts
@@ -28,6 +28,7 @@ async function postHandler (request: NextRequest): Promise<any> {
   try {
     response = await auth0Client.oauth.refreshTokenGrant({
       refresh_token: refreshToken,
+      scope: 'offline_access access_token_authz openid email profile read:current_user create:current_user_metadata update:current_user_metadata read:stats update:area_attrs',
       audience: 'https://api.openbeta.io'
     })
 


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: @mikeschen 

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description
# Mobile Auth Changes Summary

## Problem Identified
Mobile auth endpoints were generating tokens with insufficient scopes, causing 401 Unauthorized errors when attempting mutations.

## Root Cause
**Scope mismatch** between mobile and web authentication:

**Mobile Auth (Insufficient):**
```typescript
scope: 'openid profile email offline_access'
```

**Web Auth (Complete):**
```typescript
scope: 'offline_access access_token_authz openid email profile read:current_user create:current_user_metadata update:current_user_metadata read:stats update:area_attrs'
```

## Changes Made

### 1. **Updated Mobile Login Endpoint**
**File:** `src/app/api/mobile/login/route.ts`
- **Line 28:** Updated `passwordGrant` scope parameter
- **Before:** `'openid profile email offline_access'`
- **After:** `'offline_access access_token_authz openid email profile read:current_user create:current_user_metadata update:current_user_metadata read:stats update:area_attrs'`

### 2. **Updated Mobile Refresh Token Endpoint**
**File:** `src/app/api/mobile/refreshToken/route.ts`
- **Line 29:** Added scope parameter to `refreshTokenGrant`
- **Added:** `scope: 'offline_access access_token_authz openid email profile read:current_user create:current_user_metadata update:current_user_metadata read:stats update:area_attrs'`

### 3. **Fixed Linter Warning**
**File:** `src/app/api/mobile/login/route.ts`
- **Line 21:** Changed `catch (error)` to `catch (err)` and added error logging

## Missing Scopes That Were Added
- `access_token_authz` - API authorization
- `read:current_user` - User data access
- `create:current_user_metadata` - Create user metadata
- `update:current_user_metadata` - Update user metadata
- `read:stats` - Statistics access
- `update:area_attrs` - Area attribute updates

## Result
Mobile auth endpoints now generate tokens with the same permissions as web authentication, resolving 401 Unauthorized errors for mutations.
### Related Issues

Issue # 480 https://github.com/OpenBeta/openbeta-graphql/issues/480


### What this PR achieves

<!---Briefly explains what this PR does.
-->


### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->




### Notes
<!--Anything in particular you want the reviewer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->




