### PR TITLE
fix: Decode HTML entities in climb and area names

### DIFF
--- a/src/app/(default)/area/[[...slug]]/page.tsx
+++ b/src/app/(default)/area/[[...slug]]/page.tsx
@@ -9,7 +9,7 @@ import { getAreaRSC } from '@/js/graphql/getAreaRSC'
 import { StickyHeaderContainer } from '@/app/(default)/components/ui/StickyHeaderContainer'
 import { AreaCrumbs } from '@/components/breadcrumbs/AreaCrumbs'
 import { ArticleLastUpdate } from '@/components/edit/ArticleLastUpdate'
-import { getMapHref, getFriendlySlug, getAreaPageFriendlyUrl, sanitizeName, parseUuidAsFirstParam } from '@/js/utils'
+import { getMapHref, getFriendlySlug, getAreaPageFriendlyUrl, sanitizeName, parseUuidAsFirstParam, safeDecode } from '@/js/utils'
 import { LazyAreaMap } from '@/components/maps/AreaMap'
 import { DefaultPageContainer } from '@/app/(default)/components/ui/DefaultPageContainer'
 import { AreaAndClimbPageActions } from '../../components/AreaAndClimb/AreaAndClimbPageActions'
@@ -56,7 +56,7 @@ export default async function Page ({ params }: PageWithCatchAllUuidProps): Prom
           ? <UploadPhotoCTA />
           : <PhotoMontage photoList={photoList} />
       }
-      pageActions={<AreaAndClimbPageActions name={areaName} uuid={uuid} targetType={TagTargetType.area} parentUuid={uuid} area={area} />}
+      pageActions={<AreaAndClimbPageActions name={safeDecode(areaName)} uuid={uuid} targetType={TagTargetType.area} parentUuid={uuid} area={area} />}
       breadcrumbs={
         <StickyHeaderContainer>
           <AreaCrumbs pathTokens={pathTokens} ancestors={ancestors} />
@@ -73,7 +73,7 @@ export default async function Page ({ params }: PageWithCatchAllUuidProps): Prom
       summary={{
         left: (
           <AreaData
-            areaName={areaName}
+            areaName={safeDecode(areaName)}
             lat={lat}
             lng={lng}
             authorMetadata={authorMetadata}
@@ -231,7 +231,7 @@ export async function generateMetadata ({ params }: PageWithCatchAllUuidProps): 
     wall = sanitizeName(pathTokens[pathTokens.length - 2]) + ' • '
   }
 
-  const name = sanitizeName(areaName)
+  const name = sanitizeName(safeDecode(areaName))
 
   const previewImage = media.length > 0 ? `${CLIENT_CONFIG.CDN_BASE_URL}${media[0].mediaUrl}?w=1200&q=75` : null
 

--- a/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
+++ b/src/app/(default)/climb/[[...slug]]/components/ClimbData.tsx
@@ -6,7 +6,7 @@ import RouteTypeChips from '@/components/ui/RouteTypeChips'
 import { ArticleLastUpdate } from '@/components/edit/ArticleLastUpdate'
 import { ClimbType, AreaType } from '@/js/types'
 import Grade from '@/js/grades/Grade'
-import { removeTypenameFromDisciplines, getDisciplineList } from '@/js/utils'
+import { removeTypenameFromDisciplines, getDisciplineList, safeDecode } from '@/js/utils'
 
 export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { isBoulder: boolean }> = (props) => {
   const { id, name, type, safety, length, grades, fa: legacyFA, authorMetadata, gradeContext, isBoulder } = props
@@ -21,7 +21,7 @@ export const ClimbData: React.FC<ClimbType & Pick<AreaType, 'gradeContext'> & { 
   return (
     <>
       <h1 className='text-4xl md:text-5xl mr-10'>
-        {name}
+        {safeDecode(name)}
       </h1>
       <div className='mt-6'>
         <div className='flex items-center space-x-2 w-full'>

--- a/src/app/(default)/editArea/[slug]/general/components/climb/ClimbListForm.tsx
+++ b/src/app/(default)/editArea/[slug]/general/components/climb/ClimbListForm.tsx
@@ -1,7 +1,7 @@
 import clx from 'classnames'
 import { AreaMetadataType, ClimbDisciplineRecord, ClimbType } from '@/js/types'
 import { disciplineTypeToDisplay } from '@/js/grades/util'
-import { removeTypenameFromDisciplines, climbLeftRightIndexComparator, getClimbPageFriendlyUrl } from '@/js/utils'
+import { removeTypenameFromDisciplines, climbLeftRightIndexComparator, getClimbPageFriendlyUrl, safeDecode } from '@/js/utils'
 import Grade, { GradeContexts } from '@/js/grades/Grade'
 import { ClimbListMiniToolbar } from '../../../manageClimbs/components/ClimbListMiniToolbar'
 
@@ -53,7 +53,7 @@ export const ClimbRow: React.FC<ClimbType & { index: number, gradeContext: Grade
             <ListBullet index={index} disciplines={disciplines} />
             <div className='w-full'>
               <div className='flex justify-between'>
-                <div className={clx('text-base font-semibold uppercase tracking-tight', isThisRoute ? '' : 'hover:underline')}>{name}</div>
+                <div className={clx('text-base font-semibold uppercase tracking-tight', isThisRoute ? '' : 'hover:underline')}>{safeDecode(name)}</div>
                 <div>{gradeStr}</div>
               </div>
               <div><DisciplinesInfo disciplines={disciplines} /></div>
@@ -62,7 +62,7 @@ export const ClimbRow: React.FC<ClimbType & { index: number, gradeContext: Grade
         </LinkWrapper>
       </div>
       {editMode &&
-        <ClimbListMiniToolbar climbId={id} parentAreaId={areaMetadata.areaId} climbName={name} />}
+        <ClimbListMiniToolbar climbId={id} parentAreaId={areaMetadata.areaId} climbName={safeDecode(name)} />}
     </li>
   )
 }

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -336,7 +336,7 @@ export const climbLeftRightIndexComparator = (a: ClimbType, b: ClimbType): numbe
 export interface SortableAreaType { metadata: Pick<AreaMetadataType, 'leftRightIndex' | 'areaId'> }
 
 export const areaLeftRightIndexComparator = (a: SortableAreaType, b: SortableAreaType): number => {
-  const aIndex = a.metadata..leftRightIndex ?? -1
+  const aIndex = a.metadata.leftRightIndex ?? -1
   const bIndex = b.metadata.leftRightIndex ?? -1
   if (aIndex < bIndex) return -1
   else if (aIndex > bIndex) return 1
@@ -359,6 +359,22 @@ export const parseUuidAsFirstParam = ({ params }: PageWithCatchAllUuidProps): st
 }
 
 export const decodeAmpersand = (s: string): string => {
-  if (s == null) return '';
-  return s.replace(/&amp;/g, '&');
+  if (s == null) return ''
+  return s.replace(/&amp;/g, '&')
+}
+
+export const safeDecode = (s: string): string => {
+  if (s == null) return ''
+  if (typeof window !== 'undefined') {
+    const txt = document.createElement('textarea')
+    txt.innerHTML = s
+    return txt.value
+  }
+  // Basic SSR-safe decoding for common entities
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
 }

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -336,7 +336,7 @@ export const climbLeftRightIndexComparator = (a: ClimbType, b: ClimbType): numbe
 export interface SortableAreaType { metadata: Pick<AreaMetadataType, 'leftRightIndex' | 'areaId'> }
 
 export const areaLeftRightIndexComparator = (a: SortableAreaType, b: SortableAreaType): number => {
-  const aIndex = a.metadata.leftRightIndex ?? -1
+  const aIndex = a.metadata..leftRightIndex ?? -1
   const bIndex = b.metadata.leftRightIndex ?? -1
   if (aIndex < bIndex) return -1
   else if (aIndex > bIndex) return 1
@@ -356,4 +356,9 @@ export const parseUuidAsFirstParam = ({ params }: PageWithCatchAllUuidProps): st
     notFound()
   }
   return uuid
+}
+
+export const decodeAmpersand = (s: string): string => {
+  if (s == null) return '';
+  return s.replace(/&amp;/g, '&');
 }


### PR DESCRIPTION
Fixes #1242

Problem Description
Climb and area names containing ampersands (&) or other HTML entities were rendered incorrectly in the frontend.
Currently, these entities (&amp;, &lt;, &gt;, etc.) were displayed literally instead of being decoded, causing route names and climb/area names to appear incorrectly.

Solution

Added a safeDecode utility function in src/js/utils.ts to safely decode common HTML entities.

Updated the following components to use safeDecode before rendering names:

ClimbData.tsx

Area page (page.tsx)

ClimbListForm.tsx

Ensures proper display in both client-side rendering (CSR) and server-side rendering (SSR).

Idempotent solution: safe even if backend resolves encoding in the future.

Testing

Verified that climb and area names with & or other HTML entities display correctly in the UI.

Verified SSR pages render correctly without crashing.

User-facing changes

Climb and area names now display correctly (& instead of &amp;) on all pages.

Backwards-incompatible changes

None. This change only affects frontend rendering logic; existing data and backend APIs remain unchanged.

Optional / Suggestion

If the backend (REST or GraphQL API) is encoding HTML entities before sending names, it may be preferable to send plain text directly.

Frontend will continue to work safely even if the backend implements this change in the future.




