### PR TITLE
fix: disable apollo devtools for server-side clients

### DIFF
--- a/src/js/graphql/ServerClient.ts
+++ b/src/js/graphql/ServerClient.ts
@@ -36,7 +36,8 @@ const timeoutLink = new ApolloLink((operation, forward) => {
 export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
   return new ApolloClient({
     cache: new InMemoryCache(),
-    link: ApolloLink.from([timeoutLink, dynamicTagsLink, httpLink])
+    link: ApolloLink.from([timeoutLink, dynamicTagsLink, httpLink]),
+    devtools: { enabled: false }
   })
 })
 
@@ -47,6 +48,7 @@ export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
 export function getGlobalClient (): ApolloClient<any> {
   return new ApolloClient({
     cache: new InMemoryCache(),
-    link: ApolloLink.from([timeoutLink, dynamicTagsLink, httpLink])
+    link: ApolloLink.from([timeoutLink, dynamicTagsLink, httpLink]),
+    devtools: { enabled: false }
   })
 }


### PR DESCRIPTION
Disable Apollo devtools for server clients to fix deprecation warnings. Server-side clients can't use browser devtools.