### PR TITLE
fix: create apollo timeout signal per-request instead of at module load

### DIFF
--- a/src/js/graphql/ServerClient.ts
+++ b/src/js/graphql/ServerClient.ts
@@ -16,11 +16,17 @@ console.log('###################################################################
 console.log(' API Server', uri)
 console.log('#######################################################################')
 
-const httpLink = new HttpLink({
-  uri,
-  fetchOptions: {
-    signal: AbortSignal.timeout(30000) // 30 second timeout
-  }
+const httpLink = new HttpLink({ uri })
+
+// Create a fresh timeout signal for each request
+const timeoutLink = new ApolloLink((operation, forward) => {
+  operation.setContext(({ fetchOptions = {} }) => ({
+    fetchOptions: {
+      ...fetchOptions,
+      signal: AbortSignal.timeout(30000)
+    }
+  }))
+  return forward(operation)
 })
 
 /**
@@ -30,7 +36,7 @@ const httpLink = new HttpLink({
 export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
   return new ApolloClient({
     cache: new InMemoryCache(),
-    link: ApolloLink.from([dynamicTagsLink, httpLink])
+    link: ApolloLink.from([timeoutLink, dynamicTagsLink, httpLink])
   })
 })
 
@@ -41,6 +47,6 @@ export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
 export function getGlobalClient (): ApolloClient<any> {
   return new ApolloClient({
     cache: new InMemoryCache(),
-    link: ApolloLink.from([dynamicTagsLink, httpLink])
+    link: ApolloLink.from([timeoutLink, dynamicTagsLink, httpLink])
   })
 }

--- a/src/js/graphql/dynamicTagsLink.ts
+++ b/src/js/graphql/dynamicTagsLink.ts
@@ -10,9 +10,10 @@ export const dynamicTagsLink = new ApolloLink((operation, forward) => {
 
   // If dynamicTag exists, update the operation context
   if (dynamicTag != null) {
-    operation.setContext(({ headers = {} }) => ({
+    operation.setContext(({ headers = {}, fetchOptions = {} }) => ({
       headers,
       fetchOptions: {
+        ...fetchOptions,
         next: {
           tags: [dynamicTag]
         }


### PR DESCRIPTION
AbortSignal.timeout was created once at startup, causing all requests after 30s to instantly timeout. Now creates fresh signal per-request.