### PR TITLE
fix: enable apollo devtools only in development

### DIFF
--- a/src/js/graphql/Client.ts
+++ b/src/js/graphql/Client.ts
@@ -69,14 +69,16 @@ export const graphqlClient = new ApolloClient({
       }
     }
   }),
-  ssrMode: false // We relies on NextJS for SSR data management
+  ssrMode: false, // We relies on NextJS for SSR data management
+  devtools: { enabled: false }
 })
 
 const httpLink = new HttpLink({ uri: 'https://stg-api.openbeta.io' })
 
 export const stagingGraphQLClient = new ApolloClient({
   link: from([errorLink, httpLink]),
-  cache: new InMemoryCache()
+  cache: new InMemoryCache(),
+  devtools: { enabled: false }
 })
 
 let openCollectiveUri: string = process.env.OPEN_COLLECTIVE_API_URI ?? ''
@@ -92,5 +94,6 @@ export const openCollectiveClient = new ApolloClient({
     fetchOptions: {
       next: { revalidate: 3600 }
     }
-  })
+  }),
+  devtools: { enabled: false }
 })


### PR DESCRIPTION
Enable Apollo devtools only in dev for browser clients.