### PR TITLE
fix(AppAlert): prevent layout shift on initial render for new users

### DIFF
--- a/src/components/broadcast/AppAlert.tsx
+++ b/src/components/broadcast/AppAlert.tsx
@@ -16,7 +16,7 @@ export const AppAlert: React.FC<AppAlertProps> = ({
   message,
   cookieStorageKey
 }) => {
-  const [showAlert, setShowAlert] = useState(false)
+  const [showAlert, setShowAlert] = useState(true)
 
   useEffect(() => {
     const suppressed = Cookies.get(cookieStorageKey)


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
title: 'Fix layout shift for main alert component'
labels: 'bug fix'
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [ ] feature
- [x] bug fix
- [ ] documentation
- [x] optimization
- [ ] other

## Description
### What this PR achieves
AppAlert was initializing with ```useState(false)``` which caused a layout shift for every first-time visitor. Since useEffect runs after the first render, the alert would always pop in after the page painted, pushing content down.

Changing to ```useState(true)``` means the alert renders visible from the start — no shift for new users. The only tradeoff is a brief flash for returning users who already dismissed it (cookie exists), but this is barely noticeable especially on fast devices and affects a much smaller group.


### Related Issues

Issue #1452

<!---Briefly explains what this PR does.
-->


### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->
## Illustration
<img width="1191" height="742" alt="shift-illustration" src="https://github.com/user-attachments/assets/cfd1c6d0-4f58-434b-bf11-5f3aa8613f42" />

### Notes
<!--Anything in particular you want the reviewer pay attention to? This could be things that you are not sure about, or possible risks of your change.-->
- First-time visitors — the most critical audience — now get a completely clean experience with zero layout shift regardless of their network conditions. The only tradeoff is a brief flash for returning users who already dismissed the alert, which is practically invisible on fast devices and only affects a group that has already seen the site before.




