### PR TITLE
feat: show loading spinner and success states on user profile and imp…

### DIFF
--- a/src/components/users/ImportFromMtnProj.tsx
+++ b/src/components/users/ImportFromMtnProj.tsx
@@ -4,11 +4,11 @@ import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 import { FolderArrowDownIcon } from '@heroicons/react/24/outline'
 import { signIn, useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { toast } from 'react-toastify'
 import clx from 'classnames'
 
 import { INPUT_DEFAULT_CSS } from '../ui/form/TextArea'
-import Spinner from '../ui/Spinner'
 import { LeanAlert } from '../ui/micro/AlertDialogue'
 
 interface Props {
@@ -31,6 +31,7 @@ export function ImportFromMtnProj ({ username }: Props): JSX.Element {
   const [showInput, setShowInput] = useState(false)
   const [loading, setLoading] = useState(false)
   const [errors, setErrors] = useState<string[]>([])
+  const [importedCount, setImportedCount] = useState<number | null>(null)
 
   // this function is for when the component is rendered as a button and sends the user straight to the input form
   function straightToInput (): void {
@@ -51,6 +52,7 @@ export function ImportFromMtnProj ({ username }: Props): JSX.Element {
         const { count } = await bulkImportProxy(mpUID)
 
         if (count > 0) {
+          setImportedCount(count)
           toast.info(
             <>
               {count} ticks have been imported! 🎉 <br />
@@ -60,8 +62,9 @@ export function ImportFromMtnProj ({ username }: Props): JSX.Element {
 
           setTimeout(() => {
             router.push(`/u/${username}/ticks`)
-          }, 2000)
-          setShow(false)
+            setShow(false)
+            setImportedCount(null)
+          }, 4000)
         } else {
           setErrors(['Sorry, no ticks were found for that user. Please check your Mountain Project ID and try again.'])
           toast.error('Sorry, no ticks were found for that user. Please check your Mountain Project ID and try again.')
@@ -76,7 +79,6 @@ export function ImportFromMtnProj ({ username }: Props): JSX.Element {
       // handle errors
       setErrors(['Please input a valid Mountain Project ID'])
     }
-    setLoading(false)
   }
 
   return (
@@ -85,62 +87,126 @@ export function ImportFromMtnProj ({ username }: Props): JSX.Element {
 
       {show && (
         <LeanAlert
-          icon={<FolderArrowDownIcon className='h-6 w-6 text-gray-400' aria-hidden='true' />}
-          title={showInput ? 'Input your Mountain Project profile link' : 'Import your ticks from Mountain Project'}
-          description={!showInput ? "Don't lose your progress, bring it over to Open Beta." : null}
-          closeOnEsc
+          icon={
+            loading
+              ? null
+              : (
+                  importedCount !== null
+                    ? (
+                      <FolderArrowDownIcon className='h-6 w-6 text-green-500' aria-hidden='true' />
+                      )
+                    : (
+                      <FolderArrowDownIcon className='h-6 w-6 text-gray-400' aria-hidden='true' />
+                      )
+                )
+          }
+          title={
+            loading
+              ? 'Importing ticks...'
+              : (importedCount !== null
+                  ? 'Import Complete!'
+                  : (showInput ? 'Input your Mountain Project profile link' : 'Import your ticks from Mountain Project'))
+          }
+          description={
+            loading || importedCount !== null
+              ? null
+              : (!showInput ? "Don't lose your progress, bring it over to Open Beta." : null)
+          }
+          closeOnEsc={!loading}
           stackChildren
         >
-          {(errors != null) && errors.length > 0 && errors.map((err, i) => <p className='mt-2 text-ob-primary' key={i}>{err}</p>)}
+          {loading
+            ? (
+              <div className='flex flex-col items-center justify-center p-4 w-full'>
+                <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-ob-secondary' />
+                <span className='mt-2 text-sm text-primary font-medium'>Fetching ticks from Mountain Project...</span>
+              </div>
+              )
+            : importedCount !== null
+              ? (
+                <div className='flex flex-col items-center justify-center p-4 w-full'>
+                  <p className='text-lg font-semibold text-green-600 dark:text-green-400'>
+                    {importedCount} ticks have been imported! 🎉
+                  </p>
+                  <p className='mt-2 text-sm text-gray-500'>
+                    Redirecting you to your ticks page in a few seconds...
+                  </p>
+                  <div className='mt-4 flex flex-col space-y-2 w-full'>
+                    <Link
+                      href={`/u/${username}/ticks`}
+                      className='btn btn-primary w-full'
+                      onClick={() => {
+                        setShow(false)
+                        setImportedCount(null)
+                      }}
+                    >
+                      Go to my ticks now
+                    </Link>
+                    <AlertDialogPrimitive.Cancel
+                      asChild onClick={() => {
+                        setShow(false)
+                        setImportedCount(null)
+                        setErrors([])
+                      }}
+                    >
+                      <button className='btn btn-outline w-full'>Close</button>
+                    </AlertDialogPrimitive.Cancel>
+                  </div>
+                </div>
+                )
+              : (
+                <>
+                  {(errors != null) && errors.length > 0 && errors.map((err, i) => <p className='mt-2 text-ob-primary' key={i}>{err}</p>)}
 
-          {showInput && (
-            <div className='mt-1 relative rounded-md shadow-sm'>
-              <input
-                type='text'
-                name='website'
-                id='website'
-                value={mpUID}
-                onChange={(e) => setMPUID(e.target.value)}
-                className={clx(INPUT_DEFAULT_CSS, 'w-full')}
-                placeholder='https://www.mountainproject.com/user/123456789/username'
-                disabled={loading}
-              />
-            </div>
-          )}
+                  {showInput && (
+                    <div className='mt-1 relative rounded-md shadow-sm'>
+                      <input
+                        type='text'
+                        name='website'
+                        id='website'
+                        value={mpUID}
+                        onChange={(e) => setMPUID(e.target.value)}
+                        className={clx(INPUT_DEFAULT_CSS, 'w-full')}
+                        placeholder='https://www.mountainproject.com/user/123456789/username'
+                        disabled={loading}
+                      />
+                    </div>
+                  )}
 
-          <div className='mt-3 flex space-x-7 justify-center'>
-            {!showInput && (
-              <button
-                type='button'
-                onClick={() => setShowInput(true)}
-                className='text-center p-2 border-2 rounded-xl border-ob-primary transition
-                text-ob-primary hover:bg-ob-primary hover:ring hover:ring-ob-primary ring-offset-2
-                hover:text-white w-32 font-bold'
-              >
-                {loading ? 'Working...' : 'Show me how'}
-              </button>
-            )}
+                  <div className='mt-3 flex space-x-7 justify-center'>
+                    {!showInput && (
+                      <button
+                        type='button'
+                        onClick={() => setShowInput(true)}
+                        className='text-center p-2 border-2 rounded-xl border-ob-primary transition
+                    text-ob-primary hover:bg-ob-primary hover:ring hover:ring-ob-primary ring-offset-2
+                    hover:text-white w-32 font-bold'
+                      >
+                        Show me how
+                      </button>
+                    )}
 
-            {showInput && (
-              <button
-                type='button'
-                onClick={() => { void getTicks() }}
-                className='btn btn-primary'
-                disabled={loading}
-              >
-                {loading ? <Spinner /> : 'Get my ticks!'}
-              </button>
-            )}
+                    {showInput && (
+                      <button
+                        type='button'
+                        onClick={() => { void getTicks() }}
+                        className='btn btn-primary'
+                      >
+                        Get my ticks!
+                      </button>
+                    )}
 
-            <AlertDialogPrimitive.Cancel
-              asChild onClick={() => {
-                setShow(false)
-                setErrors([])
-              }}
-            >
-              <button className='btn btn-outline' disabled={loading}>Cancel</button>
-            </AlertDialogPrimitive.Cancel>
-          </div>
+                    <AlertDialogPrimitive.Cancel
+                      asChild onClick={() => {
+                        setShow(false)
+                        setErrors([])
+                      }}
+                    >
+                      <button className='btn btn-outline'>Cancel</button>
+                    </AlertDialogPrimitive.Cancel>
+                  </div>
+                </>
+                )}
         </LeanAlert>
       )}
     </>

--- a/src/components/users/PublicProfile.tsx
+++ b/src/components/users/PublicProfile.tsx
@@ -26,6 +26,7 @@ export default function PublicProfile ({ userProfile }: PublicProfileProps): JSX
   const { getUserPublicProfileByUuid } = useUserProfileCmd({ accessToken: session?.data?.accessToken as string })
 
   const [profile, setProfile] = useState<{ username?: string, displayName?: string, bio?: string, website?: string, avatar?: string } | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
 
   const { username = '', displayName = '', bio = '', website = '', avatar = '' } = profile ?? {}
 
@@ -34,10 +35,15 @@ export default function PublicProfile ({ userProfile }: PublicProfileProps): JSX
 
     if (userProfile?.userUuid != null) {
       const doAsync = async (): Promise<void> => {
-        const fetchedProfile = await getUserPublicProfileByUuid(userProfile.userUuid)
-        if (fetchedProfile != null) {
-          const { username, displayName, bio, website, avatar } = fetchedProfile
-          setProfile({ username, displayName, bio, website, avatar })
+        setIsLoading(true)
+        try {
+          const fetchedProfile = await getUserPublicProfileByUuid(userProfile.userUuid)
+          if (fetchedProfile != null) {
+            const { username, displayName, bio, website, avatar } = fetchedProfile
+            setProfile({ username, displayName, bio, website, avatar })
+          }
+        } finally {
+          setIsLoading(false)
         }
       }
       void doAsync()
@@ -47,6 +53,15 @@ export default function PublicProfile ({ userProfile }: PublicProfileProps): JSX
   let websiteWithScheme: string | null = null
   if (website != null) {
     websiteWithScheme = website.startsWith('http') ? website : `//${website}`
+  }
+
+  if (isLoading) {
+    return (
+      <div className='flex flex-col items-center justify-center p-12 w-full col-span-3'>
+        <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-ob-secondary' />
+        <span className='ml-2 mt-2 text-sm text-primary font-medium'>Loading profile...</span>
+      </div>
+    )
   }
 
   return (

--- a/src/components/users/__tests__/ImportFromMtnProj.test.tsx
+++ b/src/components/users/__tests__/ImportFromMtnProj.test.tsx
@@ -82,4 +82,36 @@ describe('<ImportFromMtnProj />', () => {
 
     expect(inputField.value).toBe('https://www.mountainproject.com/user/123456789/sampleuser')
   })
+
+  it('shows loading spinner and then success screen on valid submission', async () => {
+    const mockFetch = jest.fn().mockImplementation(async () =>
+      await Promise.resolve({
+        json: async () => await Promise.resolve({ count: 42 })
+      })
+    )
+    global.fetch = mockFetch
+
+    render(<ImportFromMtnProj username='testuser' />)
+
+    // Open the modal
+    const openModalButton = screen.getByText('Import ticks')
+    fireEvent.click(openModalButton)
+
+    // Type in a valid link
+    const inputField = await screen.findByPlaceholderText('https://www.mountainproject.com/user/123456789/username')
+    fireEvent.change(inputField, { target: { value: 'https://www.mountainproject.com/user/123456789/sampleuser' } })
+
+    // Click on Get my ticks
+    const getTicksButton = screen.getByText('Get my ticks!')
+    fireEvent.click(getTicksButton)
+
+    // Expect loading state
+    expect(screen.getByText('Fetching ticks from Mountain Project...')).toBeInTheDocument()
+
+    // Expect success screen
+    await waitFor(() => {
+      expect(screen.getByText('42 ticks have been imported! 🎉')).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Go to my ticks now' })).toHaveAttribute('href', '/u/testuser/ticks')
+    })
+  })
 })


### PR DESCRIPTION
…ort modal (#590)

---
name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [ ] refactor
- [x] feature
- [ ] bug fix
- [ ] documentation
- [ ] optimization
- [ ] other

## Description

### Related Issues

Issue #590


### What this PR achieves

This PR fixes the abrupt closing behavior of the Mountain Project import modal and provides clear asynchronous feedback to the user during data ingestion.

- **Asynchronous Feedback:** Leveraged the internal `loading` state within `getTicks()` to trigger an active loading screen.
- **Tailwind Spinner UI:** Rendered an `animate-spin` circle element paired with text ("Fetching ticks from Mountain Project...") while the background network request is active.
- **Stateful Success Layout:** Introduced an `importedCount` state tracker to display a clean completion card inside the modal upon successful data fetching, including explicit navigation links and safe closure handlers.
- **Robust UX Control:** Conditionally disabled Escape-key dismissals (`closeOnEsc={!loading}`) during active network transport to prevent truncated mutations.
- **Test Coverage:** Added new test configurations inside `ImportFromMtnProj.test.tsx` ensuring full mocking validation for both active spinner rendering and final success layouts.


### Screenshots, recordings
<!--Add an after screenshots/screen recordings. If it's not obvious, use a paint program to highlight/annotate the new changes.-->




### Notes
All unit tests and `ts-standard` lint checks pass successfully locally. The Next.js production build compiles perfectly without errors.




