### PR TITLE
fix: use redis-strings handler for vanilla redis compatibility

### DIFF
--- a/cache-handler.mjs
+++ b/cache-handler.mjs
@@ -1,6 +1,6 @@
 import { CacheHandler } from '@neshca/cache-handler'
 import createLruHandler from '@neshca/cache-handler/local-lru'
-import createRedisHandler from '@neshca/cache-handler/redis-stack'
+import createRedisHandler from '@neshca/cache-handler/redis-strings'
 import { createClient } from 'redis'
 
 CacheHandler.onCreation(async () => {


### PR DESCRIPTION
related to #1354 issues that we are seeing. redis was not properly implemented (railway expected vanilla redis instance, but was being served redis-stack). this pr fixes that so we no longer should have those out of memory induced crashes. 