### PR TITLE
Fix: prevent duplicate ticks across year boundary in heatmap (#1247)

### DIFF
--- a/src/components/logbook/ActivityHeat.tsx
+++ b/src/components/logbook/ActivityHeat.tsx
@@ -184,7 +184,7 @@ export default ActivityHeat
 
 const getYearFromTick = (tick: TickType): number => new Date(tick.dateClimbed).getFullYear()
 
-const getWeekNumberFromTick = (tick: TickType): number => getWeek(tick.dateClimbed)
+const getWeekNumberFromTick = (tick: TickType): number => getWeek(tick.dateClimbed, { weekStartsOn: 1 })
 
 const getDayOfWeekFromTick = (tick: TickType): number => (new Date(tick.dateClimbed)).getDay()
 


### PR DESCRIPTION
Closes #1247

### Problem Description

The calendar heatmap on the user dashboard was displaying duplicate ticks for dates occurring in the first week of a year. For example, a tick from January 2nd would incorrectly reappear at the end of the year's heatmap.

### Solution

This issue was caused by an inconsistency in how week numbers were being calculated within the `ActivityHeat.tsx` component.

The `getWeekNumberFromTick` helper function was not using the same `weekStartsOn: 1` option as the rest of the component, leading to a mismatch. This PR corrects the issue by adding the `{ weekStartsOn: 1 }` option to the `getWeek` call in that function. This ensures week calculations are consistent and resolves the duplication bug.

### Testing
- Verified with a tick on `01/02/2024` that it now appears **only once** in the January week and no longer gets duplicated at the end of the year.
- Other ticks in mid-year dates continue to render correctly.