### PR TITLE
fix: save multiple climb fields

### DIFF
--- a/src/app/(default)/editClimb/[slug]/components/ClimbDescriptionForm.tsx
+++ b/src/app/(default)/editClimb/[slug]/components/ClimbDescriptionForm.tsx
@@ -1,19 +1,14 @@
 'use client'
-import { useSession } from 'next-auth/react'
-
-import { SingleEntryForm } from '@/app/(default)/components/AreaAndClimb/SingleEntryForm'
 import { CLIMB_DESCRIPTION_FORM_VALIDATION_RULES } from '../validation'
 import useUpdateClimbsCmd from '@/js/hooks/useUpdateClimbsCmd'
 import { MarkdownTextArea } from '@/components/ui/form/MarkdownTextArea'
+import { SingleEntryForm } from '@/app/(default)/components/AreaAndClimb/SingleEntryForm'
 
-export const ClimbDescriptionForm: React.FC<{ initialValue: string, uuid: string, parentId: string }> = ({ initialValue, uuid, parentId }) => {
-  const session = useSession({ required: true })
-  const { updateClimbCmd } = useUpdateClimbsCmd(
-    {
-      parentId,
-      accessToken: session?.data?.accessToken as string
-    }
-  )
+export const ClimbDescriptionForm: React.FC<{ initialValue: string, uuid: string, parentId: string, accessToken: string }> = ({ initialValue, uuid, parentId, accessToken }) => {
+  const { updateClimbCmd } = useUpdateClimbsCmd({
+    parentId,
+    accessToken
+  })
 
   return (
     <SingleEntryForm<{ description: string }>

--- a/src/app/(default)/editClimb/[slug]/components/ClimbLocationForm.tsx
+++ b/src/app/(default)/editClimb/[slug]/components/ClimbLocationForm.tsx
@@ -1,19 +1,14 @@
 'use client'
-import { useSession } from 'next-auth/react'
-
-import { SingleEntryForm } from '@/app/(default)/components/AreaAndClimb/SingleEntryForm'
 import { CLIMB_LOCATION_FORM_VALIDATION_RULES } from '../validation'
 import useUpdateClimbsCmd from '@/js/hooks/useUpdateClimbsCmd'
 import { MarkdownTextArea } from '@/components/ui/form/MarkdownTextArea'
+import { SingleEntryForm } from '@/app/(default)/components/AreaAndClimb/SingleEntryForm'
 
-export const ClimbLocationForm: React.FC<{ initialValue: string, uuid: string, parentId: string }> = ({ initialValue, uuid, parentId }) => {
-  const session = useSession({ required: true })
-  const { updateClimbCmd } = useUpdateClimbsCmd(
-    {
-      parentId,
-      accessToken: session?.data?.accessToken as string
-    }
-  )
+export const ClimbLocationForm: React.FC<{ initialValue: string, uuid: string, parentId: string, accessToken: string }> = ({ initialValue, uuid, parentId, accessToken }) => {
+  const { updateClimbCmd } = useUpdateClimbsCmd({
+    parentId,
+    accessToken
+  })
 
   return (
     <SingleEntryForm<{ location: string }>

--- a/src/app/(default)/editClimb/[slug]/components/ClimbNameForm.tsx
+++ b/src/app/(default)/editClimb/[slug]/components/ClimbNameForm.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { useSession } from 'next-auth/react'
 import { ValidationValueMessage } from 'react-hook-form'
 
 import { SingleEntryForm } from '@/app/(default)/components/AreaAndClimb/SingleEntryForm'
@@ -7,14 +6,11 @@ import { DashboardInput } from '@/components/ui/form/Input'
 import useUpdateClimbsCmd from '@/js/hooks/useUpdateClimbsCmd'
 import { CLIMB_NAME_FORM_VALIDATION_RULES } from '../validation'
 
-export const ClimbNameForm: React.FC<{ initialValue: string, uuid: string, parentId: string }> = ({ uuid, initialValue, parentId }) => {
-  const session = useSession({ required: true })
-
+export const ClimbNameForm: React.FC<{ initialValue: string, uuid: string, parentId: string, accessToken: string }> = ({ uuid, initialValue, parentId, accessToken }) => {
   const { updateClimbCmd } = useUpdateClimbsCmd({
     parentId,
-    accessToken: session?.data?.accessToken as string
-  }
-  )
+    accessToken
+  })
 
   const maxLengthValidation = CLIMB_NAME_FORM_VALIDATION_RULES.maxLength as ValidationValueMessage
 

--- a/src/app/(default)/editClimb/[slug]/components/ClimbProtectionForm.tsx
+++ b/src/app/(default)/editClimb/[slug]/components/ClimbProtectionForm.tsx
@@ -1,19 +1,14 @@
 'use client'
-import { useSession } from 'next-auth/react'
-
-import { SingleEntryForm } from '@/app/(default)/components/AreaAndClimb/SingleEntryForm'
 import { CLIMB_PROTECTION_FORM_VALIDATION_RULES } from '../validation'
 import useUpdateClimbsCmd from '@/js/hooks/useUpdateClimbsCmd'
 import { MarkdownTextArea } from '@/components/ui/form/MarkdownTextArea'
+import { SingleEntryForm } from '@/app/(default)/components/AreaAndClimb/SingleEntryForm'
 
-export const ClimbProtectionForm: React.FC<{ initialValue: string, uuid: string, parentId: string }> = ({ initialValue, uuid, parentId }) => {
-  const session = useSession({ required: true })
-  const { updateClimbCmd } = useUpdateClimbsCmd(
-    {
-      parentId,
-      accessToken: session?.data?.accessToken as string
-    }
-  )
+export const ClimbProtectionForm: React.FC<{ initialValue: string, uuid: string, parentId: string, accessToken: string }> = ({ initialValue, uuid, parentId, accessToken }) => {
+  const { updateClimbCmd } = useUpdateClimbsCmd({
+    parentId,
+    accessToken
+  })
 
   return (
     <SingleEntryForm<{ protection: string }>

--- a/src/app/(default)/editClimb/[slug]/page.tsx
+++ b/src/app/(default)/editClimb/[slug]/page.tsx
@@ -15,6 +15,7 @@ import { ClimbNameForm } from './components/ClimbNameForm'
 import { ClimbDescriptionForm } from './components/ClimbDescriptionForm'
 import { ClimbLocationForm } from './components/ClimbLocationForm'
 import { ClimbProtectionForm } from './components/ClimbProtectionForm'
+import { useSession } from 'next-auth/react'
 
 // Opt out of caching for all data requests in the route segment
 export const dynamic = 'force-dynamic'
@@ -49,6 +50,10 @@ export default async function ClimbEditPage ({ params }: DashboardPageProps): Pr
     id, name, content, ancestors, pathTokens, parent
   } = pageDataForEdit
 
+  // Get session once at page level and share across all forms
+  const session = useSession({ required: true })
+  const accessToken = session?.data?.accessToken as string
+
   return (
     <div className='relative w-full h-full'>
       <div className='px-12 pt-8 pb-4'>
@@ -73,19 +78,19 @@ export default async function ClimbEditPage ({ params }: DashboardPageProps): Pr
           <main className='relative h-full w-full px-2 lg:px-16'>
             <PageContainer>
               <SectionContainer id='general'>
-                <ClimbNameForm initialValue={name} uuid={id} parentId={parent.uuid} />
+                <ClimbNameForm initialValue={name} uuid={id} parentId={parent.uuid} accessToken={accessToken} />
               </SectionContainer>
 
               <SectionContainer id='description'>
-                <ClimbDescriptionForm initialValue={content?.description} uuid={id} parentId={parent.uuid} />
+                <ClimbDescriptionForm initialValue={content?.description} uuid={id} parentId={parent.uuid} accessToken={accessToken} />
               </SectionContainer>
 
               <SectionContainer id='location'>
-                <ClimbLocationForm initialValue={content?.location} uuid={id} parentId={parent.uuid} />
+                <ClimbLocationForm initialValue={content?.location} uuid={id} parentId={parent.uuid} accessToken={accessToken} />
               </SectionContainer>
 
               <SectionContainer id='protection'>
-                <ClimbProtectionForm initialValue={content?.protection} uuid={id} parentId={parent.uuid} />
+                <ClimbProtectionForm initialValue={content?.protection} uuid={id} parentId={parent.uuid} accessToken={accessToken} />
               </SectionContainer>
             </PageContainer>
           </main>


### PR DESCRIPTION
Pull Request Template for Issue #1469

name: Pull request
about: Create a pull request
title: ''
labels: ''
assignees: ''

---

## What type of PR is this?(check all applicable)
- [x] bug fix
- [ ] refactor
- [ ] feature
- [ ] documentation
- [ ] optimization
- [ ] other


### What this PR achieves
Fixes the 401 error that occurs when saving more than one climb field at a time. Previously, each climb edit form independently called `useSession({ required: true })`, getting separate access tokens. When the first save succeeded, the session token became invalidated, causing subsequent saves to fail with 401 errors.

This PR moves the `useSession()` call to the page level and shares the `accessToken` with all four climb edit forms, ensuring all API calls use the same valid session token.



### Notes
- Modified 5 files: 1 page + 4 form components
- All climb edit forms now share the same session token
- Prevents 401 errors when saving multiple climb fields sequentially

Summary of Changes
Files Modified (5 files):

src/app/(default)/editClimb/[slug]/page.tsx - Added page-level useSession() and shares accessToken with all forms
src/app/(default)/editClimb/[slug]/components/ClimbNameForm.tsx - Accepts shared accessToken prop
src/app/(default)/editClimb/[slug]/components/ClimbDescriptionForm.tsx - Accepts shared accessToken prop
`src/app/(default)/editClimb/[slug])

