### PR TITLE
fix: allow editing profile with optional fields

### DIFF
--- a/src/components/users/account/UpdateProfileForm.tsx
+++ b/src/components/users/account/UpdateProfileForm.tsx
@@ -82,7 +82,11 @@ export const UpdateProfileForm: React.FC = () => {
 
     const successful = await updatePublicProfileCmd({ userUuid, displayName, bio, website })
     if (successful) {
-      reset({ displayName, bio, website })
+    reset({
+  displayName: displayName ?? '',
+  bio: bio ?? '',
+  website: website ?? ''
+})
       toast.info('Profile updated')
     } else {
       toast.error('Unexpected error.  Please try again.')


### PR DESCRIPTION
Title:
fix: handle undefined optional profile fields

[x] bug fix

Related Issues:
Issue #1466

What this PR achieves:
Fixes the profile edit form validation when optional fields are empty.

Previously, empty profile fields could contain null or undefined values, causing the form to remain invalid even when only one field was updated.

This change normalizes displayName, bio, and website to empty strings when resetting the form, ensuring optional empty fields are handled correctly.

Notes:
The change is limited to normalizing optional profile fields during form reset.



