### PR TITLE
fix(image): replace deprecated Next.js Image props

### DIFF
--- a/src/components/media/slideshow/ResponsiveImage.tsx
+++ b/src/components/media/slideshow/ResponsiveImage.tsx
@@ -27,7 +27,7 @@ export default function ResponsiveImage ({ mediaUrl, isHero = true, isSquare = f
         fill
         sizes={sizes}
         priority={isHero}
-        onLoadingComplete={() => setLoading(false)}
+        onLoad={() => setLoading(false)}
         style={{
           objectFit: isSquare ? 'cover' : 'contain'
         }}

--- a/src/components/ui/__tests__/Card.tsx
+++ b/src/components/ui/__tests__/Card.tsx
@@ -14,9 +14,8 @@ test('Card renders a header and a body', async () => {
         <Image
           src={imageURL}
           alt=''
-          objectFit='cover'
-          objectPosition='center'
-          layout='fill'
+          fill
+          style={{ objectFit: 'cover', objectPosition: 'center' }}
         />
       }
       header='Some Header Content'


### PR DESCRIPTION
onLoadingComplete was deprecated in Next.js 14.2

https://nextjs.org/docs/app/api-reference/components/image#deprecated-props