### PR TITLE
fix: use separate Native app client_id for mobile auth

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -12,6 +12,7 @@ interface AUTH_CONFIG_SERVER_TYPE {
   issuer: string
   clientId: string
   clientSecret: string
+  mobileClientId: string
   mgmtClientId: string
   mgmtClientSecret: string
   mgmtClientAudience: string
@@ -25,6 +26,7 @@ if (typeof window === 'undefined') {
     issuer: checkAndPrintWarning('AUTH0_DOMAIN', process.env.AUTH0_DOMAIN),
     clientId: checkAndPrintWarning('AUTH0_CLIENT_ID', process.env.AUTH0_CLIENT_ID),
     clientSecret: checkAndPrintWarning('AUTH0_CLIENT_SECRET', process.env.AUTH0_CLIENT_SECRET),
+    mobileClientId: checkAndPrintWarning('AUTH0_MOBILE_CLIENT_ID', process.env.AUTH0_MOBILE_CLIENT_ID),
     mgmtClientId: checkAndPrintWarning('AUTH0_MGMT_CLIENT_ID', process.env.AUTH0_MGMT_CLIENT_ID),
     mgmtClientSecret: checkAndPrintWarning('AUTH0_MGMT_CLIENT_SECRET', process.env.AUTH0_MGMT_CLIENT_SECRET),
     mgmtClientAudience: checkAndPrintWarning('AUTH0_MGMT_CLIENT_AUDIENCE', process.env.AUTH0_MGMT_CLIENT_AUDIENCE),

--- a/src/js/auth/mobile.ts
+++ b/src/js/auth/mobile.ts
@@ -8,13 +8,12 @@ if (process.env.MOBILE_AUTH_SECRET == null) {
   console.warn('Mobile auth secret not found')
 }
 
-const { clientSecret, clientId, issuer } = AUTH_CONFIG_SERVER
+const { mobileClientId, issuer } = AUTH_CONFIG_SERVER
 
-// Set up Auth0 client
+// Set up Auth0 client for mobile (Native app - no client secret needed)
 export const auth0Client = new Auth0.AuthenticationClient({
   domain: issuer.replace('https://', ''),
-  clientId,
-  clientSecret
+  clientId: mobileClientId
 })
 
 export const isNullOrEmpty = (str: string | null | undefined): boolean => {


### PR DESCRIPTION
Use dedicated Native Auth0 app for mobile endpoints. Requires new env var AUTH0_MOBILE_CLIENT_ID.